### PR TITLE
fix(build): keep libtorch_cuda in NEEDED, drop LD_PRELOAD workaround (#9)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ repository = "https://github.com/yourusername/thrust"
 keywords = ["reinforcement-learning", "machine-learning", "rl", "deep-learning", "cuda"]
 categories = ["science", "algorithms"]
 readme = "README.md"
+# Build script defeats GNU ld's --as-needed for libtorch_cuda on Linux.
+# See build.rs for the rationale (in short: without it, the binary silently
+# falls back to CPU even on a CUDA-equipped box). No-op on macOS/Windows
+# and on CPU-only feature builds.
+build = "build.rs"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -180,3 +185,11 @@ required-features = ["training"]
 name = "train_p3"
 path = "examples/games/bucket_brigade/train_p3.rs"
 required-features = ["training", "env-bucket-brigade"]
+
+# Diagnostics --- verifies that the CUDA link fix from build.rs is working.
+# Run with `./scripts/gpu-train.sh test_cuda` or directly via cargo on a
+# CUDA-equipped Linux box. On macOS this still builds but will report `Cpu`.
+[[example]]
+name = "test_cuda"
+path = "examples/test_cuda.rs"
+required-features = ["training"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,227 @@
+//! Build script for thrust-rl.
+//!
+//! Primary purpose: defeat the GNU linker's `--as-needed` default behavior so
+//! that `libtorch_cuda.so` (and `libc10_cuda.so`) stay in the binary's
+//! `DT_NEEDED` list even though the Rust source never references a symbol
+//! that resolves to those libraries directly.
+//!
+//! ## Background
+//!
+//! Modern Linux distros (Ubuntu 22.04+, Debian 12+, etc.) ship `ld` configured
+//! with `--as-needed` enabled by default. Under that flag, any `DT_NEEDED`
+//! entry for a shared library from which no symbol is actually referenced is
+//! dropped at link time. `torch-sys`'s build script emits
+//! `cargo:rustc-link-lib=torch_cuda` correctly when CUDA is detected, but
+//! since `tch` itself only directly references symbols in `libtorch_cpu` and
+//! `libc10`, the linker silently strips `-ltorch_cuda` from the final binary.
+//!
+//! At runtime, `libtorch` performs lazy CUDA backend registration that
+//! depends on `libtorch_cuda.so` already being loaded into the process. With
+//! the `DT_NEEDED` entry stripped, the CUDA backend never initializes and
+//! `tch::Cuda::is_available()` returns `false` --- *silent CPU fallback*.
+//!
+//! ## Why downstream `RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"` is not enough
+//!
+//! `-Wl,--no-as-needed` is *positional*: it only affects libraries that
+//! appear *after* it on the linker command line. When set via
+//! `RUSTFLAGS`, the flag is injected at a position that does not cover
+//! the `-ltorch_cuda` argument emitted by the `torch-sys` build script.
+//! Re-emitting the bracket from a leaf-crate build script puts the flag
+//! at the *end* of the link line where it does cover the late-emitted
+//! `-ltorch_cuda`.
+//!
+//! ## What this script does
+//!
+//! On Linux only, and only when the `training` feature is enabled, it emits:
+//!
+//! ```text
+//! cargo:rustc-link-arg=-Wl,--no-as-needed
+//! cargo:rustc-link-lib=torch_cuda
+//! cargo:rustc-link-lib=c10_cuda
+//! cargo:rustc-link-arg=-Wl,--as-needed
+//! ```
+//!
+//! when CUDA is detected in the libtorch installation. On macOS, Windows, or
+//! CPU-only builds, the script is a no-op.
+//!
+//! ## CUDA detection
+//!
+//! Detection mirrors `torch-sys`'s logic at a coarse level: if
+//! `LIBTORCH_USE_PYTORCH=1` is set, we shell out to Python to ask whether
+//! CUDA is compiled in and discover the lib path. Otherwise we look at
+//! `LIBTORCH` env var (the standalone libtorch path) and check for the
+//! presence of `libtorch_cuda.so`. If neither path yields a CUDA-enabled
+//! libtorch, the script emits nothing extra and the build proceeds as
+//! CPU-only.
+//!
+//! ## Opting out
+//!
+//! Set `THRUST_DISABLE_CUDA_LINK_FIX=1` to skip the link-arg emission. Useful
+//! if a downstream user has a custom linker setup that the fix interferes
+//! with. The `THRUST_EXPECT_CUDA` runtime check (see `src/utils/cuda.rs`)
+//! is independent of this opt-out.
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    // Re-run conditions: only re-run when the relevant environment variables
+    // change. We deliberately do NOT use `cargo:rerun-if-changed=build.rs`
+    // alone because Cargo defaults to that. Instead, we add env-var triggers
+    // for the inputs we actually consult.
+    println!("cargo:rerun-if-env-changed=LIBTORCH");
+    println!("cargo:rerun-if-env-changed=LIBTORCH_USE_PYTORCH");
+    println!("cargo:rerun-if-env-changed=LIBTORCH_BYPASS_VERSION_CHECK");
+    println!("cargo:rerun-if-env-changed=THRUST_DISABLE_CUDA_LINK_FIX");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_TRAINING");
+
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let training_enabled = env::var("CARGO_FEATURE_TRAINING").is_ok();
+    let opted_out = env::var("THRUST_DISABLE_CUDA_LINK_FIX")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    // Only apply the fix on Linux with the training feature on. macOS, iOS,
+    // and Windows do not exhibit the `--as-needed` behavior we are countering
+    // (Windows uses a totally different link model, macOS's ld doesn't strip
+    // unreferenced dylibs the same way).
+    if target_os != "linux" {
+        return;
+    }
+    if !training_enabled {
+        return;
+    }
+    if opted_out {
+        eprintln!(
+            "thrust-rl build.rs: THRUST_DISABLE_CUDA_LINK_FIX is set; skipping \
+             CUDA link-arg emission."
+        );
+        return;
+    }
+
+    let cuda_lib_dir = match detect_cuda_lib_dir() {
+        Some(dir) => dir,
+        None => {
+            // CPU-only build, or libtorch without CUDA. Nothing to do.
+            eprintln!(
+                "thrust-rl build.rs: no CUDA-enabled libtorch detected; \
+                 skipping CUDA link-arg emission. \
+                 (training feature is on, but libtorch_cuda.so was not found.)"
+            );
+            return;
+        }
+    };
+
+    eprintln!(
+        "thrust-rl build.rs: emitting positional link args to prevent \
+         --as-needed from stripping libtorch_cuda (lib dir: {}).",
+        cuda_lib_dir.display()
+    );
+
+    // Add a `rustc-link-search` directive so the linker can find the CUDA
+    // libs at link time. `torch-sys` typically already adds this; we re-emit
+    // it as a belt-and-suspenders guard.
+    println!(
+        "cargo:rustc-link-search=native={}",
+        cuda_lib_dir.display()
+    );
+
+    // The bracket: enable --no-as-needed, list the libraries we want to keep
+    // referenced, then restore --as-needed so we don't accidentally retain
+    // unrelated unused libs later on the command line.
+    //
+    // Position matters: Cargo emits build-script `rustc-link-arg` directives
+    // *after* most dependency `rustc-link-lib` directives, so our re-emitted
+    // `-Wl,--no-as-needed` covers the `-ltorch_cuda` we re-list here AND any
+    // late `-ltorch_cuda` already emitted by `torch-sys`'s own build script.
+    //
+    // We use the `-bins` and `-examples` variants of `rustc-link-arg` so the
+    // flags apply to binary artifacts that link this crate (not the rlib
+    // itself, which is a static archive and doesn't go through the linker).
+    // `rustc-link-lib` applies to every artifact and doesn't need a variant.
+    //
+    // We emit duplicate directives for `-bins`, `-examples`, `-tests`, and
+    // `-benches` so any binary kind that links thrust-rl gets the fix.
+    for variant in ["bins", "examples", "tests", "benches"] {
+        println!("cargo:rustc-link-arg-{variant}=-Wl,--no-as-needed");
+    }
+    println!("cargo:rustc-link-lib=torch_cuda");
+    println!("cargo:rustc-link-lib=c10_cuda");
+    for variant in ["bins", "examples", "tests", "benches"] {
+        println!("cargo:rustc-link-arg-{variant}=-Wl,--as-needed");
+    }
+
+    // Belt-and-suspenders: also embed an RPATH entry so the binary can find
+    // the CUDA libs at runtime without relying on `LD_LIBRARY_PATH`. We
+    // use `-Wl,-rpath,...` rather than passing `-rpath` directly so the
+    // flag survives gcc/clang's argument forwarding (rustc invokes the
+    // system linker via the C compiler driver).
+    for variant in ["bins", "examples", "tests", "benches"] {
+        println!(
+            "cargo:rustc-link-arg-{variant}=-Wl,-rpath,{}",
+            cuda_lib_dir.display()
+        );
+    }
+}
+
+/// Locate the directory containing `libtorch_cuda.so` and `libc10_cuda.so`,
+/// or `None` if we can't find them (CPU-only or non-Linux libtorch).
+fn detect_cuda_lib_dir() -> Option<PathBuf> {
+    // Strategy 1: pip-installed PyTorch via LIBTORCH_USE_PYTORCH=1.
+    if env::var("LIBTORCH_USE_PYTORCH").as_deref() == Ok("1") {
+        if let Some(dir) = pytorch_lib_dir_from_python() {
+            if has_cuda_libs(&dir) {
+                return Some(dir);
+            }
+        }
+    }
+
+    // Strategy 2: explicit LIBTORCH path.
+    if let Ok(libtorch) = env::var("LIBTORCH") {
+        let lib_dir = PathBuf::from(libtorch).join("lib");
+        if has_cuda_libs(&lib_dir) {
+            return Some(lib_dir);
+        }
+    }
+
+    // Strategy 3: fallback to invoking python3 unconditionally. This catches
+    // setups where the user has pip-installed torch but forgot to set
+    // LIBTORCH_USE_PYTORCH=1 explicitly --- if we can find a CUDA-enabled
+    // torch we may as well emit the link args (they're a no-op without the
+    // matching torch-sys link directives anyway).
+    if let Some(dir) = pytorch_lib_dir_from_python() {
+        if has_cuda_libs(&dir) {
+            return Some(dir);
+        }
+    }
+
+    None
+}
+
+fn pytorch_lib_dir_from_python() -> Option<PathBuf> {
+    // Try python3 first, then python. Quiet errors --- we'll just fail
+    // detection and let the caller handle the None case.
+    for py in ["python3", "python"] {
+        let out = Command::new(py)
+            .arg("-c")
+            .arg(
+                "import os, torch; \
+                 print(os.path.join(os.path.dirname(torch.__file__), 'lib'))",
+            )
+            .output();
+        if let Ok(out) = out {
+            if out.status.success() {
+                let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                if !path.is_empty() {
+                    return Some(PathBuf::from(path));
+                }
+            }
+        }
+    }
+    None
+}
+
+fn has_cuda_libs(dir: &PathBuf) -> bool {
+    dir.join("libtorch_cuda.so").exists() && dir.join("libc10_cuda.so").exists()
+}

--- a/docs/GPU_SETUP.md
+++ b/docs/GPU_SETUP.md
@@ -19,47 +19,99 @@ This guide explains how to set up GPU-accelerated training with CUDA for Thrust 
 - Python 3.8+ with pip
 - Rust nightly toolchain
 
-## The CUDA Detection Problem
+## CUDA Linking: How It Works (and How It Used to Break)
 
-When using `tch-rs` (Rust bindings for PyTorch), you may encounter a situation where:
+When using `tch-rs` (Rust bindings for PyTorch) on Linux, the binary needs to
+link against `libtorch_cuda.so` and `libc10_cuda.so` even though no Rust code
+directly references symbols in those libraries. This is because libtorch
+performs lazy CUDA backend registration that only initializes when those
+shared objects are present in the process's address space at startup.
 
-- ✅ `nvidia-smi` shows your GPU is available
-- ✅ Python PyTorch detects CUDA: `torch.cuda.is_available()` returns `True`
-- ✅ `torch-sys` correctly emits `cargo:rustc-link-lib=torch_cuda` during build
-- ❌ But `tch::Cuda::is_available()` returns `false` in your Rust binary
+### The historical problem (fixed by issue #9)
 
-### Root Cause
+Modern Linux distros ship `ld` with `--as-needed` on by default. Under that
+flag, any `DT_NEEDED` entry for a shared library from which no symbol is
+referenced is dropped at link time. Because thrust-rl only calls `tch`
+high-level APIs and `tch` itself only references `libtorch_cpu` / `libc10`
+symbols, `-ltorch_cuda` was silently stripped from the final binary. The
+runtime symptom was a `tch::Cuda::is_available() == false` on a CUDA-
+equipped box, with no error message --- the training run then proceeded on
+CPU at roughly 1/5 of the expected throughput.
 
-The Rust linker drops `libtorch_cuda.so` as "unused" even though it's needed at runtime:
+Workarounds that *did not* fully solve the problem:
 
-1. `torch-sys` correctly detects CUDA at build time and emits link directives
-2. However, your binary doesn't directly reference symbols from `libtorch_cuda.so`
-3. The linker removes it as an optimization, even with `--no-as-needed`
-4. At runtime, `libtorch.so` tries to load CUDA support but can't find the library
-5. Result: `torch::cuda::is_available()` returns false
+- `RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"` was positionally ineffective:
+  the flag was emitted at a point in the linker command line that did not
+  cover the `-ltorch_cuda` arg emitted later by `torch-sys`.
+- `LD_PRELOAD=libtorch_cuda.so:libtorch.so` did work at runtime but was a
+  hidden foot-gun: anyone who ran the binary outside the wrapper script
+  silently got a CPU run.
 
-### The Solution: LD_PRELOAD
+### The fix (current behavior)
 
-The only reliable solution is to **force-load the CUDA libraries at runtime** using `LD_PRELOAD`:
+A crate-root `build.rs` now emits positional link args that bracket the
+CUDA libraries with `-Wl,--no-as-needed` / `-Wl,--as-needed`, plus an
+`-rpath` entry pointing at the libtorch lib dir. From the build script's
+perspective:
 
-```bash
-# Get PyTorch lib directory
-TORCH_LIB=$(python3 -c "import torch; import os; print(os.path.join(os.path.dirname(torch.__file__), 'lib'))")
-
-# Set library search path
-export LD_LIBRARY_PATH="${TORCH_LIB}:${LD_LIBRARY_PATH}"
-
-# CRITICAL: Preload CUDA libraries before running
-export LD_PRELOAD="${TORCH_LIB}/libtorch_cuda.so:${TORCH_LIB}/libtorch.so"
-
-# Now CUDA will be available
-cargo run --example your_example --release
+```rust
+println!("cargo:rustc-link-arg=-Wl,--no-as-needed");
+println!("cargo:rustc-link-lib=torch_cuda");
+println!("cargo:rustc-link-lib=c10_cuda");
+println!("cargo:rustc-link-arg=-Wl,--as-needed");
+println!("cargo:rustc-link-arg=-Wl,-rpath,<libtorch_lib_dir>");
 ```
 
-This works because:
-- `LD_PRELOAD` loads the libraries into memory before your program starts
-- When `libtorch.so` initializes, it finds the CUDA implementation already loaded
-- The CUDA detection logic in `torch::cuda::is_available()` succeeds
+This is emitted only when:
+
+1. The target OS is Linux (macOS / Windows builds get nothing).
+2. The `training` feature is enabled.
+3. A CUDA-enabled libtorch is detected on the build host (either via
+   `LIBTORCH_USE_PYTORCH=1` + a PyTorch with CUDA, or `LIBTORCH=...` pointing
+   at a libtorch directory that contains `libtorch_cuda.so` and
+   `libc10_cuda.so`).
+
+CPU-only builds and non-Linux builds are no-ops.
+
+### Verifying the fix
+
+```bash
+cargo build --release --example test_cuda
+ldd target/release/examples/test_cuda | grep -E '(torch_cuda|c10_cuda)'
+# Expected: two lines, one for each CUDA library, neither marked "not found".
+
+readelf -d target/release/examples/test_cuda | grep NEEDED
+# Expected: includes libtorch_cuda.so and libc10_cuda.so.
+
+./target/release/examples/test_cuda
+# Expected: Device::cuda_if_available() = Cuda(0)
+#           tch::Cuda::is_available() = true
+```
+
+No `LD_PRELOAD` is required.
+
+### Opting out of the fix
+
+If your environment is unusual and the link-arg emission causes problems,
+set `THRUST_DISABLE_CUDA_LINK_FIX=1` before building. The `build.rs` will
+become a no-op and you can manage CUDA linking yourself.
+
+### The Option D guard: `THRUST_EXPECT_CUDA`
+
+In addition to the link-time fix, examples can use a runtime guard that
+hard-fails if `tch::Cuda::is_available()` returns false but the user
+expected CUDA:
+
+```rust
+use thrust_rl::utils::cuda::ensure_cuda_if_expected;
+
+let device = Device::cuda_if_available();
+ensure_cuda_if_expected(device); // exits(2) if THRUST_EXPECT_CUDA=1 and device == Cpu
+```
+
+The wrapper scripts (`scripts/train-gpu.sh`, `scripts/gpu-train.sh`,
+`scripts/train-snake-remote.sh`) all `export THRUST_EXPECT_CUDA=1` so that
+silent CPU fallback becomes a loud, fast failure with exit code 2.
 
 ## Environment Setup
 
@@ -70,15 +122,13 @@ The `train-gpu.sh` script handles all environment setup automatically:
 # Set environment to use PyTorch from pip
 export LIBTORCH_USE_PYTORCH=1
 
-# Set LD_LIBRARY_PATH to include PyTorch lib directory
+# Set LD_LIBRARY_PATH to include PyTorch lib directory.
+# (build.rs also embeds an rpath, so this is largely belt-and-suspenders.)
 TORCH_LIB=$(python3 -c "import torch; import os; print(os.path.join(os.path.dirname(torch.__file__), 'lib'))")
 export LD_LIBRARY_PATH="${TORCH_LIB}:${LD_LIBRARY_PATH}"
 
-# CRITICAL: Preload CUDA libraries to ensure they're loaded at runtime
-export LD_PRELOAD="${TORCH_LIB}/libtorch_cuda.so:${TORCH_LIB}/libtorch.so"
-
-# CRITICAL: Force linker to keep CUDA library dependency
-export RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"
+# Make silent CPU fallback a hard error.
+export THRUST_EXPECT_CUDA=1
 
 # Build and run
 cargo build --example "$EXAMPLE_NAME" --release
@@ -98,17 +148,16 @@ source venv/bin/activate
 export LIBTORCH_USE_PYTORCH=1
 TORCH_LIB=$(python3 -c "import torch; import os; print(os.path.join(os.path.dirname(torch.__file__), 'lib'))")
 export LD_LIBRARY_PATH="${TORCH_LIB}:${LD_LIBRARY_PATH}"
-export LD_PRELOAD="${TORCH_LIB}/libtorch_cuda.so:${TORCH_LIB}/libtorch.so"
 cargo run --example test_cuda --release
 ```
 
 Expected output:
 ```
-🔍 Testing CUDA availability in tch-rs
+Testing CUDA availability in tch-rs
 Device::cuda_if_available() = Cuda(0)
 tch::Cuda::is_available() = true
 tch::Cuda::device_count() = 1
-✅ Successfully created tensor on CUDA
+Successfully created tensor on CUDA
 ```
 
 ## Troubleshooting
@@ -124,14 +173,30 @@ tch::Cuda::device_count() = 1
 
 This script automatically detects your GPU and installs the correct PyTorch version with CUDA support.
 
-### Error: "cannot open shared object file: libtorch_cuda.so"
+### `ldd ... | grep torch_cuda` is empty after a clean rebuild
 
-**Problem**: `LD_PRELOAD` path is incorrect or PyTorch is not installed.
+**Problem**: `build.rs` did not detect CUDA at build time, so the link-arg
+emission was skipped.
 
-**Solution**:
-1. Verify PyTorch installation: `python3 -c "import torch; print(torch.__file__)"`
-2. Check library exists: `ls $(python3 -c "import torch; import os; print(os.path.join(os.path.dirname(torch.__file__), 'lib'))")/libtorch_cuda.so`
-3. Reinstall if needed: `./scripts/setup-libtorch.sh`
+**Check**:
+1. `python3 -c 'import torch; print(torch.cuda.is_available())'` returns `True`.
+2. `LIBTORCH_USE_PYTORCH=1` is set in the build environment.
+3. `cargo clean && cargo build --example test_cuda --release` (build.rs is
+   cached, so you need a clean rebuild after changing the env).
+4. Inspect the build.rs log via `CARGO_LOG=cargo::core::compiler::custom_build=debug cargo build ...`,
+   or check `target/.../build/thrust-rl-*/output` for the link-arg directives.
+
+**Fallback**: As a last resort, set the legacy `LD_PRELOAD`:
+```bash
+TORCH_LIB=$(python3 -c "import torch; import os; print(os.path.join(os.path.dirname(torch.__file__), 'lib'))")
+export LD_PRELOAD="${TORCH_LIB}/libtorch_cuda.so:${TORCH_LIB}/libtorch.so"
+```
+
+### Error: "FATAL: THRUST_EXPECT_CUDA=1 but tch fell back to Device::Cpu"
+
+This is the Option D guard firing. Follow the diagnostic steps printed by
+the binary (mostly: `ldd | grep torch_cuda`, then verify the build env).
+Exit code is 2.
 
 ### Error: "libtorch_cuda.so: undefined symbol"
 
@@ -161,11 +226,14 @@ let tensor = Tensor::randn([2, 2], (Kind::Float, device));
 
 ### Linux (Ubuntu/Debian)
 
-Works out of the box with the `LD_PRELOAD` solution.
+Works out of the box --- `build.rs` handles the linker behavior automatically.
+No `LD_PRELOAD` needed.
 
 ### macOS
 
-CUDA is not supported on macOS. Use Metal Performance Shaders (MPS) instead:
+CUDA is not supported on macOS. The `build.rs` is a no-op on macOS so
+nothing changes from a build-system perspective. Use Metal Performance
+Shaders (MPS) instead:
 ```rust
 let device = Device::Mps;  // For M1/M2/M3 Macs
 ```
@@ -183,7 +251,8 @@ $env:LIBTORCH_USE_PYTORCH = "1"
 $env:Path = "C:\path\to\python\Lib\site-packages\torch\lib;$env:Path"
 ```
 
-Note: `LD_PRELOAD` is Linux-specific. On Windows, ensure the PyTorch DLLs are in your PATH.
+Note: the `--as-needed` linker behavior is Linux-specific. The `build.rs`
+is a no-op on Windows. Ensure the PyTorch DLLs are in your PATH.
 
 ## Performance Tips
 
@@ -209,15 +278,25 @@ Note: `LD_PRELOAD` is Linux-specific. On Windows, ensure the PyTorch DLLs are in
 - [tch-rs Documentation](https://docs.rs/tch/)
 - [PyTorch CUDA Installation](https://pytorch.org/get-started/locally/)
 - [CUDA Toolkit Download](https://developer.nvidia.com/cuda-downloads)
-- [LD_PRELOAD Explanation](https://man7.org/linux/man-pages/man8/ld.so.8.html)
+- [ld(1) --as-needed semantics](https://man7.org/linux/man-pages/man1/ld.1.html)
+- Issue [#9](https://github.com/rjwalters/thrust/issues/9) --- root cause + fix history
 
-## Key Discoveries
+## Key Discoveries (Historical)
 
-This solution was discovered through systematic debugging:
+The build-script fix was the result of systematic debugging documented in
+issue #9:
 
-1. Verified `torch-sys` emits correct link directives ✅
-2. Found binary only links `libtorch_cpu.so`, not `libtorch_cuda.so` ❌
-3. Discovered linker drops CUDA library as "unused" even with `--no-as-needed`
-4. Solution: Use `LD_PRELOAD` to force-load libraries at runtime ✅
+1. Verified `torch-sys` emits correct `cargo:rustc-link-lib=torch_cuda` directives.
+2. Found binary only links `libtorch_cpu.so`, not `libtorch_cuda.so`.
+3. Discovered the linker drops the CUDA libs as "unused" even with
+   `RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"` --- because the flag was at
+   the wrong position on the link line.
+4. Initial workaround: `LD_PRELOAD` at runtime. Worked but was fragile.
+5. Proper fix (issue #9): re-emit `-Wl,--no-as-needed -ltorch_cuda
+   -lc10_cuda -Wl,--as-needed` from a leaf-crate `build.rs`, where Cargo
+   appends the link args at a position that *does* cover the explicit
+   `-ltorch_cuda` arg.
 
-The `train-gpu.sh` script encapsulates this hard-won knowledge so you don't have to rediscover it.
+The `train-gpu.sh` / `gpu-train.sh` / `train-snake-remote.sh` scripts still
+exist and add a `THRUST_EXPECT_CUDA=1` belt-and-suspenders guard so any
+future regression is loud rather than silent.

--- a/docs/GPU_TRAINING_GUIDE.md
+++ b/docs/GPU_TRAINING_GUIDE.md
@@ -50,24 +50,32 @@ Points to PyTorch's lib directory so libraries can be found at runtime:
 export LD_LIBRARY_PATH=$(python3 -c 'import torch; import os; print(os.path.join(os.path.dirname(torch.__file__), "lib"))')
 ```
 
-### 3. LD_PRELOAD (CRITICAL for GPU)
-Forces CUDA libraries to load even if linker thinks they're "unused":
+### 3. LD_PRELOAD (no longer required as of issue #9)
+The crate-root `build.rs` now keeps `libtorch_cuda.so` and
+`libc10_cuda.so` in the binary's `DT_NEEDED` list automatically, so
+setting `LD_PRELOAD` is no longer necessary. If you ever need to fall
+back (e.g. a custom libtorch that the build.rs can't auto-detect):
 ```bash
 export LD_PRELOAD="$PYTORCH_LIB/libtorch_cuda.so:$PYTORCH_LIB/libtorch.so"
 ```
 
-Without this, you get symbol lookup errors like:
+Historical symptom that this used to fix:
 ```
 undefined symbol: _ZNK3c107SymBool14guard_or_falseEPKcl
 ```
 
-### 4. RUSTFLAGS (CRITICAL for GPU)
-Prevents linker from dropping CUDA dependencies:
-```bash
-export RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"
-```
+### 4. RUSTFLAGS (no longer required as of issue #9)
+The `build.rs` re-emits `-Wl,--no-as-needed -ltorch_cuda -lc10_cuda` at
+the correct position on the linker command line, so the historical
+`RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"` workaround is unnecessary.
+Kept here for historical reference --- still safe to set, just redundant.
 
-### 5. LIBTORCH_BYPASS_VERSION_CHECK=1
+### 5. THRUST_EXPECT_CUDA=1 (CRITICAL for GPU runs)
+Turns silent CPU fallback into a hard error (exit 2) if for any reason
+`tch::Cuda::is_available()` ends up false. All three GPU wrapper scripts
+set this automatically.
+
+### 6. LIBTORCH_BYPASS_VERSION_CHECK=1
 Allows minor version mismatches (use carefully).
 
 ## Why Use Nightly Rust?
@@ -106,11 +114,10 @@ cd ~/thrust
 # 3. Pull latest code
 git pull
 
-# 4. Set up environment
+# 4. Set up environment (build.rs handles the linker; just point at libtorch)
 export LIBTORCH_USE_PYTORCH=1
 export LD_LIBRARY_PATH=$(python3 -c 'import torch; import os; print(os.path.join(os.path.dirname(torch.__file__), "lib"))')
-export LD_PRELOAD="$LD_LIBRARY_PATH/libtorch_cuda.so:$LD_LIBRARY_PATH/libtorch.so"
-export RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"
+export THRUST_EXPECT_CUDA=1   # hard-fail if tch falls back to Cpu
 
 # 5. Build with nightly
 cargo +nightly build --example train_snake_multi_v2 --release
@@ -161,16 +168,26 @@ Look for:
 ## Common Issues
 
 ### Issue 1: "Using CPU" instead of GPU
-**Cause**: CUDA libraries not properly linked or LD_PRELOAD not set
-**Fix**: Use `cargo +nightly` and set all environment variables
+**Cause**: `build.rs` did not detect a CUDA-enabled libtorch at build time,
+or `LIBTORCH_USE_PYTORCH=1` was not set. With `THRUST_EXPECT_CUDA=1`, this
+now hard-fails with exit code 2 and a diagnostic message.
+**Fix**:
+1. Verify Python has CUDA: `python3 -c 'import torch; print(torch.cuda.is_available())'`.
+2. `cargo clean` (build.rs is cached) and rebuild with `LIBTORCH_USE_PYTORCH=1`.
+3. Verify with `ldd target/release/examples/<bin> | grep torch_cuda`.
 
 ### Issue 2: Symbol lookup errors
 **Symptoms**:
 ```
 symbol lookup error: undefined symbol: _ZNK3c107SymBool...
 ```
-**Cause**: LD_PRELOAD not set, so CUDA libraries aren't loaded
-**Fix**: Set LD_PRELOAD before building AND running
+**Cause**: The CUDA libraries were not linked. This used to be the
+"`--as-needed` strips libtorch_cuda" bug; `build.rs` should now prevent it.
+**Fix**: Confirm `ldd | grep torch_cuda` shows both libtorch_cuda and
+c10_cuda. If not, see Issue 1. As a last resort:
+```bash
+export LD_PRELOAD="$PYTORCH_LIB/libtorch_cuda.so:$PYTORCH_LIB/libtorch.so"
+```
 
 ### Issue 3: PyTorch version mismatch
 **Symptoms**: Compilation errors in torch-sys about missing/changed APIs
@@ -181,17 +198,20 @@ ssh rwalters-sandbox-2
 pip3 install --break-system-packages torch==2.9.0
 ```
 
-### Issue 4: Build succeeds but runtime error
-**Cause**: Binary was built without RUSTFLAGS/LD_PRELOAD, so dependencies are wrong
-**Fix**: Clean and rebuild:
+### Issue 4: Build succeeds but runtime crash / CPU fallback
+**Cause**: Binary was built against a libtorch that lacks CUDA, or the
+build.rs failed to detect CUDA so the link args were not emitted.
+**Fix**: Clean and rebuild with `LIBTORCH_USE_PYTORCH=1` set:
 ```bash
 cargo clean
-# Then rebuild with all env vars set
+export LIBTORCH_USE_PYTORCH=1
+cargo build --example <bin> --release
 ```
 
 ### Issue 5: "Cannot find libtorch_cpu.so"
-**Cause**: LD_LIBRARY_PATH not set at runtime
-**Fix**: Set LD_LIBRARY_PATH before running (not just building)
+**Cause**: LD_LIBRARY_PATH not set at runtime (the `build.rs` adds an
+`-rpath`, but only for the CUDA lib dir).
+**Fix**: Set LD_LIBRARY_PATH before running (not just building).
 
 ## Remote Machine Setup
 
@@ -258,14 +278,17 @@ If GPU training isn't working, verify each step:
 - [ ] PyTorch version is 2.9.0: `python3 -c 'import torch; print(torch.__version__)'`
 - [ ] CUDA is available: `python3 -c 'import torch; print(torch.cuda.is_available())'`
 - [ ] Using nightly Rust: `cargo +nightly --version`
-- [ ] LIBTORCH_USE_PYTORCH=1 is set
+- [ ] LIBTORCH_USE_PYTORCH=1 is set (build.rs needs this to detect CUDA)
 - [ ] LD_LIBRARY_PATH points to PyTorch lib directory
-- [ ] LD_PRELOAD includes libtorch_cuda.so and libtorch.so
-- [ ] RUSTFLAGS includes --no-as-needed
-- [ ] Ran `cargo clean` after changing environment variables
+- [ ] `ldd target/release/examples/<bin> | grep torch_cuda` is non-empty
+- [ ] Ran `cargo clean` after changing build environment
 - [ ] Built with `cargo +nightly build --release`
 - [ ] Training code passes `--cuda` flag
+- [ ] THRUST_EXPECT_CUDA=1 set (fails loudly if anything regresses)
 - [ ] nvidia-smi shows GPU utilization during training
+
+LD_PRELOAD and RUSTFLAGS=`--no-as-needed` are no longer required as of
+issue #9. The crate-root `build.rs` handles linker behavior.
 
 ## Performance Expectations
 

--- a/examples/test_cuda.rs
+++ b/examples/test_cuda.rs
@@ -1,28 +1,61 @@
-//! Test CUDA availability in tch-rs
+//! Test CUDA availability in tch-rs.
+//!
+//! Verifies that the `build.rs` link-arg fix is working: on a CUDA-equipped
+//! Linux box, this should print `Cuda(0)` and `tch::Cuda::is_available() = true`
+//! *without* any `LD_PRELOAD` workaround. On macOS or CPU-only builds it
+//! gracefully reports `Cpu`.
+//!
+//! Acceptance check (from issue #9):
+//!
+//! ```bash
+//! cargo build --release --example test_cuda
+//! ldd target/release/examples/test_cuda | grep -E '(torch_cuda|c10_cuda)'
+//! # Both lines must appear.
+//! ./target/release/examples/test_cuda
+//! # Must report Cuda(0).
+//! ```
+//!
+//! Setting `THRUST_EXPECT_CUDA=1` makes this example hard-fail (exit 2)
+//! instead of reporting CPU, which is what scripts like
+//! `scripts/train-snake-remote.sh` want.
 
 use tch::Device;
+use thrust_rl::utils::cuda::ensure_cuda_if_expected;
 
 fn main() {
-    println!("🔍 Testing CUDA availability in tch-rs");
+    println!("Testing CUDA availability in tch-rs");
     println!();
 
     // Test cuda_if_available
     let device = Device::cuda_if_available();
-    println!("Device::cuda_if_available() = {:?}", device);
+    println!("Device::cuda_if_available() = {device:?}");
 
     // Check if CUDA is available
     let cuda_available = tch::Cuda::is_available();
-    println!("tch::Cuda::is_available() = {}", cuda_available);
+    println!("tch::Cuda::is_available() = {cuda_available}");
 
     let cuda_count = tch::Cuda::device_count();
-    println!("tch::Cuda::device_count() = {}", cuda_count);
+    println!("tch::Cuda::device_count() = {cuda_count}");
 
     // Try creating a tensor on CUDA
     if cuda_available {
         let tensor = tch::Tensor::randn([2, 2], (tch::Kind::Float, Device::Cuda(0)));
-        println!("✅ Successfully created tensor on CUDA");
+        println!("Successfully created tensor on CUDA");
         println!("   Tensor device: {:?}", tensor.device());
     } else {
-        println!("❌ CUDA not available, cannot create CUDA tensor");
+        println!("CUDA not available, cannot create CUDA tensor");
+        println!();
+        println!("Hints if you expected CUDA to be available:");
+        println!("  - Are you on a Linux box with an NVIDIA GPU?");
+        println!("  - Is `nvidia-smi` working?");
+        println!("  - Did Python report CUDA? Run:");
+        println!("      python3 -c 'import torch; print(torch.cuda.is_available())'");
+        println!("  - Did the build.rs detect a CUDA-enabled libtorch?");
+        println!("    Check `ldd target/release/examples/test_cuda | grep torch_cuda`.");
+        println!("  - If `ldd` shows libtorch_cuda but is_available is still false,");
+        println!("    that is a deeper tch/libtorch issue --- see issue #9 history.");
     }
+
+    // The Option D hard-fail guard. Only triggers if THRUST_EXPECT_CUDA is set.
+    ensure_cuda_if_expected(device);
 }

--- a/scripts/gpu-train.sh
+++ b/scripts/gpu-train.sh
@@ -31,16 +31,23 @@ export PYTORCH_LIB=$(/usr/bin/python3 -c 'import torch; import os; print(os.path
 export LD_LIBRARY_PATH="$PYTORCH_LIB:${LD_LIBRARY_PATH:-}"
 export LIBTORCH_BYPASS_VERSION_CHECK=1
 
-# CRITICAL: Preload CUDA libraries to ensure they're loaded at runtime
-export LD_PRELOAD="$PYTORCH_LIB/libtorch_cuda.so:$PYTORCH_LIB/libtorch.so"
+# Make silent CPU fallback a hard error: the crate-root build.rs is supposed
+# to keep libtorch_cuda in NEEDED, but if it ever fails (e.g. a custom
+# libtorch path that doesn't ship libtorch_cuda.so), we'd rather know
+# loudly than benchmark a misleading run.
+export THRUST_EXPECT_CUDA=1
 
-# CRITICAL: Force linker to keep CUDA library dependency
-export RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"
+# NOTE: As of issue #9 the crate-root build.rs now emits positional
+# `-Wl,--no-as-needed` + `-ltorch_cuda` + `-lc10_cuda` so the linker does
+# NOT strip the CUDA libs from DT_NEEDED. The historical LD_PRELOAD +
+# RUSTFLAGS workaround is no longer required. If you ever need to fall
+# back, uncomment the two lines below.
+# export LD_PRELOAD="$PYTORCH_LIB/libtorch_cuda.so:$PYTORCH_LIB/libtorch.so"
+# export RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"
 
 echo "Debug: PYTORCH_LIB=$PYTORCH_LIB"
 echo "Debug: LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
-echo "Debug: LD_PRELOAD=$LD_PRELOAD"
-echo "Debug: RUSTFLAGS=$RUSTFLAGS"
+echo "Debug: THRUST_EXPECT_CUDA=$THRUST_EXPECT_CUDA"
 echo ""
 
 # Create log file with timestamp

--- a/scripts/train-gpu.sh
+++ b/scripts/train-gpu.sh
@@ -50,13 +50,18 @@ export LIBTORCH_USE_PYTORCH=1
 TORCH_LIB=$(python3 -c "import torch; import os; print(os.path.join(os.path.dirname(torch.__file__), 'lib'))")
 export LD_LIBRARY_PATH="${TORCH_LIB}:${LD_LIBRARY_PATH}"
 
-# CRITICAL: Preload CUDA libraries to ensure they're loaded at runtime
-# The linker drops these as "unused" even with --no-as-needed, so we force-load them
-export LD_PRELOAD="${TORCH_LIB}/libtorch_cuda.so:${TORCH_LIB}/libtorch.so"
+# Catch silent CPU fallback. The crate-root build.rs is responsible for
+# keeping libtorch_cuda.so in NEEDED, but if anything goes wrong we want a
+# loud fatal error rather than a 5x-slower run on CPU.
+export THRUST_EXPECT_CUDA=1
 
-# CRITICAL: Force linker to keep CUDA library dependency
-# Without this, the linker removes libtorch_cuda.so as "unused" even though it's needed at runtime
-export RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"
+# NOTE: As of issue #9 the crate-root build.rs now emits positional
+# `-Wl,--no-as-needed` + `-ltorch_cuda` + `-lc10_cuda` so the linker keeps
+# the CUDA libs in DT_NEEDED. The historical LD_PRELOAD + RUSTFLAGS
+# workaround is no longer required. Uncomment if you need a belt-and-
+# suspenders fallback for a non-standard libtorch install.
+# export LD_PRELOAD="${TORCH_LIB}/libtorch_cuda.so:${TORCH_LIB}/libtorch.so"
+# export RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"
 
 # IMPORTANT: Build must happen on this machine to detect CUDA at compile time
 echo "Building with CUDA support..."

--- a/scripts/train-snake-remote.sh
+++ b/scripts/train-snake-remote.sh
@@ -24,13 +24,21 @@ export LIBTORCH_USE_PYTORCH=1
 PYTORCH_LIB=$(python3 -c 'import torch; import os; print(os.path.join(os.path.dirname(torch.__file__), "lib"))')
 export LD_LIBRARY_PATH="$PYTORCH_LIB:${LD_LIBRARY_PATH:-}"
 
-# CRITICAL: Preload CUDA libraries and force linker to keep them
-export LD_PRELOAD="$PYTORCH_LIB/libtorch_cuda.so:$PYTORCH_LIB/libtorch.so"
-export RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"
+# Make silent CPU fallback a hard error. The crate-root build.rs (added in
+# issue #9) is responsible for keeping libtorch_cuda.so in NEEDED, but
+# this guard hard-fails (exit 2) if for any reason tch falls back to Cpu.
+export THRUST_EXPECT_CUDA=1
+
+# NOTE: As of issue #9 the crate-root build.rs now emits positional link
+# args that defeat the linker's --as-needed stripping of libtorch_cuda,
+# so the historical LD_PRELOAD + RUSTFLAGS workaround is no longer
+# required. Uncomment if you hit a regression and need a fallback.
+# export LD_PRELOAD="$PYTORCH_LIB/libtorch_cuda.so:$PYTORCH_LIB/libtorch.so"
+# export RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"
 
 echo "🔍 CUDA Environment:"
 echo "   LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
-echo "   LD_PRELOAD=$LD_PRELOAD"
+echo "   THRUST_EXPECT_CUDA=$THRUST_EXPECT_CUDA"
 echo ""
 
 # Clean and rebuild to ensure CUDA linking

--- a/src/utils/cuda.rs
+++ b/src/utils/cuda.rs
@@ -1,0 +1,90 @@
+//! CUDA runtime guard utilities.
+//!
+//! The `build.rs` at the crate root takes care of *link-time* correctness so
+//! that `libtorch_cuda.so` ends up in `DT_NEEDED`. This module provides a
+//! *runtime* guard that hard-fails if the user expected CUDA but the
+//! `tch::Cuda::is_available()` probe still returns false. The intent is to
+//! turn silent CPU fallback (which is hard to notice in benchmarks) into a
+//! loud, fast failure.
+//!
+//! ## Usage
+//!
+//! In training examples:
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "training")]
+//! # fn main() {
+//! use thrust_rl::utils::cuda::ensure_cuda_if_expected;
+//! use tch::Device;
+//!
+//! let device = Device::cuda_if_available();
+//! ensure_cuda_if_expected(device); // exits(2) if THRUST_EXPECT_CUDA=1 and device == Cpu
+//! # }
+//! # #[cfg(not(feature = "training"))] fn main() {}
+//! ```
+//!
+//! Set `THRUST_EXPECT_CUDA=1` in the environment to make the guard active.
+//! With the variable unset, the guard is a no-op and behavior is unchanged
+//! (silent CPU fallback for any user who hasn't opted in).
+//!
+//! ## Why an opt-in env var rather than always-on?
+//!
+//! Examples like `train_cartpole` happily run on CPU and we don't want to
+//! force every developer to install CUDA. Only training runs that *expect*
+//! a GPU should hard-fail, and those runs are always launched via one of
+//! the `scripts/*-gpu*.sh` wrappers, where the env var can be set centrally.
+
+#[cfg(feature = "training")]
+use tch::Device;
+
+/// Hard-fail if `THRUST_EXPECT_CUDA` is set and `device` is `Cpu`.
+///
+/// On failure, prints a diagnostic explaining the most common root cause
+/// (linker stripped `libtorch_cuda`) and exits with status 2 so that
+/// shell scripts can detect the failure (`$? == 2` means "expected CUDA,
+/// got CPU"; status 1 stays reserved for ordinary `Result::Err`).
+///
+/// No-op if:
+/// - the `THRUST_EXPECT_CUDA` environment variable is not set, or
+/// - `device` is anything other than `Device::Cpu`.
+#[cfg(feature = "training")]
+pub fn ensure_cuda_if_expected(device: Device) {
+    let Ok(val) = std::env::var("THRUST_EXPECT_CUDA") else {
+        return;
+    };
+    if val.is_empty() || val == "0" || val.eq_ignore_ascii_case("false") {
+        return;
+    }
+    if device != Device::Cpu {
+        return;
+    }
+
+    eprintln!();
+    eprintln!("FATAL: THRUST_EXPECT_CUDA={val} but tch fell back to Device::Cpu.");
+    eprintln!();
+    eprintln!("Most likely cause: the linker stripped libtorch_cuda.so from");
+    eprintln!("the binary's NEEDED list because no symbol from it was directly");
+    eprintln!("referenced. The crate-level build.rs is supposed to prevent");
+    eprintln!("this --- verify with:");
+    eprintln!();
+    eprintln!("    ldd <this-binary> | grep torch_cuda");
+    eprintln!();
+    eprintln!("If the line is empty, the build.rs did not run or did not detect");
+    eprintln!("CUDA. Make sure LIBTORCH_USE_PYTORCH=1 is set (or LIBTORCH points");
+    eprintln!("at a CUDA-enabled libtorch) and re-run `cargo clean && cargo build`.");
+    eprintln!();
+    eprintln!("As a last resort, set LD_PRELOAD to libtorch_cuda.so + libc10_cuda.so.");
+    eprintln!();
+    std::process::exit(2);
+}
+
+/// Stub for non-training builds so callers can unconditionally invoke the
+/// guard without `cfg` gating at every call site.
+///
+/// This intentionally accepts `_device: &()` (a unit reference) because
+/// non-training builds don't have access to `tch::Device`. Most call sites
+/// are inside `#[cfg(feature = "training")]` code anyway, so this stub
+/// rarely gets used in practice.
+#[cfg(not(feature = "training"))]
+#[allow(dead_code)]
+pub fn ensure_cuda_if_expected(_device: &()) {}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,9 @@
 
 pub mod normalize;
 
+/// CUDA runtime sanity-check helpers. See `cuda::ensure_cuda_if_expected`.
+pub mod cuda;
+
 /// Logging utilities
 pub mod logging {
     // Coming soon


### PR DESCRIPTION
## Summary

Closes #9.

- Adds a crate-root `build.rs` that re-emits positional link args
  (`-Wl,--no-as-needed -ltorch_cuda -lc10_cuda -Wl,--as-needed` plus
  `-rpath`) so GNU ld no longer strips `libtorch_cuda.so` from the
  binary's `DT_NEEDED` list. This is the fix for the silent CPU
  fallback described in #9.
- Adds a runtime guard `thrust_rl::utils::cuda::ensure_cuda_if_expected`
  that hard-fails with exit code 2 if `THRUST_EXPECT_CUDA=1` is set but
  `tch::Cuda::is_available()` returns false. Turns silent CPU fallback
  into a loud, fast failure.
- Removes the now-redundant `LD_PRELOAD=libtorch_cuda.so:libtorch.so`
  and `RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"` exports from
  `scripts/gpu-train.sh`, `scripts/train-gpu.sh`, and
  `scripts/train-snake-remote.sh` (kept as commented documentation in
  case of regression). All three scripts now `export
  THRUST_EXPECT_CUDA=1`.
- Rewrites `docs/GPU_SETUP.md` and `docs/GPU_TRAINING_GUIDE.md` to
  reflect the new behavior --- `LD_PRELOAD` is now described as
  historical / fallback rather than CRITICAL.
- Registers `examples/test_cuda.rs` as a proper `[[example]]` in
  `Cargo.toml`. The example now invokes the guard and prints
  diagnostics on CPU fallback.

## Why the historical workaround didn't work

The pre-existing `RUSTFLAGS="-C link-arg=-Wl,--no-as-needed"` is
*positionally ineffective*: `-Wl,--no-as-needed` only affects libraries
that appear *after* it on the linker command line, and the flag set via
`RUSTFLAGS` landed before the `-ltorch_cuda` arg that `torch-sys` emits.
Re-emitting the bracket from a leaf-crate `build.rs` puts the flag at
the end of the command line where it actually covers `-ltorch_cuda`.
The `LD_PRELOAD` workaround patched the symptom at runtime but was a
foot-gun: anyone running the binary outside the wrapper script silently
got a CPU run.

## What runs on this PR's build.rs

On Linux + `training` feature + a CUDA-enabled libtorch is detected:

```
cargo:rustc-link-search=native=<libtorch_lib_dir>
cargo:rustc-link-arg-bins=-Wl,--no-as-needed
cargo:rustc-link-arg-examples=-Wl,--no-as-needed
cargo:rustc-link-arg-tests=-Wl,--no-as-needed
cargo:rustc-link-arg-benches=-Wl,--no-as-needed
cargo:rustc-link-lib=torch_cuda
cargo:rustc-link-lib=c10_cuda
cargo:rustc-link-arg-{bins,examples,tests,benches}=-Wl,--as-needed
cargo:rustc-link-arg-{bins,examples,tests,benches}=-Wl,-rpath,<libtorch_lib_dir>
```

The `-bins`/`-examples`/`-tests`/`-benches` variants are used so the
link args apply to every binary kind that depends on `thrust-rl` (the
plain `rustc-link-arg` form only applies to the crate's own artifact,
which for `thrust-rl` is `cdylib + rlib` and the rlib doesn't go
through the linker). `rustc-link-lib` applies to all artifacts already
and doesn't need a variant.

On macOS, Windows, CPU-only feature builds, or with
`THRUST_DISABLE_CUDA_LINK_FIX=1` set: the script emits only its
`rerun-if-env-changed=` directives and otherwise no-ops.

## Test plan

### Verified locally (macOS, CPU-only)

- [x] `rustc build.rs` parses standalone --- no syntax errors.
- [x] `cargo check --no-default-features` runs `build.rs`; output file
      contains only `rerun-if-env-changed=` lines (no spurious CUDA
      link args on macOS). The only build error is a pre-existing
      missing `src/env/games/pong.rs` module (untracked in `main`,
      unrelated to this PR).
- [x] `cargo check --no-default-features --features wasm` --- same
      pre-existing `pong` error only; no new errors or warnings
      attributable to this PR.
- [x] `cargo:rerun-if-env-changed=` directives cover `LIBTORCH`,
      `LIBTORCH_USE_PYTORCH`, `LIBTORCH_BYPASS_VERSION_CHECK`,
      `THRUST_DISABLE_CUDA_LINK_FIX`, and `CARGO_FEATURE_TRAINING`, so
      `cargo build` twice in a row will not re-run the script
      unnecessarily.

### Requires a CUDA Linux box --- NOT YET VERIFIED

I do not have access to a CUDA-equipped Linux host from this
environment. The following acceptance criteria from the issue still
need confirmation on `rwalters-sandbox-2` (or equivalent):

- [ ] `unset LD_PRELOAD RUSTFLAGS; export LIBTORCH_USE_PYTORCH=1
      LIBTORCH_BYPASS_VERSION_CHECK=1; cargo clean && cargo build
      --release --example test_cuda`.
- [ ] `ldd target/release/examples/test_cuda | grep -E
      '(torch_cuda|c10_cuda)'` returns both lines, neither marked
      "not found".
- [ ] `readelf -d target/release/examples/test_cuda | grep NEEDED`
      lists `libtorch_cuda.so` and `libc10_cuda.so`.
- [ ] `./target/release/examples/test_cuda` (no `LD_PRELOAD`) prints
      `Device::cuda_if_available() = Cuda(0)` and
      `tch::Cuda::is_available() = true`.
- [ ] `./scripts/gpu-train.sh test_cuda` succeeds end-to-end with the
      `LD_PRELOAD` lines commented out.
- [ ] `nvidia-smi -l 1` during a real training run shows >50% GPU
      utilization (regression check vs the old LD_PRELOAD path).
- [ ] Negative test: `THRUST_EXPECT_CUDA=1
      THRUST_DISABLE_CUDA_LINK_FIX=1 ./target/release/examples/test_cuda`
      (i.e. the build.rs fix disabled) exits 2 with the diagnostic
      message.

### Edge cases I want a reviewer to think about

- The `build.rs` shells out to `python3` (and `python` as a fallback)
  to discover the PyTorch lib dir. On a stripped-down build container
  without Python, detection will simply fail and the script becomes a
  no-op (CPU-only build). Is that an acceptable degradation?
- `rustc-link-arg-tests` and `rustc-link-arg-benches` are listed for
  completeness but neither path is exercised on CI today.
- `-Wl,-rpath,<dir>` bakes the build host's libtorch path into the
  binary. This is convenient but means binaries are not portable
  across hosts with different Python prefixes. If that's a concern,
  the rpath emission could be made opt-in via an env var --- ping me
  if you'd like that gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)