### PR TITLE
MultiAgentEnvironment: support multi-discrete action spaces

### DIFF
--- a/src/env/games/bucket_brigade.rs
+++ b/src/env/games/bucket_brigade.rs
@@ -14,12 +14,16 @@
 //! [`crate::policy::multi_discrete_mlp::MultiDiscreteMlpPolicy`] with
 //! `action_dims = vec![10, 2]`.
 //!
-//! Does **not** implement [`crate::multi_agent::MultiAgentEnvironment`]
-//! because that trait currently takes `&[i64]` and doesn't support factored
-//! action spaces (see upstream issue #3). When the trait is widened, this
-//! struct can grow a trivial impl.
+//! In addition to its inherent [`BucketBrigadeMaEnv::step`] API (which takes
+//! the typed `&[[u8; 2]]` form), this type implements the multi-discrete
+//! [`crate::multi_agent::MultiAgentEnvironment`] trait so it can be driven
+//! through the generic multi-agent rollout surface (one `Vec<i64>` per
+//! agent, length matching [`BucketBrigadeMaEnv::action_dims`]).
 
 use bucket_brigade_core::{Action, AgentObservation, BucketBrigade, Scenario};
+
+use crate::env::{Environment, SpaceInfo, SpaceType, StepInfo, StepResult};
+use crate::multi_agent::{MultiAgentEnvironment, MultiAgentResult};
 
 /// Number of houses on the Bucket Brigade ring. Constant; the engine
 /// hard-codes 10.
@@ -127,6 +131,128 @@ impl BucketBrigadeMaEnv {
             .collect();
 
         MaStepResult { rewards: result.rewards, done: result.done, observations }
+    }
+}
+
+// -------- Single-agent `Environment` adapter --------
+//
+// `MultiAgentEnvironment` requires `Environment`. Bucket Brigade is
+// fundamentally multi-agent, so this single-agent surface exists only to
+// satisfy the trait hierarchy: it returns agent 0's observation and treats a
+// single scalar action as a Cartesian-product index over `[house, mode]`.
+// Real consumers should drive the env through `MultiAgentEnvironment`.
+impl Environment for BucketBrigadeMaEnv {
+    fn reset(&mut self) {
+        let _ = BucketBrigadeMaEnv::reset(self, None);
+    }
+
+    fn get_observation(&self) -> Vec<f32> {
+        flatten_observation(&self.inner.get_observation(0))
+    }
+
+    fn step(&mut self, action: i64) -> StepResult {
+        // Single-agent surface: decode the scalar Cartesian-product index
+        // `house * 2 + mode` and broadcast it to every agent. This is a
+        // degenerate path; multi-agent consumers should use
+        // [`MultiAgentEnvironment::step_multi`] instead.
+        let house = ((action / 2) % NUM_HOUSES as i64) as u8;
+        let mode = (action % 2) as u8;
+        let actions: Vec<[u8; 2]> = (0..self.num_agents).map(|_| [house, mode]).collect();
+        let r = BucketBrigadeMaEnv::step(self, &actions);
+        StepResult {
+            observation: r.observations.into_iter().next().unwrap_or_default(),
+            reward: r.rewards.first().copied().unwrap_or(0.0),
+            terminated: r.done,
+            truncated: false,
+            info: StepInfo::default(),
+        }
+    }
+
+    fn observation_space(&self) -> SpaceInfo {
+        SpaceInfo { shape: vec![self.obs_dim()], space_type: SpaceType::Box }
+    }
+
+    fn action_space(&self) -> SpaceInfo {
+        // Cartesian-product flattening for the single-agent surface only.
+        SpaceInfo { shape: vec![], space_type: SpaceType::Discrete(NUM_HOUSES * 2) }
+    }
+
+    fn render(&self) -> Vec<u8> {
+        Vec::new()
+    }
+
+    fn close(&mut self) {}
+}
+
+// -------- Multi-agent factored action surface --------
+impl MultiAgentEnvironment for BucketBrigadeMaEnv {
+    fn num_agents(&self) -> usize {
+        self.num_agents
+    }
+
+    fn get_agent_observation(&self, agent_id: usize) -> Vec<f32> {
+        flatten_observation(&self.inner.get_observation(agent_id))
+    }
+
+    fn agent_action_space(&self, _agent_id: usize) -> Vec<usize> {
+        // Factored `[house_index, mode]` -- matches
+        // `MultiDiscreteMlpPolicy::action_dims` used by the BB trainer.
+        vec![NUM_HOUSES, 2]
+    }
+
+    fn step_multi(&mut self, actions: &[Vec<i64>]) -> MultiAgentResult {
+        assert_eq!(
+            actions.len(),
+            self.num_agents,
+            "BucketBrigadeMaEnv::step_multi: expected {} actions, got {}",
+            self.num_agents,
+            actions.len()
+        );
+
+        let inner_actions: Vec<[u8; 2]> = actions
+            .iter()
+            .enumerate()
+            .map(|(i, a)| {
+                assert_eq!(
+                    a.len(),
+                    2,
+                    "BucketBrigadeMaEnv::step_multi: agent {} action must have 2 dims \
+                     ([house_index, mode]), got {}",
+                    i,
+                    a.len()
+                );
+                assert!(
+                    (0..NUM_HOUSES as i64).contains(&a[0]),
+                    "BucketBrigadeMaEnv::step_multi: agent {} house_index {} out of range \
+                     0..{}",
+                    i,
+                    a[0],
+                    NUM_HOUSES
+                );
+                assert!(
+                    a[1] == 0 || a[1] == 1,
+                    "BucketBrigadeMaEnv::step_multi: agent {} mode {} must be 0 or 1",
+                    i,
+                    a[1]
+                );
+                [a[0] as u8, a[1] as u8]
+            })
+            .collect();
+
+        let result = BucketBrigadeMaEnv::step(self, &inner_actions);
+        let n = self.num_agents;
+        MultiAgentResult::new(
+            result.observations,
+            result.rewards,
+            vec![result.done; n],
+            vec![false; n],
+        )
+    }
+
+    fn active_agents(&self) -> Vec<bool> {
+        // The underlying engine has no per-agent termination signal; either
+        // the whole night is still running or the episode is over.
+        vec![true; self.num_agents]
     }
 }
 

--- a/src/multi_agent/environment.rs
+++ b/src/multi_agent/environment.rs
@@ -12,6 +12,20 @@ use crate::env::Environment;
 /// Environments implementing this trait support multiple agents interacting
 /// in the same game instance, enabling cooperative, competitive, and
 /// mixed-motive scenarios.
+///
+/// # Multi-discrete action spaces
+///
+/// This trait supports both pure-discrete and *factored* (multi-discrete)
+/// action spaces. Each agent's action is a `Vec<i64>` whose length equals the
+/// number of action dimensions for that agent:
+///
+/// - Pure-discrete agent with `n` choices: action vector has length 1
+///   (e.g. `vec![3]` to pick action `3`).
+/// - Factored Bucket-Brigade agent with `[house_index, mode]`: action vector
+///   has length 2 (e.g. `vec![7, 1]` for "house 7, mode 1").
+///
+/// The per-agent layout is published via
+/// [`agent_action_space`](MultiAgentEnvironment::agent_action_space).
 pub trait MultiAgentEnvironment: Environment {
     /// Number of agents in this environment
     fn num_agents(&self) -> usize;
@@ -23,17 +37,32 @@ pub trait MultiAgentEnvironment: Environment {
     /// * `agent_id` - Index of the agent (0 to num_agents - 1)
     fn get_agent_observation(&self, agent_id: usize) -> Vec<f32>;
 
-    /// Step the environment with multiple actions (one per agent)
+    /// Per-agent action-space layout.
+    ///
+    /// Returns one bin count per action dimension for the agent. For a
+    /// pure-discrete agent with `n` choices this is `vec![n]`; for a factored
+    /// Bucket-Brigade agent with `[house_index, mode]` this is `vec![10, 2]`.
+    ///
+    /// The length of this vector must match the length of each per-agent
+    /// action passed to [`step_multi`](MultiAgentEnvironment::step_multi), and
+    /// it must match the `action_dims` of any policy driving this agent.
+    fn agent_action_space(&self, agent_id: usize) -> Vec<usize>;
+
+    /// Step the environment with multiple actions (one per agent).
     ///
     /// # Arguments
     ///
-    /// * `actions` - Slice of actions, one for each agent
+    /// * `actions` - One action vector per agent. `actions.len()` must equal
+    ///   [`num_agents`](MultiAgentEnvironment::num_agents). Each inner
+    ///   `Vec<i64>` carries one entry per action dimension and must match the
+    ///   layout reported by
+    ///   [`agent_action_space`](MultiAgentEnvironment::agent_action_space).
     ///
     /// # Returns
     ///
     /// Multi-agent result containing observations, rewards, and termination
     /// flags for each agent.
-    fn step_multi(&mut self, actions: &[i64]) -> MultiAgentResult;
+    fn step_multi(&mut self, actions: &[Vec<i64>]) -> MultiAgentResult;
 
     /// Get which agents are currently active (not terminated)
     fn active_agents(&self) -> Vec<bool>;

--- a/src/multi_agent/simulator.rs
+++ b/src/multi_agent/simulator.rs
@@ -166,10 +166,17 @@ where
                     values.push(value_val as f32);
                 }
 
-                // Step environment with all actions
-                // Convert Vec<i64> to Vec<E::Action> if needed
-                // For now, assume E::Action = i64 (discrete action spaces)
-                let result = env.step_multi(&actions);
+                // Step environment with all actions.
+                //
+                // The simulator's `Experience::action` is a scalar `i64`, so
+                // for now we only drive pure-discrete agents through the
+                // `MultiAgentEnvironment` trait. Each scalar action is wrapped
+                // in a length-1 `Vec<i64>` to match the multi-discrete trait
+                // signature. End-to-end multi-discrete support (widening
+                // `Experience::action` to `Vec<i64>`) is tracked separately
+                // -- see issue #3 scope notes.
+                let actions_md: Vec<Vec<i64>> = actions.iter().map(|&a| vec![a]).collect();
+                let result = env.step_multi(&actions_md);
 
                 // Send experiences to learners
                 for (i, &agent_id) in agent_ids.iter().enumerate() {
@@ -261,50 +268,76 @@ mod tests {
         multi_agent::{environment::MultiAgentResult, population::PopulationConfig},
     };
 
-    #[derive(Clone)]
-    struct MockObs;
+    /// Minimal `Environment` impl for tests.
+    ///
+    /// `num_agents` is fixed at 4 and each agent observes a 4-dim zero vector.
+    struct MockEnv {
+        num_agents: usize,
+        obs_dim: usize,
+    }
 
-    struct MockEnv;
+    impl MockEnv {
+        fn new() -> Self {
+            Self { num_agents: 4, obs_dim: 4 }
+        }
+    }
 
     impl Environment for MockEnv {
-        type Observation = MockObs;
-        type Action = i64;
+        fn reset(&mut self) {}
 
-        fn reset(&mut self) -> Result<Self::Observation> {
-            Ok(MockObs)
+        fn get_observation(&self) -> Vec<f32> {
+            vec![0.0; self.obs_dim]
         }
 
-        fn step(&mut self, _action: Self::Action) -> Result<StepResult<Self::Observation>> {
-            Ok(StepResult {
-                observation: MockObs,
+        fn step(&mut self, _action: i64) -> StepResult {
+            StepResult {
+                observation: vec![0.0; self.obs_dim],
                 reward: 0.0,
                 terminated: false,
                 truncated: false,
                 info: StepInfo::default(),
-            })
+            }
         }
 
         fn observation_space(&self) -> SpaceInfo {
-            SpaceInfo { shape: vec![], dtype: SpaceType::Discrete(2) }
+            SpaceInfo { shape: vec![self.obs_dim], space_type: SpaceType::Box }
         }
 
         fn action_space(&self) -> SpaceInfo {
-            SpaceInfo { shape: vec![], dtype: SpaceType::Discrete(2) }
+            SpaceInfo { shape: vec![], space_type: SpaceType::Discrete(2) }
         }
+
+        fn render(&self) -> Vec<u8> {
+            Vec::new()
+        }
+
+        fn close(&mut self) {}
     }
 
     impl MultiAgentEnvironment for MockEnv {
         fn num_agents(&self) -> usize {
-            4
+            self.num_agents
         }
 
-        fn get_observation(&self, _agent_id: usize) -> Self::Observation {
-            MockObs
+        fn get_agent_observation(&self, _agent_id: usize) -> Vec<f32> {
+            vec![0.0; self.obs_dim]
         }
 
-        fn step_multi(&mut self, actions: &[Self::Action]) -> MultiAgentResult<Self> {
+        fn agent_action_space(&self, _agent_id: usize) -> Vec<usize> {
+            // Pure-discrete agent with 2 choices: a single action dim.
+            vec![2]
+        }
+
+        fn step_multi(&mut self, actions: &[Vec<i64>]) -> MultiAgentResult {
+            assert_eq!(
+                actions.len(),
+                self.num_agents,
+                "MockEnv::step_multi: expected {} actions, got {}",
+                self.num_agents,
+                actions.len()
+            );
             MultiAgentResult::new(
-                vec![MockObs; actions.len()],
+                vec![vec![0.0; self.obs_dim]; actions.len()],
                 vec![1.0; actions.len()],
                 vec![false; actions.len()],
                 vec![false; actions.len()],
@@ -312,7 +345,7 @@ mod tests {
         }
 
         fn active_agents(&self) -> Vec<bool> {
-            vec![true; 4]
+            vec![true; self.num_agents]
         }
     }
 
@@ -327,7 +360,7 @@ mod tests {
         let (_policy_sender, policy_receiver) = crossbeam_channel::unbounded();
 
         let _simulator = GameSimulator::new(
-            &|| MockEnv,
+            &MockEnv::new,
             4, // num_envs
             population,
             matchmaker,
@@ -335,5 +368,23 @@ mod tests {
             exp_senders,
             policy_receiver,
         );
+    }
+
+    #[test]
+    fn test_mock_env_step_multi_shape() {
+        // Sanity check that the test mock satisfies the trait contract:
+        // each agent's action vec has length 1 (pure-discrete) and the
+        // result has one entry per agent.
+        let mut env = MockEnv::new();
+        let actions: Vec<Vec<i64>> = (0..env.num_agents()).map(|_| vec![0]).collect();
+        let result = env.step_multi(&actions);
+        assert_eq!(result.rewards.len(), env.num_agents());
+        assert_eq!(result.observations.len(), env.num_agents());
+        for obs in &result.observations {
+            assert_eq!(obs.len(), 4);
+        }
+        for aid in 0..env.num_agents() {
+            assert_eq!(env.agent_action_space(aid), vec![2]);
+        }
     }
 }

--- a/tests/test_multi_discrete_env.rs
+++ b/tests/test_multi_discrete_env.rs
@@ -1,0 +1,145 @@
+//! Integration tests for the multi-discrete `MultiAgentEnvironment` trait
+//! surface.
+//!
+//! Exercises [`BucketBrigadeMaEnv`] through the widened trait (one
+//! `Vec<i64>` per agent) added in upstream issue #3. Lives in `tests/` for
+//! the same reason as the other thrust-port tests in this branch:
+//! pre-existing in-module test failures on `main` (see upstream issue #7)
+//! prevent `cargo test --lib` from compiling.
+//!
+//! Run with:
+//! `cargo test --test test_multi_discrete_env --features env-bucket-brigade`.
+
+#![cfg(feature = "env-bucket-brigade")]
+
+use bucket_brigade_core::SCENARIOS;
+use thrust_rl::env::games::bucket_brigade::BucketBrigadeMaEnv;
+use thrust_rl::multi_agent::MultiAgentEnvironment;
+
+fn make_env(num_agents: usize, seed: u64) -> BucketBrigadeMaEnv {
+    let scenario = SCENARIOS["default"].clone();
+    let mut env = BucketBrigadeMaEnv::new(scenario, num_agents, Some(seed));
+    env.reset(Some(seed));
+    env
+}
+
+#[test]
+fn agent_action_space_is_house_mode_for_every_agent() {
+    let env = make_env(4, 42);
+    for aid in 0..MultiAgentEnvironment::num_agents(&env) {
+        assert_eq!(
+            env.agent_action_space(aid),
+            vec![10, 2],
+            "agent {aid}: expected factored [house_index, mode] action space",
+        );
+    }
+}
+
+#[test]
+fn step_multi_returns_one_entry_per_agent() {
+    let mut env = make_env(4, 42);
+    let actions: Vec<Vec<i64>> = vec![vec![3, 1], vec![5, 0], vec![7, 1], vec![0, 0]];
+    let result = env.step_multi(&actions);
+
+    let n = MultiAgentEnvironment::num_agents(&env);
+    assert_eq!(result.rewards.len(), n, "rewards.len() must equal num_agents");
+    assert_eq!(result.observations.len(), n, "observations.len() must equal num_agents");
+    assert_eq!(result.terminated.len(), n);
+    assert_eq!(result.truncated.len(), n);
+
+    let obs_dim = env.obs_dim();
+    for (i, obs) in result.observations.iter().enumerate() {
+        assert_eq!(obs.len(), obs_dim, "agent {i} observation has wrong length");
+    }
+}
+
+#[test]
+fn step_multi_agrees_with_inherent_step() {
+    // Calling the env through the trait and through its inherent typed API
+    // with identical actions must produce identical results.
+    let mut env_trait = make_env(3, 7);
+    let mut env_inherent = make_env(3, 7);
+
+    let actions_trait: Vec<Vec<i64>> = vec![vec![2, 1], vec![4, 0], vec![9, 1]];
+    let actions_inherent: Vec<[u8; 2]> = vec![[2, 1], [4, 0], [9, 1]];
+
+    for _ in 0..3 {
+        let r_trait = env_trait.step_multi(&actions_trait);
+        let r_inherent = env_inherent.step(&actions_inherent);
+
+        assert_eq!(r_trait.rewards, r_inherent.rewards);
+        assert_eq!(r_trait.observations, r_inherent.observations);
+        assert!(r_trait.terminated.iter().all(|&t| t == r_inherent.done));
+        if r_inherent.done {
+            break;
+        }
+    }
+}
+
+#[test]
+fn active_agents_marks_all_agents_active() {
+    let env = make_env(5, 1);
+    let active = env.active_agents();
+    assert_eq!(active.len(), 5);
+    assert!(active.iter().all(|&a| a), "BB engine has no per-agent termination");
+}
+
+#[test]
+fn get_agent_observation_returns_per_agent_view() {
+    let env = make_env(4, 42);
+    let obs_dim = env.obs_dim();
+    for aid in 0..MultiAgentEnvironment::num_agents(&env) {
+        let obs = env.get_agent_observation(aid);
+        assert_eq!(obs.len(), obs_dim, "agent {aid} obs has wrong length");
+    }
+}
+
+#[test]
+#[should_panic(expected = "expected 4 actions")]
+fn step_multi_panics_on_wrong_agent_count() {
+    let mut env = make_env(4, 42);
+    let actions: Vec<Vec<i64>> = vec![vec![0, 0], vec![1, 0]]; // only 2, not 4
+    let _ = env.step_multi(&actions);
+}
+
+#[test]
+#[should_panic(expected = "action must have 2 dims")]
+fn step_multi_panics_on_wrong_action_dim_count() {
+    let mut env = make_env(2, 42);
+    // Action vectors have length 3 instead of the required 2.
+    let actions: Vec<Vec<i64>> = vec![vec![0, 0, 0], vec![1, 1, 1]];
+    let _ = env.step_multi(&actions);
+}
+
+#[test]
+#[should_panic(expected = "house_index")]
+fn step_multi_panics_on_house_out_of_range() {
+    let mut env = make_env(2, 42);
+    // house_index = 99 is out of range 0..10.
+    let actions: Vec<Vec<i64>> = vec![vec![99, 0], vec![0, 0]];
+    let _ = env.step_multi(&actions);
+}
+
+#[test]
+#[should_panic(expected = "mode")]
+fn step_multi_panics_on_invalid_mode() {
+    let mut env = make_env(2, 42);
+    let actions: Vec<Vec<i64>> = vec![vec![0, 5], vec![1, 0]];
+    let _ = env.step_multi(&actions);
+}
+
+#[test]
+fn step_multi_handles_single_dim_action_space_shape() {
+    // Sanity check: even though BB itself is 2-dim, this confirms the trait
+    // accepts arbitrary inner vec lengths -- the env's own dim-check is the
+    // only gatekeeper. A pure-discrete env (vec![n]) would round-trip here
+    // through the same trait surface.
+    let env = make_env(3, 42);
+    for aid in 0..MultiAgentEnvironment::num_agents(&env) {
+        let dims = env.agent_action_space(aid);
+        assert!(!dims.is_empty(), "agent {aid} action space must be non-empty");
+        // For BB, this should be exactly [10, 2]; a pure-discrete env would
+        // return [n] here. Both are valid trait shapes.
+        assert_eq!(dims, vec![10, 2]);
+    }
+}


### PR DESCRIPTION
## Summary

- Widens `MultiAgentEnvironment::step_multi` from `&[i64]` to `&[Vec<i64>]` so factored action spaces (e.g. Bucket Brigade's `[house_index, mode]`) can be driven through the generic multi-agent rollout surface.
- Adds `agent_action_space(agent_id) -> Vec<usize>` so consumers can discover the per-agent dim layout (`vec![n]` for pure-discrete, `vec![10, 2]` for BB).
- Adds `impl MultiAgentEnvironment for BucketBrigadeMaEnv` and removes the FIXME at `src/env/games/bucket_brigade.rs:17-20` that called out this gap.
- Updates the simulator's `MockEnv` to match the widened trait + adds a `tests/test_multi_discrete_env.rs` integration test that drives BB through the new trait surface.

## Scope notes

The new trait surface is a strict superset of the old one: a pure-discrete agent with `n` choices uses `vec![n]` for its action space and length-1 action vectors. The simulator's call site wraps each scalar action it produces (per its still-scalar `Experience::action: i64` field) in a length-1 `Vec<i64>` so the new trait signature compiles without forcing an `Experience`-wide refactor. End-to-end multi-discrete support inside `GameSimulator` / `Experience` / `PolicyLearner` is left as a separate follow-up per the curator's scope guard -- the `examples/games/bucket_brigade/train_p3.rs` trainer doesn't use `GameSimulator` (it has its own joint rollout) so the BB experiment isn't blocked.

The inherent `SnakeEnv::step_multi(&[i64])` and the wasm call site that uses it are unaffected (they're inherent methods on a concrete type, not the trait).

## Test plan

- [x] `cargo build --features "training env-bucket-brigade"` succeeds
- [x] `cargo build --features wasm` succeeds
- [x] `cargo build --release --features "training env-bucket-brigade"` succeeds
- [x] `cargo build --example train_p3 --features "training env-bucket-brigade"` succeeds
- [x] `cargo build --test test_multi_discrete_env --features env-bucket-brigade` succeeds
- [x] `cargo clippy --features "training env-bucket-brigade"` reports no new warnings on the changed files
- [ ] Local test execution blocked by a system-environment dyld mismatch (`libabsl_*.2508.0.0.dylib` vs homebrew's `2601.0.0`) that also breaks the pre-existing `test_bucket_brigade_env` integration test -- pre-existing on `main`, see upstream issue #7. Integration test will run in CI.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)