### PR TITLE
Fix test_pool_action_space stale shape assertion

### DIFF
--- a/src/env/pool.rs
+++ b/src/env/pool.rs
@@ -293,7 +293,11 @@ mod tests {
     fn test_pool_action_space() {
         let pool = EnvPool::new(CartPole::new, 4);
         let action_space = pool.action_space();
-        assert_eq!(action_space.shape, Vec::<usize>::new());
+        // CartPole action space reports shape `[2]` alongside SpaceType::Discrete(2);
+        // see PR #16 for the rationale. Pool delegates to env[0].action_space(),
+        // so the pool inherits the same shape semantics.
+        assert_eq!(action_space.shape, vec![2]);
+        assert!(matches!(action_space.space_type, crate::env::SpaceType::Discrete(2)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix runtime assertion failure in `test_pool_action_space` at `src/env/pool.rs:296`. The test was asserting `action_space.shape == Vec::<usize>::new()` (i.e. `[]`), but `CartPole::action_space()` returns `SpaceInfo { shape: vec![2], space_type: SpaceType::Discrete(2) }`. Since `EnvPool::action_space()` delegates to `envs[0].action_space()`, the pool inherits this shape and the assertion failed at runtime.

This is the sibling test that PR #16's audit missed because `pool.rs` lives under `#[cfg(feature = "training")]` and PR #16's compile-driven sweep used `--no-default-features` for some passes.

## Changes

- `src/env/pool.rs`: update `test_pool_action_space` to assert `shape == vec![2]` and additionally assert `space_type == SpaceType::Discrete(2)`, mirroring the `test_cartpole_action_space` fix from PR #16.

## Test plan

- [x] `cargo build --lib --features training --tests` succeeds (verified locally)
- [x] `cargo +nightly fmt` clean (run on edited file)
- [ ] `cargo test --lib --features training test_pool_action_space` passes on a host with libtorch + abseil available (local environment is missing `libabsl_log_internal_check_op.2508.0.0.dylib`; this is the same dyld blocker noted in PR #16's test plan and unrelated to this change)
- [ ] `cargo test --lib --features training test_pool` shows 10/10 passing

## Out of scope

Per the curator notes on #20, `CartPole::action_space()` keeps `shape: vec![2]` for `Discrete` spaces. PR #16 chose this stance for the cartpole sibling test; standardizing discrete-shape semantics across all environments is a separate decision.

Closes #20

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>