### PR TITLE
test(snake): fix collision detection test assertions

### DIFF
--- a/src/env/games/snake/snake.rs
+++ b/src/env/games/snake/snake.rs
@@ -196,20 +196,26 @@ mod tests {
     fn test_snake_collision_detection() {
         let mut snake = Snake::new(0, Position::new(1, 1), Direction::Right);
         snake.grow();
-        snake.move_forward(); // Now at (2,1) with body at (1,1)
+        snake.move_forward(); // head now at (2, 1) — last in-bounds column on 3x3
+        assert!(!snake.collides_with_wall(3, 3), "(2, 1) is in-bounds on 3x3");
 
-        // Wall collision
-        assert!(snake.collides_with_wall(3, 3)); // Grid is 3x3 (0-2)
+        // Wall collision — step off the right edge
+        snake.move_forward(); // head now at (3, 1) — off the right edge
+        assert!(snake.collides_with_wall(3, 3), "(3, 1) is out-of-bounds on 3x3");
 
-        // Self collision - move to create collision
+        // Self collision - grow long enough to loop back onto own body
         let mut snake2 = Snake::new(0, Position::new(5, 5), Direction::Right);
         snake2.grow();
-        snake2.move_forward();
+        snake2.grow();
+        snake2.grow();
+        snake2.grow(); // length is now 5 (initial 1 + 4 grows)
+        snake2.move_forward(); // head (6, 5)
         snake2.change_direction(Direction::Down);
-        snake2.move_forward();
+        snake2.move_forward(); // head (6, 6)
         snake2.change_direction(Direction::Left);
-        snake2.move_forward();
-        // Now should be colliding with itself
+        snake2.move_forward(); // head (5, 6)
+        snake2.change_direction(Direction::Up);
+        snake2.move_forward(); // head back at (5, 5) — collides with body tail
         assert!(snake2.collides_with_self());
     }
 


### PR DESCRIPTION
## Summary

Fixes the failing `test_snake_collision_detection` test by correcting both the wall-collision and self-collision assertions. The implementation (`Snake::collides_with_wall`, `Position::in_bounds`) is correct and unchanged — only the test was wrong.

## Changes

- `src/env/games/snake/snake.rs` (test only): replace the incorrect wall-collision assertion at line 202 with a pair of assertions that exercise both an in-bounds case (`(2, 1)`, last valid column on 3x3) and an out-of-bounds case (`(3, 1)`, first invalid column). This locks in boundary correctness in both directions.
- Fix the self-collision portion of the same test: the snake was too short (length 2) to actually collide with itself after three moves. Grow to length 5 and walk a closed square (Right, Down, Left, Up) so the head returns to its starting position and collides with the retained body tail.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `cargo test --lib --no-default-features` reports 0 failures | Met | 45 passed; 0 failed (was 44/1) |
| Regression test covers the corrected boundary case | Met | New assertions cover both `(2, 1)` in-bounds and `(3, 1)` out-of-bounds on 3x3 |
| No changes to `Snake::collides_with_wall` or `Position::in_bounds` | Met | Implementation untouched; `git diff --stat` is one file |

## Test Plan

- `cargo test --lib --no-default-features test_snake_collision_detection` — passes
- `cargo test --lib --no-default-features` — 45 passed, 0 failed
- `cargo +nightly fmt` — clean

## Note on Scope

The curator's review recommended touching only the wall-collision portion of the test. While implementing that fix, the self-collision portion also began failing — it had been silently masked by the earlier panic. Since the issue body's acceptance criterion is "`cargo test --lib --no-default-features` reports 0 failures," the self-collision portion had to be fixed in the same PR to meet acceptance. Both fixes are test-only and scoped to a single file.

Closes #17