### PR TITLE
Fix drift in train_cartpole*.rs examples (closes #18)

### DIFF
--- a/examples/games/cartpole/train_cartpole.rs
+++ b/examples/games/cartpole/train_cartpole.rs
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
     let action_space = env.action_space();
 
     let obs_dim = obs_space.shape[0] as i64;
-    let action_dim = match action_space.dtype {
+    let action_dim = match action_space.space_type {
         thrust_rl::env::SpaceType::Discrete(n) => n as i64,
         _ => panic!("Expected discrete action space"),
     };
@@ -110,7 +110,7 @@ fn main() -> Result<()> {
                 buffer.add(
                     step,
                     env_id,
-                    observations[env_id].clone(),
+                    &observations[env_id],
                     actions_vec[env_id],
                     results[env_id].reward,
                     values_vec[env_id],

--- a/examples/games/cartpole/train_cartpole_hybrid.rs
+++ b/examples/games/cartpole/train_cartpole_hybrid.rs
@@ -256,6 +256,7 @@ fn main() -> Result<()> {
         environment: "CartPole-v1".to_string(),
         algorithm: "PPO (Hybrid config)".to_string(),
         timestamp: Some(chrono::Utc::now().to_rfc3339()),
+        hyperparameters: None,
         notes: Some(format!(
             "Hybrid training: ReLU activation, 128 hidden units, n_steps=64, batch_size=256, n_epochs=15, \
              lr=0.0005->0 (linear decay), gamma=0.99, gae_lambda=0.95, ent_coef=0.005. \

--- a/examples/games/cartpole/train_cartpole_long.rs
+++ b/examples/games/cartpole/train_cartpole_long.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
     let action_space = env.action_space();
 
     let obs_dim = obs_space.shape[0] as i64;
-    let action_dim = match action_space.dtype {
+    let action_dim = match action_space.space_type {
         thrust_rl::env::SpaceType::Discrete(n) => n as i64,
         _ => panic!("Expected discrete action space"),
     };
@@ -114,7 +114,7 @@ fn main() -> Result<()> {
                 buffer.add(
                     step,
                     env_id,
-                    observations[env_id].clone(),
+                    &observations[env_id],
                     actions_vec[env_id],
                     results[env_id].reward,
                     values_vec[env_id],
@@ -153,15 +153,16 @@ fn main() -> Result<()> {
         let batch = buffer.get_batch();
 
         // Convert to tensors
-        let obs_flat: Vec<f32> = batch.observations.iter().flatten().copied().collect();
-        let batch_size = batch.observations.len();
+        // RolloutBatch.observations is now a flat Vec<f32> of length batch_size *
+        // obs_dim
+        let batch_size = batch.observations.len() / obs_dim as usize;
 
-        let obs_tensor = tch::Tensor::from_slice(&obs_flat)
+        let obs_tensor = tch::Tensor::from_slice(&batch.observations)
             .reshape([batch_size as i64, obs_dim])
             .to_device(device);
         let actions_tensor = tch::Tensor::from_slice(&batch.actions).to_device(device);
-        let old_log_probs_tensor = tch::Tensor::from_slice(&batch.log_probs).to_device(device);
-        let old_values_tensor = tch::Tensor::from_slice(&batch.values).to_device(device);
+        let old_log_probs_tensor = tch::Tensor::from_slice(&batch.old_log_probs).to_device(device);
+        let old_values_tensor = tch::Tensor::from_slice(&batch.old_values).to_device(device);
         let advantages_tensor = tch::Tensor::from_slice(&batch.advantages).to_device(device);
         let returns_tensor = tch::Tensor::from_slice(&batch.returns).to_device(device);
 

--- a/examples/games/cartpole/train_cartpole_modern.rs
+++ b/examples/games/cartpole/train_cartpole_modern.rs
@@ -259,6 +259,7 @@ fn main() -> Result<()> {
         environment: "CartPole-v1".to_string(),
         algorithm: "PPO (Proximal Policy Optimization)".to_string(),
         timestamp: Some(chrono::Utc::now().to_rfc3339()),
+        hyperparameters: None,
         notes: Some(format!(
             "Modern RL training: ReLU activation, 128 hidden units, n_steps=256, lr=0.0003->0 (linear decay), \
              no obs normalization (inference compatible). \

--- a/examples/games/cartpole/train_cartpole_sb3.rs
+++ b/examples/games/cartpole/train_cartpole_sb3.rs
@@ -262,6 +262,7 @@ fn main() -> Result<()> {
         environment: "CartPole-v1".to_string(),
         algorithm: "PPO (Stable-Baselines3 config)".to_string(),
         timestamp: Some(chrono::Utc::now().to_rfc3339()),
+        hyperparameters: None,
         notes: Some(format!(
             "SB3-matched training: n_steps=32, batch_size=256, n_epochs=20, lr=0.001->0 (linear decay), \
              gamma=0.98, gae_lambda=0.8, ent_coef=0.0, Tanh activation. \


### PR DESCRIPTION
## Summary

Closes #18.

Five example files in `examples/games/cartpole/` had drifted from the current `master` API surface and failed to compile under `cargo check --features training --examples` (11 compile errors across 5 of the 6 listed files; `train_cartpole_best.rs` already compiled cleanly and is untouched).

This patch reapplies the API renames so the training examples build again.

### Per-file fixes

| File | Errors | What changed |
|---|---|---|
| `train_cartpole.rs` | 2 | `action_space.dtype` -> `.space_type`; `buffer.add` now takes `&observations[env_id]` (was `.clone()`). |
| `train_cartpole_best.rs` | 0 | **Unchanged.** Already correct. |
| `train_cartpole_hybrid.rs` | 1 | Add `hyperparameters: None,` to `TrainingMetadata`. |
| `train_cartpole_long.rs` | 6 | `.dtype`->`.space_type`; `&observations[env_id]`; flat `batch.observations` (no `.flatten().copied()`); `batch_size = batch.observations.len() / obs_dim as usize` (fixes a latent logic bug from the old nested-vec shape); `batch.log_probs`->`batch.old_log_probs`; `batch.values`->`batch.old_values`. |
| `train_cartpole_modern.rs` | 1 | Add `hyperparameters: None,`. |
| `train_cartpole_sb3.rs` | 1 | Add `hyperparameters: None,`. |

### Authoritative shape references

- `TrainingMetadata` — `src/policy/inference.rs:226` (new required field `hyperparameters: Option<HashMap<String, serde_json::Value>>`, no `Default` derived).
- `SpaceInfo` — `src/env/mod.rs:51` (field renamed `dtype` -> `space_type`).
- `RolloutBuffer::add` — `src/buffer/rollout/storage.rs:107` (9-arg signature; `observation: &[f32]`).
- `RolloutBatch` — `src/buffer/rollout/storage.rs:212` (`old_log_probs`, `old_values`; `observations` is a flat `Vec<f32>`).

### Out of scope

`examples/games/cartpole/debug_cartpole.rs` (9 errors) is a different drift class — stale `env.reset()?` / `env.step(action)?` from when `Environment` still returned `Result`. Curator flagged it as out of scope for this issue; it should be tracked in a separate follow-up.

## Test plan

- [x] `cargo check --features training --example train_cartpole` (clean)
- [x] `cargo check --features training --example train_cartpole_best` (clean, untouched file still passes)
- [x] `cargo check --features training --example train_cartpole_hybrid` (clean)
- [x] `cargo check --features training --example train_cartpole_long` (clean)
- [x] `cargo check --features training --example train_cartpole_modern` (clean)
- [x] `cargo check --features training --example train_cartpole_sb3` (clean)
- [x] `cargo build --features training --example <each>` (all six link successfully)
- [x] `cargo +nightly fmt` on changed files
- [ ] CI `Tests (Linux + libtorch)` and `Tests (macOS + libtorch)` go green