### PR TITLE
Fix 47 unresolved rustdoc link warnings across 14 files (closes #19)

### DIFF
--- a/src/buffer/rollout.rs
+++ b/src/buffer/rollout.rs
@@ -36,7 +36,7 @@ impl RolloutBuffer {
     /// This is a convenience method that calls the module-level function.
     ///
     /// # Arguments
-    /// * `last_values` - Value estimates for the final states [num_envs]
+    /// * `last_values` - Value estimates for the final states `[num_envs]`
     /// * `gamma` - Discount factor
     /// * `gae_lambda` - GAE lambda parameter
     pub fn compute_advantages(&mut self, last_values: &[f32], gamma: f32, gae_lambda: f32) {

--- a/src/buffer/rollout/gae.rs
+++ b/src/buffer/rollout/gae.rs
@@ -11,7 +11,7 @@
 ///
 /// # Arguments
 /// * `buffer` - Rollout buffer to compute advantages for
-/// * `last_values` - Value estimates for the final states [num_envs]
+/// * `last_values` - Value estimates for the final states `[num_envs]`
 /// * `gamma` - Discount factor (0 < gamma <= 1)
 /// * `gae_lambda` - GAE lambda parameter (0 < lambda <= 1)
 ///
@@ -136,7 +136,7 @@ fn compute_gae_single_env(
 ///
 /// # Arguments
 /// * `buffer` - Rollout buffer to compute returns for
-/// * `last_values` - Value estimates for final states [num_envs]
+/// * `last_values` - Value estimates for final states `[num_envs]`
 /// * `gamma` - Discount factor
 pub fn compute_nstep_returns(
     buffer: &mut super::storage::RolloutBuffer,

--- a/src/buffer/rollout/sampling.rs
+++ b/src/buffer/rollout/sampling.rs
@@ -91,19 +91,19 @@ pub struct Minibatch {
     /// Observations [batch_size * obs_dim]
     pub observations: Vec<f32>,
 
-    /// Actions [batch_size]
+    /// Actions `[batch_size]`
     pub actions: Vec<i64>,
 
-    /// Old log probabilities [batch_size]
+    /// Old log probabilities `[batch_size]`
     pub old_log_probs: Vec<f32>,
 
-    /// Old value estimates [batch_size]
+    /// Old value estimates `[batch_size]`
     pub old_values: Vec<f32>,
 
-    /// Advantages [batch_size]
+    /// Advantages `[batch_size]`
     pub advantages: Vec<f32>,
 
-    /// Returns [batch_size]
+    /// Returns `[batch_size]`
     pub returns: Vec<f32>,
 
     /// Observation dimension

--- a/src/buffer/rollout/storage.rs
+++ b/src/buffer/rollout/storage.rs
@@ -207,25 +207,25 @@ impl RolloutBuffer {
 /// Batch of rollout data for training
 ///
 /// Contains flattened tensors suitable for neural network training.
-/// All arrays have shape [batch_size].
+/// All arrays have shape `[batch_size]`.
 #[derive(Debug, Clone)]
 pub struct RolloutBatch {
     /// Flattened observations [batch_size, obs_dim]
     pub observations: Vec<f32>,
 
-    /// Actions taken [batch_size]
+    /// Actions taken `[batch_size]`
     pub actions: Vec<i64>,
 
-    /// Old log probabilities [batch_size]
+    /// Old log probabilities `[batch_size]`
     pub old_log_probs: Vec<f32>,
 
-    /// Old value estimates [batch_size]
+    /// Old value estimates `[batch_size]`
     pub old_values: Vec<f32>,
 
-    /// Computed advantages [batch_size]
+    /// Computed advantages `[batch_size]`
     pub advantages: Vec<f32>,
 
-    /// Computed returns [batch_size]
+    /// Computed returns `[batch_size]`
     pub returns: Vec<f32>,
 }
 

--- a/src/inference/snake.rs
+++ b/src/inference/snake.rs
@@ -112,7 +112,7 @@ impl SnakeCNNInference {
     ///   [c0_pixels..., c1_pixels..., ...]
     ///
     /// # Returns
-    /// * `(logits, value)` - Action logits [num_actions] and state value
+    /// * `(logits, value)` - Action logits `[num_actions]` and state value
     ///   (scalar)
     pub fn forward(&self, grid: &[f32]) -> (Vec<f32>, f32) {
         let grid_size = self.grid_width * self.grid_height;

--- a/src/multi_agent/joint.rs
+++ b/src/multi_agent/joint.rs
@@ -335,9 +335,7 @@ impl<P: JointPolicy> JointMultiAgentTrainer<P> {
     /// Construct a trainer from a fully-initialized set of policies.
     ///
     /// `optimizers` must have one entry per policy and be configured for the
-    /// caller's choice of learning rate / weight decay. Use
-    /// [`Self::with_adam`] for the common case of a fresh Adam optimizer per
-    /// policy at a single shared learning rate.
+    /// caller's choice of learning rate / weight decay.
     ///
     /// All policies must be on the same device.
     pub fn new(

--- a/src/multi_agent/messages.rs
+++ b/src/multi_agent/messages.rs
@@ -14,7 +14,7 @@ pub struct Experience {
     /// Agent that generated this experience
     pub agent_id: AgentId,
 
-    /// Observation tensor [obs_dim]
+    /// Observation tensor `[obs_dim]`
     pub observation: Tensor,
 
     /// Action taken
@@ -23,7 +23,7 @@ pub struct Experience {
     /// Reward received
     pub reward: f32,
 
-    /// Next observation tensor [obs_dim]
+    /// Next observation tensor `[obs_dim]`
     pub next_observation: Tensor,
 
     /// Whether episode terminated

--- a/src/multi_agent/mod.rs
+++ b/src/multi_agent/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides two complementary multi-agent training architectures:
 //!
-//! ## 1. Per-thread independent learners ([`PolicyLearner`], [`Population`], [`GameSimulator`])
+//! ## 1. Per-thread independent learners ([`crate::multi_agent::learner::PolicyLearner`], [`crate::multi_agent::population::Population`], [`crate::multi_agent::simulator::GameSimulator`])
 //!
 //! Each agent runs in its own learner thread and updates from a shared rollout
 //! pool. Good for league play, self-play, evolutionary tournaments, and any
@@ -14,7 +14,7 @@
 //! - **PolicyLearner**: Per-agent training thread with PPO
 //! - **Matchmaker**: Strategy for assigning agents to games
 //!
-//! ## 2. Synchronized joint trainer ([`joint::JointMultiAgentTrainer`])
+//! ## 2. Synchronized joint trainer ([`crate::multi_agent::joint::JointMultiAgentTrainer`])
 //!
 //! A single process owns `N` policies and `N` optimizers and runs them in
 //! lockstep on a shared rollout buffer. Required when the loss function
@@ -24,7 +24,8 @@
 //! every agent's encoder through the auxiliary term while leaving per-agent
 //! gradient updates isolated (each optimizer reads only its own var-store).
 //!
-//! See [`joint`] for the detailed semantics and acceptance criteria.
+//! See [`crate::multi_agent::joint`] for the detailed semantics and acceptance
+//! criteria.
 
 pub mod environment;
 pub mod joint;

--- a/src/policy/inference.rs
+++ b/src/policy/inference.rs
@@ -129,7 +129,7 @@ impl SnakeCNNInference {
     ///   [c0_pixels..., c1_pixels..., ...]
     ///
     /// # Returns
-    /// * `(logits, value)` - Action logits [num_actions] and state value
+    /// * `(logits, value)` - Action logits `[num_actions]` and state value
     ///   (scalar)
     pub fn forward(&self, grid: &[f32]) -> (Vec<f32>, f32) {
         let grid_size = self.grid_width * self.grid_height;
@@ -271,22 +271,22 @@ pub struct InferenceModel {
 
     /// Shared layer 1: weights [obs_dim, hidden_dim]
     pub shared_fc1_weight: Vec<Vec<f32>>,
-    /// Shared layer 1: bias [hidden_dim]
+    /// Shared layer 1: bias `[hidden_dim]`
     pub shared_fc1_bias: Vec<f32>,
 
     /// Shared layer 2: weights [hidden_dim, hidden_dim]
     pub shared_fc2_weight: Vec<Vec<f32>>,
-    /// Shared layer 2: bias [hidden_dim]
+    /// Shared layer 2: bias `[hidden_dim]`
     pub shared_fc2_bias: Vec<f32>,
 
     /// Policy head: weights [hidden_dim, action_dim]
     pub policy_weight: Vec<Vec<f32>>,
-    /// Policy head: bias [action_dim]
+    /// Policy head: bias `[action_dim]`
     pub policy_bias: Vec<f32>,
 
     /// Value head: weights [hidden_dim, 1]
     pub value_weight: Vec<Vec<f32>>,
-    /// Value head: bias [1]
+    /// Value head: bias `[1]`
     pub value_bias: Vec<f32>,
 }
 
@@ -327,10 +327,10 @@ impl InferenceModel {
     /// Forward pass: compute action logits and value
     ///
     /// # Arguments
-    /// * `obs` - Observation vector [obs_dim]
+    /// * `obs` - Observation vector `[obs_dim]`
     ///
     /// # Returns
-    /// * `(logits, value)` - Action logits [action_dim] and state value
+    /// * `(logits, value)` - Action logits `[action_dim]` and state value
     ///   (scalar)
     pub fn forward(&self, obs: &[f32]) -> (Vec<f32>, f32) {
         assert_eq!(obs.len(), self.obs_dim, "Observation dimension mismatch");
@@ -377,7 +377,7 @@ impl InferenceModel {
     /// Get action from observation using softmax sampling
     ///
     /// # Arguments
-    /// * `obs` - Observation vector [obs_dim]
+    /// * `obs` - Observation vector `[obs_dim]`
     ///
     /// # Returns
     /// * Action index

--- a/src/policy/multi_discrete_mlp.rs
+++ b/src/policy/multi_discrete_mlp.rs
@@ -10,10 +10,11 @@
 //! inflates the policy head dimension multiplicatively and discards the
 //! factorization structure PPO can exploit.
 //!
-//! This module provides the multi-discrete analogue of [`MlpPolicy`]: a
-//! shared trunk plus one [`nn::Linear`] action head per dimension. Per-step
-//! log-probs are summed across dims (treating the dims as conditionally
-//! independent), and per-step entropies are averaged.
+//! This module provides the multi-discrete analogue of
+//! [`crate::policy::mlp::MlpPolicy`]: a shared trunk plus one [`nn::Linear`]
+//! action head per dimension. Per-step log-probs are summed across dims
+//! (treating the dims as conditionally independent), and per-step entropies are
+//! averaged.
 //!
 //! # Architecture
 //!

--- a/src/policy/universal_inference.rs
+++ b/src/policy/universal_inference.rs
@@ -302,7 +302,7 @@ impl Layer {
 /// Multi-dimensional tensor representation for intermediate activations
 #[derive(Debug, Clone)]
 pub enum Tensor {
-    /// 1D tensor [size]
+    /// 1D tensor `[size]`
     D1(Vec<f32>),
     /// 3D tensor [channels, height, width]
     D3(Vec<Vec<Vec<f32>>>),

--- a/src/train/ppo/loss.rs
+++ b/src/train/ppo/loss.rs
@@ -114,7 +114,7 @@ pub fn generate_minibatch_indices(buffer_size: usize, batch_size: usize) -> Vec<
 /// # Arguments
 /// * `rewards` - Reward tensor [num_steps, num_envs]
 /// * `values` - Value estimates [num_steps, num_envs]
-/// * `next_values` - Next step value estimates [num_envs]
+/// * `next_values` - Next step value estimates `[num_envs]`
 /// * `dones` - Done flags [num_steps, num_envs]
 /// * `gamma` - Discount factor
 /// * `gae_lambda` - GAE lambda parameter

--- a/src/train/ppo/trainer.rs
+++ b/src/train/ppo/trainer.rs
@@ -82,12 +82,12 @@ impl<P> PPOTrainer<P> {
     ///
     /// # Arguments
     ///
-    /// * `observations` - Observation tensor [batch_size, obs_dim]
-    /// * `actions` - Action tensor [batch_size]
-    /// * `old_log_probs` - Old log probabilities [batch_size]
-    /// * `old_values` - Old value estimates [batch_size]
-    /// * `advantages` - Computed advantages [batch_size]
-    /// * `returns` - Computed returns [batch_size]
+    /// * `observations` - Observation tensor `[batch_size, obs_dim]`
+    /// * `actions` - Action tensor `[batch_size]`
+    /// * `old_log_probs` - Old log probabilities `[batch_size]`
+    /// * `old_values` - Old value estimates `[batch_size]`
+    /// * `advantages` - Computed advantages `[batch_size]`
+    /// * `returns` - Computed returns `[batch_size]`
     /// * `forward_fn` - Function that performs forward pass through policy
     ///
     /// # Returns
@@ -330,12 +330,12 @@ impl<P> PPOTrainer<P> {
     /// # Arguments
     ///
     /// * `policy` - Policy to evaluate
-    /// * `observations` - Observation tensor [batch_size, obs_dim]
-    /// * `actions` - Action tensor [batch_size]
-    /// * `old_log_probs` - Old log probabilities [batch_size]
-    /// * `old_values` - Old value estimates [batch_size]
-    /// * `advantages` - Computed advantages [batch_size]
-    /// * `returns` - Computed returns [batch_size]
+    /// * `observations` - Observation tensor `[batch_size, obs_dim]`
+    /// * `actions` - Action tensor `[batch_size]`
+    /// * `old_log_probs` - Old log probabilities `[batch_size]`
+    /// * `old_values` - Old value estimates `[batch_size]`
+    /// * `advantages` - Computed advantages `[batch_size]`
+    /// * `returns` - Computed returns `[batch_size]`
     /// * `evaluate_fn` - Function that evaluates policy at (obs, actions)
     ///
     /// # Returns

--- a/src/utils/normalize.rs
+++ b/src/utils/normalize.rs
@@ -28,7 +28,7 @@ impl RunningMeanStd {
     /// Update statistics with a batch of observations
     ///
     /// # Arguments
-    /// * `observations` - Batch of observations [batch_size][obs_dim]
+    /// * `observations` - Batch of observations `[batch_size][obs_dim]`
     pub fn update(&mut self, observations: &[Vec<f32>]) {
         if observations.is_empty() {
             return;
@@ -87,7 +87,7 @@ impl RunningMeanStd {
     /// Normalize observations
     ///
     /// # Arguments
-    /// * `observations` - Observations to normalize [obs_dim]
+    /// * `observations` - Observations to normalize `[obs_dim]`
     ///
     /// # Returns
     /// * Normalized observations (mean=0, std=1)
@@ -103,7 +103,7 @@ impl RunningMeanStd {
     /// Normalize a batch of observations in-place
     ///
     /// # Arguments
-    /// * `observations` - Batch of observations [batch_size][obs_dim]
+    /// * `observations` - Batch of observations `[batch_size][obs_dim]`
     pub fn normalize_batch(&self, observations: &mut [Vec<f32>]) {
         for obs in observations {
             *obs = self.normalize(obs);


### PR DESCRIPTION
## Summary

Closes #19.

Fixes all 47 `unresolved link` rustdoc warnings reported by the curator's audit on `cargo +nightly doc --no-deps --all-features`. Since CI runs with `RUSTDOCFLAGS="-D warnings"`, every one of these was a hard failure for the Documentation job.

### Scope note: expanded from 4 files to 14 files

The original issue title listed only 4 files. The curator audit revealed the same root cause across 14 files (47 warnings total). All 47 warnings have to land together — fixing only the originally-cited subset would still leave CI red.

### Changes

**Group A — shape-annotation false positives (42 warnings).** Doc comments like ``"Action logits [num_actions]"`` were being parsed by rustdoc as intra-doc links to an item named `num_actions`. Wrapped each bracketed shape annotation in inline-code backticks so rustdoc treats them as code rather than links. Affects:

- `src/buffer/rollout.rs`, `src/buffer/rollout/{gae,sampling,storage}.rs`
- `src/inference/snake.rs`
- `src/multi_agent/messages.rs`
- `src/policy/{inference,universal_inference}.rs`
- `src/train/ppo/{loss,trainer}.rs`
- `src/utils/normalize.rs`

**Group B — genuine broken references (5 warnings).**

- `src/multi_agent/mod.rs` (3 warnings): `[`PolicyLearner`]`, `[`Population`]`, `[`GameSimulator`]` in the `//!` module doc resolved against `multi_agent`'s scope, where these names only exist inside submodules. Replaced with fully-qualified `[`crate::multi_agent::learner::PolicyLearner`]` etc. Also rewrote `[`joint::JointMultiAgentTrainer`]` and `[`joint`]` (declared *after* the `//!` block) as `[`crate::multi_agent::joint::JointMultiAgentTrainer`]` / `[`crate::multi_agent::joint`]`.
- `src/policy/multi_discrete_mlp.rs`: replaced unqualified `[`MlpPolicy`]` with `[`crate::policy::mlp::MlpPolicy`]`.
- `src/multi_agent/joint.rs:339`: **noteworthy finding** — the doc comment referenced `[`Self::with_adam`]`, but `with_adam` does not exist on `JointMultiAgentTrainer` (only `new`, `device`, `collect_rollout`, `update`). This is a stale reference, most likely left over from PR #15. Per the curator's recommendation, deleted the sentence promising the helper rather than synthesising a method just to make the link resolve. If `with_adam` is genuinely planned, a follow-up issue is the right tracker for it.

### Verification

```
$ cargo +nightly doc --features training --no-deps 2>&1 | grep -c "unresolved link"
0
$ cargo +nightly doc --all-features --no-deps 2>&1 | grep -c "unresolved link"
0
```

Total rustdoc warning count drops from 194 to 147; the remaining 147 are pre-existing `missing documentation for ...` warnings on `pub` items (e.g. `src/optimize/space.rs:38,40`) that predate this branch and are **out of scope** for #19. They are a separate hygiene issue — the Documentation job will still fail until they're cleaned up — but the unresolved-link class of failure is now eliminated.

## Test plan

- [x] `cargo +nightly doc --features training --no-deps` shows zero `unresolved link` warnings
- [x] `cargo +nightly doc --all-features --no-deps` shows zero `unresolved link` warnings
- [x] `cargo +nightly check --all-features` still compiles (no syntactic damage from edits)
- [x] `cargo +nightly fmt` applied
- [ ] CI `Documentation` job: will still fail because of the pre-existing `missing_docs` warnings, but the unresolved-link warnings should be gone from the log