### PR TITLE
Fix stale reset()/step() syntax in debug_cartpole example

### DIFF
--- a/examples/games/cartpole/debug_cartpole.rs
+++ b/examples/games/cartpole/debug_cartpole.rs
@@ -15,7 +15,8 @@ fn main() -> Result<()> {
     let device = policy.device();
 
     // Reset environment
-    let mut obs = env.reset()?;
+    env.reset();
+    let mut obs = env.get_observation();
     println!("Initial observation: {:?}", obs);
     println!();
 
@@ -36,7 +37,7 @@ fn main() -> Result<()> {
         println!("  Value estimate: {:.4}", value);
 
         // Step environment
-        let result = env.step(action)?;
+        let result = env.step(action);
 
         println!("  Reward: {}", result.reward);
         println!("  Terminated: {}", result.terminated);


### PR DESCRIPTION
## Summary

- Removes two stale `?` operators in `examples/games/cartpole/debug_cartpole.rs` that survived the `Environment` trait migration in PR #16.
- Applies the canonical migration pattern from `src/env/games/cartpole.rs:249-268`: `let obs = env.reset()?` becomes `env.reset(); let obs = env.get_observation()`, and `env.step(action)?` becomes `env.step(action)`.
- Restores `cargo check --features training --examples` to a clean build (zero errors).

## Scope

- Only the two lines flagged by the curator are changed (line 18 and line 39).
- The other three `?` operators in the file (lines 60, 61, 80 — `Vec::try_from` and `f64::try_from` on `Tensor`) are legitimate `tch::TchError` conversions and are left untouched.
- The `main() -> Result<()>` signature is preserved because those legitimate `?` operators still need it.
- No other drift classes (`SpaceInfo.dtype`, `SpaceType::Continuous`, `TrainingMetadata.hyperparameters`, `RolloutBuffer::add`, `batch.log_probs`/`batch.values`) are present in this file — the fix is genuinely narrow.

## Test plan

- [x] `cargo check --features training --example debug_cartpole` succeeds with zero errors.
- [x] `cargo check --features training --examples` succeeds with zero errors (full regression guard).
- [x] `cargo +nightly fmt` produces no changes.
- [ ] `cargo run --features training --example debug_cartpole` produces expected diagnostic output (entropy near `ln(2) ≈ 0.693`, action distribution summing to 100). Not executed locally — verified by source inspection that print sites and field accesses on `StepResult` are unchanged.

Closes #25

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>