### PR TITLE
Fix zero-padded rollout contamination in PPO train_step

### DIFF
--- a/src/buffer/rollout.rs
+++ b/src/buffer/rollout.rs
@@ -16,7 +16,8 @@
 
 // Re-export main components
 pub use gae::{
-    compute_advantages, compute_mc_returns, compute_nstep_returns, normalize_advantages,
+    compute_advantages, compute_advantages_partial, compute_mc_returns, compute_nstep_returns,
+    normalize_advantages,
 };
 pub use sampling::{
     Minibatch, MinibatchIterator, generate_minibatch_indices, sample_minibatch, shuffle_indices,
@@ -34,6 +35,9 @@ impl RolloutBuffer {
     /// Compute advantages using Generalized Advantage Estimation
     ///
     /// This is a convenience method that calls the module-level function.
+    /// Iterates the full `[num_steps, num_envs]` capacity; use
+    /// [`Self::compute_advantages_partial`] when the buffer is only
+    /// partially filled.
     ///
     /// # Arguments
     /// * `last_values` - Value estimates for the final states `[num_envs]`
@@ -43,10 +47,49 @@ impl RolloutBuffer {
         gae::compute_advantages(self, last_values, gamma, gae_lambda);
     }
 
+    /// Compute advantages over the first `valid_steps` rows only.
+    ///
+    /// Convenience wrapper around the module-level
+    /// [`compute_advantages_partial`]. Use this when the rollout buffer
+    /// has been partially filled (`valid_steps < num_steps`) to prevent
+    /// zero-padded tail rows from contaminating GAE on the real prefix.
+    ///
+    /// # Arguments
+    /// * `valid_steps` - Number of filled rows at the start of the buffer
+    /// * `last_values` - Bootstrap `V(s_{T+1})` for the state after row
+    ///   `valid_steps - 1`, per environment `[num_envs]`
+    /// * `gamma` - Discount factor
+    /// * `gae_lambda` - GAE lambda parameter
+    pub fn compute_advantages_partial(
+        &mut self,
+        valid_steps: usize,
+        last_values: &[f32],
+        gamma: f32,
+        gae_lambda: f32,
+    ) {
+        gae::compute_advantages_partial(self, valid_steps, last_values, gamma, gae_lambda);
+    }
+
     /// Get a batch of all data from the buffer
     ///
     /// This is a convenience method that calls the module-level function.
+    /// Returns the full `[num_steps, num_envs]` capacity, including any
+    /// zero-padded unwritten tail; use [`Self::get_filled_batch`] when
+    /// the buffer is only partially filled.
     pub fn get_batch(&self) -> RolloutBatch {
         RolloutBatch::from_buffer(self)
+    }
+
+    /// Get a batch covering only the first `valid_steps` rows.
+    ///
+    /// Use this when the buffer was filled with fewer than `num_steps`
+    /// transitions (e.g. an early-terminating rollout). It prevents the
+    /// zero-initialized tail of the buffer from being handed to PPO as
+    /// fake training data.
+    ///
+    /// # Panics
+    /// Panics if `valid_steps > self.shape().0`.
+    pub fn get_filled_batch(&self, valid_steps: usize) -> RolloutBatch {
+        RolloutBatch::from_buffer_partial(self, valid_steps)
     }
 }

--- a/src/buffer/rollout/gae.rs
+++ b/src/buffer/rollout/gae.rs
@@ -34,9 +34,53 @@ pub fn compute_advantages(
     gamma: f32,
     gae_lambda: f32,
 ) {
+    let num_steps = buffer.shape().0;
+    compute_advantages_partial(buffer, num_steps, last_values, gamma, gae_lambda);
+}
+
+/// Compute Generalized Advantage Estimation (GAE) over the first
+/// `valid_steps` rows of the buffer.
+///
+/// This is the partial-fill counterpart to [`compute_advantages`]. The
+/// backward GAE iteration is restricted to `(0..valid_steps).rev()`, so
+/// zero-padded tail rows (rows in `valid_steps..num_steps`) do not
+/// contaminate the advantage/return signal on the real rows.
+///
+/// `last_values[env_id]` is the bootstrap `V(s_{T+1})` for the state
+/// immediately after row `valid_steps - 1` — exactly the same semantics
+/// as for the full-capacity variant, just anchored to the end of the
+/// filled prefix rather than the end of capacity.
+///
+/// # Arguments
+/// * `buffer` - Rollout buffer to compute advantages for
+/// * `valid_steps` - Number of filled rows at the start of the buffer. Must be
+///   `<= buffer.shape().0`.
+/// * `last_values` - Value estimates for the final states `[num_envs]`
+/// * `gamma` - Discount factor (0 < gamma <= 1)
+/// * `gae_lambda` - GAE lambda parameter (0 < lambda <= 1)
+///
+/// # Panics
+/// Panics if `valid_steps > buffer.shape().0`.
+pub fn compute_advantages_partial(
+    buffer: &mut super::storage::RolloutBuffer,
+    valid_steps: usize,
+    last_values: &[f32],
+    gamma: f32,
+    gae_lambda: f32,
+) {
     let (num_steps, num_envs) = (buffer.shape().0, buffer.shape().1);
 
+    assert!(
+        valid_steps <= num_steps,
+        "valid_steps ({}) must not exceed buffer.num_steps ({})",
+        valid_steps,
+        num_steps
+    );
     debug_assert_eq!(last_values.len(), num_envs, "last_values length mismatch");
+
+    if valid_steps == 0 {
+        return;
+    }
 
     // Collect all immutable data first to avoid borrow checker issues
     let rewards: Vec<Vec<f32>> = buffer.rewards().iter().map(|step| step.to_vec()).collect();
@@ -46,14 +90,18 @@ pub fn compute_advantages(
     // Now we can get mutable access to both advantages and returns
     let (advantages, returns) = buffer.advantages_and_returns_mut();
 
-    // Compute advantages and returns for each environment
+    // Compute advantages and returns for each environment, restricted to
+    // the filled prefix.
     for env_id in 0..num_envs {
-        let env_rewards: Vec<f32> = rewards.iter().map(|step| step[env_id]).collect();
-        let env_values: Vec<f32> = values.iter().map(|step| step[env_id]).collect();
-        let env_terminated: Vec<bool> = terminated.iter().map(|step| step[env_id]).collect();
+        let env_rewards: Vec<f32> =
+            rewards.iter().take(valid_steps).map(|step| step[env_id]).collect();
+        let env_values: Vec<f32> =
+            values.iter().take(valid_steps).map(|step| step[env_id]).collect();
+        let env_terminated: Vec<bool> =
+            terminated.iter().take(valid_steps).map(|step| step[env_id]).collect();
 
-        let mut env_advantages: Vec<f32> = vec![0.0; num_steps];
-        let mut env_returns: Vec<f32> = vec![0.0; num_steps];
+        let mut env_advantages: Vec<f32> = vec![0.0; valid_steps];
+        let mut env_returns: Vec<f32> = vec![0.0; valid_steps];
 
         compute_gae_single_env(
             &env_rewards,
@@ -66,8 +114,8 @@ pub fn compute_advantages(
             &mut env_returns,
         );
 
-        // Copy results back
-        for step in 0..num_steps {
+        // Copy results back into the filled prefix only.
+        for step in 0..valid_steps {
             advantages[step][env_id] = env_advantages[step];
             returns[step][env_id] = env_returns[step];
         }
@@ -239,5 +287,182 @@ pub fn normalize_advantages(buffer: &mut super::storage::RolloutBuffer) {
         for env in 0..num_envs {
             advantages[step][env] = (advantages[step][env] - mean) / std;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::buffer::rollout::storage::RolloutBuffer;
+
+    /// `compute_advantages_partial` over the first `valid_steps` rows must
+    /// match the values that `compute_advantages` would produce on a
+    /// shorter buffer containing only those rows. This locks in the
+    /// invariant that the partial variant is purely a loop-bound change
+    /// and not a math change.
+    #[test]
+    fn test_compute_advantages_partial_matches_full_on_prefix() {
+        let valid_steps = 3usize;
+        let total_capacity = 8usize;
+        let num_envs = 1usize;
+        let obs_dim = 1usize;
+
+        // Build a full-capacity buffer where rows 0..valid_steps carry
+        // real data and rows valid_steps..total_capacity are left at the
+        // zero-initialized default.
+        let mut partial_buffer = RolloutBuffer::new(total_capacity, num_envs, obs_dim);
+        let rewards = [1.0_f32, 0.5, -0.25];
+        let values = [0.4_f32, 0.6, 0.8];
+        let log_probs = [-0.1_f32, -0.2, -0.3];
+        for step in 0..valid_steps {
+            partial_buffer.add(
+                step,
+                0,
+                &[0.0],
+                0,
+                rewards[step],
+                values[step],
+                log_probs[step],
+                false,
+                false,
+            );
+        }
+
+        // Build a tight buffer with only `valid_steps` rows holding the
+        // same data.
+        let mut tight_buffer = RolloutBuffer::new(valid_steps, num_envs, obs_dim);
+        for step in 0..valid_steps {
+            tight_buffer.add(
+                step,
+                0,
+                &[0.0],
+                0,
+                rewards[step],
+                values[step],
+                log_probs[step],
+                false,
+                false,
+            );
+        }
+
+        let last_values = vec![0.7_f32];
+        let gamma = 0.99_f32;
+        let gae_lambda = 0.95_f32;
+
+        compute_advantages_partial(
+            &mut partial_buffer,
+            valid_steps,
+            &last_values,
+            gamma,
+            gae_lambda,
+        );
+        compute_advantages(&mut tight_buffer, &last_values, gamma, gae_lambda);
+
+        // Filled prefix: partial and tight buffers must agree exactly.
+        for step in 0..valid_steps {
+            let p_adv = partial_buffer.advantages()[step][0];
+            let t_adv = tight_buffer.advantages()[step][0];
+            let p_ret = partial_buffer.returns()[step][0];
+            let t_ret = tight_buffer.returns()[step][0];
+            assert!(
+                (p_adv - t_adv).abs() < 1e-6_f32,
+                "advantage mismatch at step {}: partial={}, tight={}",
+                step,
+                p_adv,
+                t_adv
+            );
+            assert!(
+                (p_ret - t_ret).abs() < 1e-6_f32,
+                "return mismatch at step {}: partial={}, tight={}",
+                step,
+                p_ret,
+                t_ret
+            );
+        }
+
+        // Unwritten tail: advantages and returns must remain at the
+        // zero-initialized default. If `compute_advantages_partial` had
+        // accidentally written into the tail, this would catch it.
+        for step in valid_steps..total_capacity {
+            assert_eq!(partial_buffer.advantages()[step][0], 0.0);
+            assert_eq!(partial_buffer.returns()[step][0], 0.0);
+        }
+    }
+
+    /// Direct regression for the second contamination point flagged on
+    /// issue #28: with the old full-capacity GAE, a partially-filled
+    /// buffer with a non-zero bootstrap propagates `γ^k * last_value`
+    /// backward through the zero-padded tail and into the real prefix.
+    /// `compute_advantages_partial` must not exhibit that behavior.
+    #[test]
+    fn test_compute_advantages_partial_does_not_leak_bootstrap_through_padding() {
+        let valid_steps = 2usize;
+        let total_capacity = 16usize;
+        let num_envs = 1usize;
+
+        let mut buffer = RolloutBuffer::new(total_capacity, num_envs, 1);
+        // Two real rows, neither terminal. With a single step left after
+        // index 1, the bootstrap should hit at row 1 (index valid_steps - 1).
+        buffer.add(0, 0, &[0.0], 0, 0.0, 0.0, 0.0, false, false);
+        buffer.add(1, 0, &[0.0], 0, 0.0, 0.0, 0.0, false, false);
+
+        let bootstrap = 1.0_f32;
+        let last_values = vec![bootstrap];
+        let gamma = 0.99_f32;
+        let gae_lambda = 0.95_f32;
+
+        compute_advantages_partial(&mut buffer, valid_steps, &last_values, gamma, gae_lambda);
+
+        // Expected (closed form, single env, no terminations):
+        //   delta_1 = 0 + γ * bootstrap - 0 = γ * bootstrap
+        //   gae_1   = delta_1                = γ * bootstrap
+        //   delta_0 = 0 + γ * V_1 - 0        = 0  (since V_1 = 0)
+        //   gae_0   = 0 + γ * λ * gae_1      = γ^2 * λ * bootstrap
+        let expected_adv_1 = gamma * bootstrap;
+        let expected_adv_0 = gamma * gamma * gae_lambda * bootstrap;
+
+        let a1 = buffer.advantages()[1][0];
+        let a0 = buffer.advantages()[0][0];
+        assert!(
+            (a1 - expected_adv_1).abs() < 1e-6_f32,
+            "advantage[1] expected {}, got {}",
+            expected_adv_1,
+            a1
+        );
+        assert!(
+            (a0 - expected_adv_0).abs() < 1e-6_f32,
+            "advantage[0] expected {} (γ²λ * bootstrap), got {}. \
+             If this is closer to γ^15 * bootstrap, the GAE iteration is \
+             still walking through padded rows.",
+            expected_adv_0,
+            a0
+        );
+
+        // Tail must stay zero.
+        for step in valid_steps..total_capacity {
+            assert_eq!(buffer.advantages()[step][0], 0.0);
+        }
+    }
+
+    /// `valid_steps == 0` is a defensive edge case — the function should
+    /// be a no-op (no panics, no writes to advantages/returns).
+    #[test]
+    fn test_compute_advantages_partial_zero_valid_is_noop() {
+        let mut buffer = RolloutBuffer::new(4, 1, 1);
+        buffer.add(0, 0, &[0.0], 0, 1.0, 0.5, 0.0, false, false);
+        // Pre-stamp the advantage so we can detect any rogue write.
+        buffer.advantages_mut()[0][0] = 99.0;
+
+        compute_advantages_partial(&mut buffer, 0, &[0.0], 0.99, 0.95);
+
+        assert_eq!(buffer.advantages()[0][0], 99.0);
+    }
+
+    /// Passing `valid_steps > num_steps` must panic with a clear message.
+    #[test]
+    #[should_panic(expected = "valid_steps")]
+    fn test_compute_advantages_partial_panics_on_overflow() {
+        let mut buffer = RolloutBuffer::new(4, 1, 1);
+        compute_advantages_partial(&mut buffer, 5, &[0.0], 0.99, 0.95);
     }
 }

--- a/src/buffer/rollout/storage.rs
+++ b/src/buffer/rollout/storage.rs
@@ -231,8 +231,33 @@ pub struct RolloutBatch {
 
 impl RolloutBatch {
     /// Create a new batch from rollout buffer
+    ///
+    /// Iterates the full `[num_steps, num_envs]` capacity. If the buffer
+    /// was only partially filled, the unwritten tail surfaces as
+    /// zero-initialized rows. Use [`Self::from_buffer_partial`] (or
+    /// [`super::RolloutBuffer::get_filled_batch`]) when the caller
+    /// knows the fill count.
     pub fn from_buffer(buffer: &RolloutBuffer) -> Self {
-        let batch_size = buffer.len();
+        Self::from_buffer_partial(buffer, buffer.num_steps)
+    }
+
+    /// Create a new batch from the first `valid_steps` rows of the buffer.
+    ///
+    /// Rows in `valid_steps..num_steps` (the unfilled tail of a partial
+    /// rollout) are skipped, preventing zero-padded rows from
+    /// contaminating PPO gradients.
+    ///
+    /// # Panics
+    /// Panics if `valid_steps > buffer.num_steps`.
+    pub fn from_buffer_partial(buffer: &RolloutBuffer, valid_steps: usize) -> Self {
+        assert!(
+            valid_steps <= buffer.num_steps,
+            "valid_steps ({}) must not exceed buffer.num_steps ({})",
+            valid_steps,
+            buffer.num_steps
+        );
+
+        let batch_size = valid_steps * buffer.num_envs;
         let obs_size = batch_size * buffer.obs_dim;
 
         let mut observations = Vec::with_capacity(obs_size);
@@ -242,8 +267,8 @@ impl RolloutBatch {
         let mut advantages = Vec::with_capacity(batch_size);
         let mut returns = Vec::with_capacity(batch_size);
 
-        // Flatten all data into 1D arrays
-        for step in 0..buffer.num_steps {
+        // Flatten the filled prefix into 1D arrays
+        for step in 0..valid_steps {
             for env in 0..buffer.num_envs {
                 observations.extend_from_slice(&buffer.observations[step][env]);
                 actions.push(buffer.actions[step][env]);
@@ -332,6 +357,52 @@ mod tests {
         assert_eq!(batch.advantages, vec![0.5, 0.8]);
         assert_eq!(batch.returns, vec![1.3, 2.0]);
         assert_eq!(batch.observations, vec![1.0, 2.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn test_rollout_batch_from_buffer_partial_skips_unfilled_tail() {
+        // 4-step buffer, single env, only the first 2 rows filled.
+        let mut buffer = RolloutBuffer::new(4, 1, 2);
+
+        buffer.add(0, 0, &[1.0, 2.0], 1, 1.5, 0.8, -0.2, false, false);
+        buffer.add(1, 0, &[2.0, 3.0], 0, 2.0, 1.2, -0.1, false, false);
+        buffer.advantages_mut()[0][0] = 0.5;
+        buffer.returns_mut()[0][0] = 1.3;
+        buffer.advantages_mut()[1][0] = 0.8;
+        buffer.returns_mut()[1][0] = 2.0;
+
+        let batch = RolloutBatch::from_buffer_partial(&buffer, 2);
+
+        // Batch has exactly 2 rows — the zero-initialized tail (rows 2-3)
+        // is skipped.
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch.actions, vec![1, 0]);
+        assert_eq!(batch.old_values, vec![0.8, 1.2]);
+        assert_eq!(batch.old_log_probs, vec![-0.2, -0.1]);
+        assert_eq!(batch.advantages, vec![0.5, 0.8]);
+        assert_eq!(batch.returns, vec![1.3, 2.0]);
+        assert_eq!(batch.observations, vec![1.0, 2.0, 2.0, 3.0]);
+
+        // `from_buffer` (full capacity) still emits 4 rows; the 2-row
+        // partial batch is a strict subset.
+        let full_batch = RolloutBatch::from_buffer(&buffer);
+        assert_eq!(full_batch.len(), 4);
+    }
+
+    #[test]
+    fn test_rollout_batch_from_buffer_partial_zero_valid() {
+        let buffer = RolloutBuffer::new(4, 2, 3);
+        let batch = RolloutBatch::from_buffer_partial(&buffer, 0);
+        assert!(batch.is_empty());
+        assert_eq!(batch.actions.len(), 0);
+        assert_eq!(batch.observations.len(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "valid_steps")]
+    fn test_rollout_batch_from_buffer_partial_panics_on_overflow() {
+        let buffer = RolloutBuffer::new(4, 1, 2);
+        let _ = RolloutBatch::from_buffer_partial(&buffer, 5);
     }
 
     #[test]

--- a/src/multi_agent/learner.rs
+++ b/src/multi_agent/learner.rs
@@ -47,8 +47,11 @@ pub struct PolicyLearner {
     model_save_dir: String,
 
     /// Index into the rollout buffer for the next experience to be inserted.
-    /// Wraps modulo `config.buffer_size` and is reset to 0 after each
-    /// `train()` cycle (when the buffer is cleared via `reset`).
+    /// Monotonically increments as experiences are ingested and is reset
+    /// to 0 after each successful `train()` cycle. The collection loop
+    /// bounds it above by `config.buffer_size`, so it is always in
+    /// `0..=config.buffer_size`. Doubles as the canonical fill count
+    /// (`RolloutBuffer::len()` returns capacity, not fill).
     buffer_step_idx: usize,
 
     /// Snapshot of the most recently received experience for the current
@@ -137,8 +140,16 @@ impl PolicyLearner {
             //      true`), `V(s_{T+1}) = 0`.
             //    - Otherwise (truncation / buffer-full), bootstrap with `V(s_{T+1})` from
             //      the current policy, computed under `no_grad`.
+            //
+            //    Restrict the GAE backward iteration to the filled prefix
+            //    (`buffer_step_idx` rows). Otherwise the unwritten tail —
+            //    zero rewards, zero values, `terminated == false` — would
+            //    propagate `γ^k * last_value` backward through the padding
+            //    into the real rows, corrupting advantages on the actual
+            //    data.
             let last_values = self.compute_bootstrap_last_values();
-            self.buffer.compute_advantages(
+            self.buffer.compute_advantages_partial(
+                self.buffer_step_idx,
                 &last_values,
                 self.config.gamma as f32,
                 self.config.gae_lambda as f32,
@@ -290,8 +301,12 @@ impl PolicyLearner {
 
     /// Run PPO training step
     fn train_step(&mut self) -> Result<TrainingStats> {
-        // Get batch from buffer
-        let batch = self.buffer.get_batch();
+        // Get batch from the filled prefix of the buffer. `RolloutBuffer`
+        // pre-allocates its full capacity at construction, so calling
+        // `get_batch()` here would include zero-padded unwritten rows
+        // when the rollout ended before `buffer_size` (early-terminating
+        // episode, truncation, etc.) and feed fake transitions to PPO.
+        let batch = self.buffer.get_filled_batch(self.buffer_step_idx);
 
         // Convert Vec data to Tensors
         let device = self.trainer.policy().device();
@@ -585,6 +600,120 @@ mod tests {
         );
         let stats = learner.train_step().expect("train_step should run end-to-end");
         // Loss values must be finite (no NaN/Inf).
+        assert!(stats.total_loss.is_finite(), "total_loss must be finite");
+        assert!(stats.policy_loss.is_finite(), "policy_loss must be finite");
+        assert!(stats.value_loss.is_finite(), "value_loss must be finite");
+    }
+
+    /// Regression test for issue #28: `PolicyLearner::train_step` must not
+    /// consume zero-padded unwritten rows from `RolloutBuffer`, and the
+    /// preceding GAE pass must not walk backward through them either.
+    ///
+    /// With `buffer_size = 64` and 10 ingested experiences, the PPO batch
+    /// must contain exactly 10 rows — not 64. The strongest single signal
+    /// is that every batch entry's `old_log_prob` equals the sentinel
+    /// value (`-0.69`) we send through the channel, since the buffer's
+    /// storage default is `0.0`. If any zero-padded row leaked into the
+    /// batch, that assertion would fail.
+    #[test]
+    fn test_train_step_does_not_zero_pad_partial_rollout() {
+        let obs_dim: usize = 4;
+        let action_dim: i64 = 2;
+        let policy = MlpPolicy::new(obs_dim as i64, action_dim, 16);
+
+        let (exp_sender, exp_receiver) = crossbeam_channel::unbounded();
+        let (policy_sender, _policy_receiver) = crossbeam_channel::unbounded();
+
+        let config = LearnerConfig {
+            obs_dim,
+            buffer_size: 64,
+            min_batch_size: 4,
+            n_epochs: 1,
+            ..LearnerConfig::default()
+        };
+
+        let mut learner =
+            PolicyLearner::new(0, policy, exp_receiver, policy_sender, config, "/tmp".to_string())
+                .expect("learner construction should succeed");
+
+        // Ingest exactly 10 experiences (well under buffer_size = 64).
+        // Each experience carries the sentinel log_prob `-0.69`, distinct
+        // from the storage default of `0.0`.
+        let n_exp = 10usize;
+        let sentinel_log_prob: f32 = -0.69;
+        for i in 0..n_exp {
+            let obs = Tensor::ones([obs_dim as i64], (Kind::Float, tch::Device::Cpu));
+            let next_obs = Tensor::ones([obs_dim as i64], (Kind::Float, tch::Device::Cpu));
+            let terminated = i == n_exp - 1;
+            let exp = Experience::new(
+                0,
+                obs,
+                (i % action_dim as usize) as i64,
+                1.0,
+                next_obs,
+                terminated,
+                false,
+                0.5,
+                sentinel_log_prob,
+            );
+            exp_sender.send(exp).expect("channel send should succeed");
+        }
+        // Drop sender so `collect_experiences` times out instead of
+        // blocking after consuming the queue.
+        drop(exp_sender);
+
+        learner.collect_experiences().expect("collect_experiences should not error");
+        assert_eq!(
+            learner.buffer_step_idx, n_exp,
+            "buffer_step_idx must reflect every received experience"
+        );
+
+        // Run partial-fill GAE on just the filled prefix. Bootstrap value
+        // is 0.0 because the final experience is terminal.
+        let last_values = learner.compute_bootstrap_last_values();
+        learner.buffer.compute_advantages_partial(
+            learner.buffer_step_idx,
+            &last_values,
+            learner.config.gamma as f32,
+            learner.config.gae_lambda as f32,
+        );
+
+        // Core assertion: the batch consumed by PPO is sized to the
+        // filled prefix, not to buffer capacity.
+        let batch = learner.buffer.get_filled_batch(learner.buffer_step_idx);
+        assert_eq!(batch.actions.len(), n_exp, "batch must contain only filled rows");
+        assert_eq!(batch.old_log_probs.len(), n_exp);
+        assert_eq!(batch.old_values.len(), n_exp);
+        assert_eq!(batch.advantages.len(), n_exp);
+        assert_eq!(batch.returns.len(), n_exp);
+        assert_eq!(batch.observations.len(), n_exp * obs_dim);
+
+        // Sanity: every batch row came from real data — its
+        // `old_log_prob` must equal the sentinel we sent, not the
+        // storage default `0.0`. This is the single strongest signal
+        // that no zero-padded row leaked into the batch.
+        for &lp in &batch.old_log_probs {
+            assert!(
+                (lp - sentinel_log_prob).abs() < 1e-6,
+                "old_log_prob in batch must be real (-0.69), not zero-padded; got {}",
+                lp
+            );
+        }
+
+        // Same sanity check for `old_values` (we sent `0.5`).
+        for &v in &batch.old_values {
+            assert!(
+                (v - 0.5).abs() < 1e-6,
+                "old_value in batch must be real (0.5), not zero-padded; got {}",
+                v
+            );
+        }
+
+        // End-to-end: a full `train_step` on the partial rollout must
+        // produce finite losses. (Bad GAE contamination from padded
+        // rows could in principle push losses to NaN/Inf via outsized
+        // advantage normalization; this is a backstop assertion.)
+        let stats = learner.train_step().expect("train_step end-to-end should not error");
         assert!(stats.total_loss.is_finite(), "total_loss must be finite");
         assert!(stats.policy_loss.is_finite(), "policy_loss must be finite");
         assert!(stats.value_loss.is_finite(), "value_loss must be finite");


### PR DESCRIPTION
## Summary

- Restricts both PPO batch construction and GAE backward iteration to the actually-filled prefix of `RolloutBuffer` (`buffer_step_idx` rows), so zero-padded unwritten tail rows can no longer contaminate gradients.
- Adds `RolloutBatch::from_buffer_partial`, `RolloutBuffer::get_filled_batch`, and `compute_advantages_partial` as additive APIs. The existing `get_batch` / `compute_advantages` remain (their docstrings now flag the full-capacity semantics).
- Corrects the `buffer_step_idx` docstring on `PolicyLearner` — the old text claimed "wraps modulo `config.buffer_size`", which the code has never done; it is in fact monotonic with a single reset at the end of each successful `train()` cycle.

## Second contamination point (not in the original issue)

The original report only flagged `train_step`'s call to `get_batch()`. During curator verification, a second contamination point was identified and is also fixed in this PR: `PolicyLearner::train` calls `buffer.compute_advantages(...)` *before* `train_step`, and the old `compute_advantages` iterates the full `[num_steps, num_envs]` capacity with the inner backward GAE loop walking `(0..num_steps).rev()`. With `buffer_size = 64` and 10 filled rows, GAE iterates 64 steps backward starting from row 63 with `last_value = V(s_{T+1})` — but the bootstrap is correctly anchored after the 10th row, *not* after row 63. The 54 padding rows have `reward = 0`, `value = 0`, `terminated = false`, so `delta = γ * next_value`, and GAE accumulates `γ^k * last_value` backward through the padding before reaching the real data at index 9. Result: the 10 real rows get an advantage signal corrupted by 54 steps of decayed bootstrap value, and the 54 padding rows get nonzero advantages/returns that would also be sliced into the PPO batch.

The GAE fix is purely a loop-bound change, not a math change: the bootstrap value already corresponds to "the state after the last filled row", so clamping the inner loop to `(0..valid_steps).rev()` is correct. This is verified by `test_compute_advantages_partial_matches_full_on_prefix`, which asserts that partial-fill GAE over the first 3 rows of an 8-row buffer matches full GAE over a tight 3-row buffer to within 1e-6, and by `test_compute_advantages_partial_does_not_leak_bootstrap_through_padding`, which uses closed-form expected values.

Closes #28.

## Test plan

- [x] `cargo test --lib` — all 110 unit tests pass (8 new), including:
  - `test_train_step_does_not_zero_pad_partial_rollout` — end-to-end: 10 experiences with sentinel `old_log_prob = -0.69` into a `buffer_size = 64` learner. Asserts the PPO batch has exactly 10 rows and every `old_log_prob` in the batch equals the sentinel (would fail at `0.0` for any leaked zero-padded row).
  - `test_compute_advantages_partial_matches_full_on_prefix` — partial GAE on a prefix matches full GAE on a tight buffer.
  - `test_compute_advantages_partial_does_not_leak_bootstrap_through_padding` — direct regression for the second contamination point with closed-form expectations.
  - `test_rollout_batch_from_buffer_partial_skips_unfilled_tail` — batch construction correctness.
  - Plus `should_panic` tests for `valid_steps > num_steps` on both new APIs, and zero-valid-steps no-op tests.
- [x] All pre-existing tests still pass (`test_learner_ingests_experiences_and_trains`, etc.). Note: `tests/test_ppo_learning.rs::test_ppo_learns_from_synthetic_data` was already failing on master; not affected by this change.
- [x] `cargo +nightly fmt` clean.
- [x] `cargo +nightly clippy --lib --tests` — no new warnings on the changed files (`src/buffer/rollout.rs`, `src/buffer/rollout/gae.rs`, `src/buffer/rollout/storage.rs`, `src/multi_agent/learner.rs`).