### PR TITLE
Remove unused bincode dep (resolves RUSTSEC-2025-0141)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,11 +3,4 @@
 # accepted, with a tracking issue for resolving it where applicable.
 
 [advisories]
-ignore = [
-  # RUSTSEC-2025-0141 — bincode 1.3.3 is unmaintained (informational).
-  # The bincode team formally declared 1.3.3 a complete version that doesn't
-  # need updates; this is not a vulnerability. We pull bincode 1.x via the
-  # `training` feature. Migration to bincode 2.x or postcard is tracked
-  # separately.
-  "RUSTSEC-2025-0141",
-]
+ignore = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ bytemuck = { version = "1.14", features = ["derive"] }
 # Serialization for checkpoints
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-bincode = { version = "1.3", optional = true }
 
 # Metrics and logging (simplified for WASM)
 tracing = { version = "0.1", optional = true }
@@ -67,7 +66,7 @@ console_error_panic_hook = { version = "0.1", optional = true }
 
 [features]
 default = ["training"]
-training = ["tch", "tokio", "rayon", "bincode", "tracing", "tracing-subscriber", "crossbeam-channel", "chrono"]  # Include PyTorch and async deps for training
+training = ["tch", "tokio", "rayon", "tracing", "tracing-subscriber", "crossbeam-channel", "chrono"]  # Include PyTorch and async deps for training
 wasm = ["wasm-bindgen", "web-sys", "js-sys", "console_error_panic_hook"]  # Pure Rust for WASM
 # Bucket Brigade env adapter for the Slepian-Wolf MARL experiments. Pulls in
 # the bucket-brigade-core crate as a pure-Rust dep --- does *not* require

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ Thrust aims to be the **first production-ready RL library in pure Rust** with:
 
 **WASM Infrastructure (Partial)**
 - [x] Pure Rust inference module (no PyTorch deps)
-- [x] ExportedModel with JSON/bincode serialization
+- [x] ExportedModel with JSON serialization
 - [x] Forward pass implementation (softmax, linear layers)
 - [x] 5 passing inference tests
 

--- a/WASM_ROADMAP.md
+++ b/WASM_ROADMAP.md
@@ -28,7 +28,7 @@ Compile Rust inference code to WASM and run trained policies in the browser with
 ├─────────────────────────────────────────────────────────────┤
 │  • Load .pt model                                           │
 │  • Extract layer weights & biases                           │
-│  • Export to JSON/bincode                                   │
+│  • Export to JSON                                           │
 └─────────────────────────────────────────────────────────────┘
                           │
                           │ Portable weights
@@ -66,7 +66,6 @@ Compile Rust inference code to WASM and run trained policies in the browser with
 
 2. **Weight Export/Import** (`src/inference/weights.rs`)
    - `save_json()` / `load_json()`: JSON serialization
-   - `save_bincode()` / `load_bincode()`: Binary format
    - Tests: Roundtrip serialization
 
 3. **Training Infrastructure**

--- a/src/inference/weights.rs
+++ b/src/inference/weights.rs
@@ -27,27 +27,6 @@ impl ExportedModel {
         let model = serde_json::from_str(&contents)?;
         Ok(model)
     }
-
-    /// Save model to binary format (bincode)
-    /// Only available with the "training" feature
-    #[cfg(feature = "training")]
-    pub fn save_bincode<P: AsRef<Path>>(&self, path: P) -> Result<()> {
-        let encoded = bincode::serialize(self)?;
-        let mut file = File::create(path)?;
-        file.write_all(&encoded)?;
-        Ok(())
-    }
-
-    /// Load model from binary format (bincode)
-    /// Only available with the "training" feature
-    #[cfg(feature = "training")]
-    pub fn load_bincode<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let mut file = File::open(path)?;
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer)?;
-        let model = bincode::deserialize(&buffer)?;
-        Ok(model)
-    }
 }
 
 #[cfg(test)]
@@ -74,21 +53,6 @@ mod tests {
         assert_eq!(model.input_dim, loaded.input_dim);
         assert_eq!(model.output_dim, loaded.output_dim);
         assert_eq!(model.hidden_dim, loaded.hidden_dim);
-
-        Ok(())
-    }
-
-    #[test]
-    #[cfg(feature = "training")]
-    fn test_bincode_roundtrip() -> Result<()> {
-        let model = create_test_model();
-        let temp_file = NamedTempFile::new()?;
-
-        model.save_bincode(temp_file.path())?;
-        let loaded = ExportedModel::load_bincode(temp_file.path())?;
-
-        assert_eq!(model.input_dim, loaded.input_dim);
-        assert_eq!(model.output_dim, loaded.output_dim);
 
         Ok(())
     }


### PR DESCRIPTION
Closes #35

## Summary

This is a **YAGNI removal**, not a migration. Per the curator's investigation on #35, the bincode crate is effectively dead code in this repo:

- Only two functions referenced it: `ExportedModel::save_bincode` and `ExportedModel::load_bincode` in `src/inference/weights.rs`.
- **Zero callers** anywhere in `src/`, `examples/`, or `tests/` outside the file's own self-test.
- No `.bc` / `.bincode` artifacts are committed — only JSON model exports are persisted.
- The WASM frontend reads JSON, not bincode.

Rather than migrate to bincode 2.x and keep carrying a binary-serialization path nobody uses, this PR deletes it. The advisory motivation is now resolved at the root: both the dep and the audit-ignore are gone.

## Changes

- `src/inference/weights.rs`: removed `save_bincode`, `load_bincode`, and `test_bincode_roundtrip` (~36 lines).
- `Cargo.toml`: removed `bincode` from `[dependencies]` and from the `training` feature deps list.
- `.cargo/audit.toml`: removed the `RUSTSEC-2025-0141` ignore entry (the array is now empty; file kept as infra for future advisories).
- `ROADMAP.md`, `WASM_ROADMAP.md`: removed `bincode` mentions, since the supported export format is JSON.

Diff: 5 files, 4 insertions, 49 deletions.

## Test plan

- [x] `cargo check --no-default-features` passes.
- [x] `cargo check --features training` passes (built with `LIBTORCH_USE_PYTORCH=1 LIBTORCH_BYPASS_VERSION_CHECK=1` locally because the dev box has PyTorch 2.10 vs tch's expected 2.9; not related to this PR).
- [x] `cargo test --no-default-features --lib` — 45 passed, 0 failed. `test_json_roundtrip` (the actually-used path) still covers serialization.
- [x] `grep -rn "bincode" src/ examples/ tests/` returns no matches.
- [x] `cargo +nightly fmt` clean.
- [ ] CI Security Audit job is green without the ignore (verify on GitHub Actions).

## Reversibility

If a binary format becomes a real need later, bincode 2.x (or postcard/rkyv) can be added at that point with a clean slate, without dragging along the 1.x advisory.