### PR TITLE
Fix nested PPO epoch loop in PolicyLearner::train_step

### DIFF
--- a/src/multi_agent/learner.rs
+++ b/src/multi_agent/learner.rs
@@ -299,7 +299,13 @@ impl PolicyLearner {
         }
     }
 
-    /// Run PPO training step
+    /// Run a PPO training step.
+    ///
+    /// Delegates to `PPOTrainer::train_step_with_policy`, which internally
+    /// iterates over the rollout for `config.n_epochs` PPO epochs and returns
+    /// averaged statistics across all minibatch updates. This method performs
+    /// exactly one such trainer call --- it does NOT add an outer epoch loop
+    /// (doing so would compound epochs multiplicatively; see issue #41).
     fn train_step(&mut self) -> Result<TrainingStats> {
         // Get batch from the filled prefix of the buffer. `RolloutBuffer`
         // pre-allocates its full capacity at construction, so calling
@@ -324,49 +330,47 @@ impl PolicyLearner {
         let advantages = Tensor::from_slice(&batch.advantages).to_device(device);
         let returns = Tensor::from_slice(&batch.returns).to_device(device);
 
-        // Train for multiple epochs
-        // Note: We can't use train_step() because it requires both &self.policy and
-        // &mut self.trainer Instead, we'll use a workaround by calling the
-        // trainer directly with its own policy
-        let mut total_stats = TrainingStats::default();
-        for _ in 0..self.config.n_epochs {
-            // Safety: The trainer owns the policy, so this is safe as long as we don't
-            // call any methods that would try to borrow trainer mutably during policy
-            // access
-            let trainer_ptr: *mut PPOTrainer<MlpPolicy> = &mut self.trainer;
-            let policy_ptr: *const MlpPolicy = unsafe { &*trainer_ptr }.policy();
+        // Run one PPO update. `PPOTrainer::train_step_with_policy` already
+        // performs `config.n_epochs` epochs over the batch internally and
+        // returns the averaged statistics across all minibatch updates, so we
+        // must NOT wrap this call in an additional `n_epochs` loop --- doing so
+        // would cause `n_epochs²` PPO epochs per call (see issue #41).
+        //
+        // Note: We can't use the convenience `train_step()` because it requires
+        // both `&self.policy` and `&mut self.trainer`. Instead, we call the
+        // trainer with its own policy via raw pointers.
+        //
+        // Safety: The trainer owns the policy, so this is safe as long as we don't
+        // call any methods that would try to borrow trainer mutably during policy
+        // access.
+        let trainer_ptr: *mut PPOTrainer<MlpPolicy> = &mut self.trainer;
+        let policy_ptr: *const MlpPolicy = unsafe { &*trainer_ptr }.policy();
 
-            let stats = unsafe {
-                (*trainer_ptr).train_step_with_policy(
-                    &*policy_ptr,
-                    &observations,
-                    &actions,
-                    &old_log_probs,
-                    &old_values,
-                    &advantages,
-                    &returns,
-                    |policy: &MlpPolicy, obs: &Tensor, acts: &Tensor| {
-                        policy.evaluate_actions(obs, acts)
-                    },
-                )?
-            };
+        let stats = unsafe {
+            (*trainer_ptr).train_step_with_policy(
+                &*policy_ptr,
+                &observations,
+                &actions,
+                &old_log_probs,
+                &old_values,
+                &advantages,
+                &returns,
+                |policy: &MlpPolicy, obs: &Tensor, acts: &Tensor| {
+                    policy.evaluate_actions(obs, acts)
+                },
+            )?
+        };
 
-            // Accumulate stats
-            total_stats.total_loss += stats.total_loss;
-            total_stats.policy_loss += stats.policy_loss;
-            total_stats.value_loss += stats.value_loss;
-            total_stats.entropy += stats.entropy;
-        }
-
-        // Average over epochs
-        let n = self.config.n_epochs as f64;
-        total_stats.total_loss /= n;
-        total_stats.policy_loss /= n;
-        total_stats.value_loss /= n;
-        total_stats.entropy /= n;
-        total_stats.step = self.step;
-
-        Ok(total_stats)
+        // The trainer returns averaged stats already; just pass through the
+        // fields we expose on the multi-agent `TrainingStats` message.
+        Ok(TrainingStats {
+            total_loss: stats.total_loss,
+            policy_loss: stats.policy_loss,
+            value_loss: stats.value_loss,
+            entropy: stats.entropy,
+            step: self.step,
+            ..TrainingStats::default()
+        })
     }
 
     /// Send policy update to simulator


### PR DESCRIPTION
Closes #41

## Summary

`PolicyLearner::train_step` wrapped a call to `PPOTrainer::train_step_with_policy` in an outer `for _ in 0..n_epochs { ... }` loop. The trainer call itself already iterates over `config.n_epochs` PPO epochs internally, so every learner step was performing **n_epochs^2** PPO epochs over the same rollout.

With the default `LearnerConfig::n_epochs = 4` (which overrides PPO's default 10 via `From<LearnerConfig>`), this translated to 16 epochs per nominal step instead of 4 --- roughly 4x more gradient updates than declared, with corresponding effects on clipping behavior and gradient magnitudes.

## Curator's finding (from #39)

> `PolicyLearner::train_step` in `src/multi_agent/learner.rs` runs `for _ in 0..n_epochs { ... }` around a call into `PPOTrainer::train_step_with_aux` (or `train_step_with_policy`), which internally runs ANOTHER `for epoch in 0..n_epochs { ... }` over the same data. Net effect: `n_epochs^2` PPO epochs per call. With `LearnerConfig::n_epochs = 4` (overrides PPO default 10 via `From<LearnerConfig>`), this is 16 epochs per nominal step.
>
> The inner loop in `PPOTrainer::train_step_with_aux` is the **correct** PPO behavior --- multiple epochs over the same rollout is how PPO is supposed to work. The outer loop in `PolicyLearner::train_step` is the redundant one.

Reference: https://github.com/rjwalters/thrust/issues/39#issuecomment-4456739019

## Changes

- Removed the outer `for _ in 0..self.config.n_epochs` loop in `PolicyLearner::train_step`.
- Dropped the per-epoch stats accumulation + division-by-n_epochs averaging, since the trainer already returns stats averaged across all minibatch updates.
- Updated the docstring on `train_step` to clarify that it delegates a single trainer call which internally iterates `config.n_epochs` epochs.
- Preserved the existing `unsafe` block around the trainer call as-is. That is being addressed independently in #39 (the heads-up in the issue noted #39's builder is also touching this same function; merge ordering will need to be sorted manually).

## Test plan

- [x] `cargo build --features training` passes (locally with `LIBTORCH_USE_PYTORCH=1 LIBTORCH_BYPASS_VERSION_CHECK=1`).
- [x] `cargo test --features training --lib` --- all 109 tests pass.
- [x] `cargo +nightly fmt` clean.
- [x] No tests required adjustment: both `test_learner_ingests_experiences_and_trains` and `test_train_step_does_not_zero_pad_partial_rollout` use `n_epochs: 1` and only assert finiteness of returned stats, so neither was implicitly depending on the buggy behavior.

## Note on benchmarks

Any benchmark numbers calibrated against the old behavior may shift after this lands. That is expected --- the algorithm now does what was advertised (`config.n_epochs` PPO epochs per call, not `n_epochs^2`). Per-step throughput should improve by roughly `n_epochs`x (4x at the default), and convergence behavior may change because PPO's effective hyperparameters now match the configured ones.