### PR TITLE
fix(dqn): remove misleading target_synced field from DQNStepStats

### DIFF
--- a/src/train/dqn/trainer.rs
+++ b/src/train/dqn/trainer.rs
@@ -27,8 +27,6 @@ pub struct DQNStepStats {
     pub epsilon: f64,
     /// Replay buffer fill level at the time of this update.
     pub buffer_len: usize,
-    /// Whether the target network was synced this step.
-    pub target_synced: bool,
 }
 
 /// DQN Trainer.
@@ -247,7 +245,6 @@ impl DQNTrainer {
             mean_q: mean_q_val,
             epsilon: self.last_epsilon,
             buffer_len: self.buffer.len(),
-            target_synced: false, // set by caller via maybe_sync_target
         }))
     }
 }


### PR DESCRIPTION
## Summary

Removes the `target_synced: bool` field from `DQNStepStats` in `src/train/dqn/trainer.rs`. The field was always hardcoded to `false` with a comment claiming the caller would patch it, but no caller ever did. The env-step loop already tracks sync timing itself via `total_env_steps % target_update_interval`, so the field added nothing and was misleading to any tooling reading it.

This is option 2 from the issue (cleanest), as the field had no consumer.

## Scope of changes

- `src/train/dqn/trainer.rs`: removed the field from the `DQNStepStats` struct definition (with its doc comment) and from the struct literal returned by `train_step`. Total: 3 lines deleted, no other files touched.

No tests, examples, or other consumers referenced `target_synced` (verified by `grep -rn "target_synced"`), so no caller-side cleanup was needed.

## Test plan

- [x] `cargo build --features training --release` succeeds
- [x] `cargo test --features training` passes (153 lib tests + integration + doc tests, all green)
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo +nightly doc --no-deps --all-features` produces 0 warnings
- [x] `examples/games/cartpole/train_cartpole_dqn.rs` builds

Closes #57

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>