### PR TITLE
Environment trait: add associated Action type for continuous (Box) action spaces

### DIFF
--- a/src/env/games/bucket_brigade.rs
+++ b/src/env/games/bucket_brigade.rs
@@ -144,6 +144,8 @@ impl BucketBrigadeMaEnv {
 // single scalar action as a Cartesian-product index over `[house, mode]`.
 // Real consumers should drive the env through `MultiAgentEnvironment`.
 impl Environment for BucketBrigadeMaEnv {
+    type Action = i64;
+
     fn reset(&mut self) {
         let _ = BucketBrigadeMaEnv::reset(self, None);
     }

--- a/src/env/games/cartpole.rs
+++ b/src/env/games/cartpole.rs
@@ -182,6 +182,8 @@ impl Default for CartPole {
 }
 
 impl Environment for CartPole {
+    type Action = i64;
+
     fn reset(&mut self) {
         self.reset_state();
         self.steps = 0;

--- a/src/env/games/continuous_lqr.rs
+++ b/src/env/games/continuous_lqr.rs
@@ -1,0 +1,201 @@
+//! Minimal continuous-action environment for trait-wiring proof.
+//!
+//! `ContinuousLqr` is a one-dimensional linear quadratic regulator.
+//! It exists to demonstrate that the [`crate::env::Environment`] trait
+//! accepts a non-`i64` action (see issue #61), not to be a useful
+//! training target.
+//!
+//! State:  `[position, velocity]`.
+//! Action: `Vec<f32>` of length 1 (a scalar force in `[-1.0, 1.0]`).
+//! Reward: `-position^2 - 0.01 * action^2` (penalise being away from
+//! the origin and using control effort).
+//!
+//! Episode terminates after `max_steps` steps (default 50).
+//!
+//! Continuous-action training algorithms (SAC, TD3, DDPG, PPO with
+//! Gaussian heads) are explicitly *out of scope* for this env. Its
+//! only job is to compile against the trait.
+
+use crate::env::{Environment, SpaceInfo, SpaceType, StepInfo, StepResult};
+
+/// Force clamp range applied to the 1D action input.
+const ACTION_CLAMP: f32 = 1.0;
+
+/// Per-step integration constant (treated as a unit timestep).
+const DT: f32 = 1.0;
+
+/// Mild linear damping on velocity each step.
+const VELOCITY_DAMPING: f32 = 0.1;
+
+/// Default episode length cap.
+const DEFAULT_MAX_STEPS: usize = 50;
+
+/// 1D linear quadratic regulator with a continuous-force action.
+#[derive(Debug, Clone)]
+pub struct ContinuousLqr {
+    /// Position scalar.
+    position: f32,
+
+    /// Velocity scalar.
+    velocity: f32,
+
+    /// Step counter for the current episode.
+    steps: usize,
+
+    /// Maximum number of steps before truncation.
+    max_steps: usize,
+}
+
+impl ContinuousLqr {
+    /// Create a new env with the default episode length.
+    pub fn new() -> Self {
+        Self::with_max_steps(DEFAULT_MAX_STEPS)
+    }
+
+    /// Create a new env with a custom maximum episode length.
+    pub fn with_max_steps(max_steps: usize) -> Self {
+        Self { position: 0.5, velocity: 0.0, steps: 0, max_steps }
+    }
+
+    /// Current position (for inspection / tests).
+    pub fn position(&self) -> f32 {
+        self.position
+    }
+
+    /// Current velocity (for inspection / tests).
+    pub fn velocity(&self) -> f32 {
+        self.velocity
+    }
+}
+
+impl Default for ContinuousLqr {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Environment for ContinuousLqr {
+    /// Continuous force action. Length-1 `Vec<f32>`; values outside
+    /// `[-ACTION_CLAMP, ACTION_CLAMP]` are clamped.
+    type Action = Vec<f32>;
+
+    fn reset(&mut self) {
+        self.position = 0.5;
+        self.velocity = 0.0;
+        self.steps = 0;
+    }
+
+    fn get_observation(&self) -> Vec<f32> {
+        vec![self.position, self.velocity]
+    }
+
+    fn step(&mut self, action: Vec<f32>) -> StepResult {
+        // Length-1 action; if a caller hands us an empty vec we
+        // treat it as zero force rather than panicking. Anything
+        // beyond index 0 is ignored.
+        let raw = action.first().copied().unwrap_or(0.0);
+        let force = raw.clamp(-ACTION_CLAMP, ACTION_CLAMP);
+
+        // Integrate: v_{t+1} = v_t + (force - damping*v_t)*dt
+        //            x_{t+1} = x_t + v_{t+1}*dt
+        self.velocity += (force - VELOCITY_DAMPING * self.velocity) * DT;
+        self.position += self.velocity * DT;
+
+        self.steps += 1;
+        let truncated = self.steps >= self.max_steps;
+
+        let reward = -(self.position * self.position) - 0.01 * (force * force);
+
+        StepResult {
+            observation: self.get_observation(),
+            reward,
+            terminated: false,
+            truncated,
+            info: StepInfo::default(),
+        }
+    }
+
+    fn observation_space(&self) -> SpaceInfo {
+        // [position, velocity], both continuous.
+        SpaceInfo { shape: vec![2], space_type: SpaceType::Box }
+    }
+
+    fn action_space(&self) -> SpaceInfo {
+        // 1D continuous force.
+        SpaceInfo { shape: vec![1], space_type: SpaceType::Box }
+    }
+
+    fn render(&self) -> Vec<u8> {
+        Vec::new()
+    }
+
+    fn close(&mut self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn continuous_lqr_accepts_vec_f32_action() {
+        let mut env = ContinuousLqr::new();
+        env.reset();
+
+        // Apply a positive force; velocity should become positive
+        // and position should move forward by the new velocity.
+        let result = env.step(vec![0.5]);
+        assert_eq!(result.observation.len(), 2);
+        assert!(env.velocity() > 0.0, "positive force should produce positive velocity");
+        assert!(env.position() > 0.5, "positive velocity should advance position");
+
+        // Reward should be negative (we are off the origin and used
+        // control effort).
+        assert!(result.reward < 0.0);
+
+        // Single step does not terminate or truncate the episode.
+        assert!(!result.terminated);
+        assert!(!result.truncated);
+    }
+
+    #[test]
+    fn continuous_lqr_terminates_after_max_steps() {
+        let mut env = ContinuousLqr::with_max_steps(3);
+        env.reset();
+
+        for _ in 0..2 {
+            let r = env.step(vec![0.0]);
+            assert!(!r.truncated);
+        }
+
+        let r = env.step(vec![0.0]);
+        assert!(r.truncated, "episode should truncate after max_steps");
+    }
+
+    #[test]
+    fn continuous_lqr_clamps_extreme_actions() {
+        let mut env = ContinuousLqr::new();
+        env.reset();
+
+        // Force way above clamp range: effective force is clamped
+        // to ACTION_CLAMP, so velocity change is bounded.
+        let _ = env.step(vec![1000.0]);
+        assert!(env.velocity() <= ACTION_CLAMP);
+    }
+
+    #[test]
+    fn continuous_lqr_action_space_is_box() {
+        let env = ContinuousLqr::new();
+        let space = env.action_space();
+        assert_eq!(space.shape, vec![1]);
+        assert!(matches!(space.space_type, SpaceType::Box));
+    }
+
+    #[test]
+    fn continuous_lqr_empty_action_treated_as_zero() {
+        let mut env = ContinuousLqr::new();
+        env.reset();
+        // No panic on empty action.
+        let _ = env.step(Vec::new());
+        assert_eq!(env.velocity(), -VELOCITY_DAMPING * 0.0);
+    }
+}

--- a/src/env/games/mod.rs
+++ b/src/env/games/mod.rs
@@ -5,8 +5,11 @@
 //! - Snake: Snake game with configurable grid size
 //! - SimpleBandit: Simple multi-armed bandit for testing
 //! - Pong: Single-player Pong vs rule-based opponent
+//! - ContinuousLqr: 1D LQR placeholder env that exercises the continuous
+//!   (`Vec<f32>`) action surface added in issue #61
 
 pub mod cartpole;
+pub mod continuous_lqr;
 pub mod pong;
 pub mod simple_bandit;
 pub mod snake;
@@ -18,6 +21,7 @@ pub mod bucket_brigade;
 #[cfg(feature = "env-bucket-brigade")]
 pub use bucket_brigade::BucketBrigadeMaEnv;
 pub use cartpole::CartPole;
+pub use continuous_lqr::ContinuousLqr;
 pub use pong::Pong;
 pub use simple_bandit::SimpleBandit;
 pub use snake::SnakeEnv;

--- a/src/env/games/pong.rs
+++ b/src/env/games/pong.rs
@@ -192,6 +192,8 @@ impl Default for Pong {
 }
 
 impl Environment for Pong {
+    type Action = i64;
+
     fn reset(&mut self) {
         self.left_y = 0.5;
         self.right_y = 0.5;

--- a/src/env/games/simple_bandit.rs
+++ b/src/env/games/simple_bandit.rs
@@ -38,6 +38,8 @@ impl Default for SimpleBandit {
 }
 
 impl Environment for SimpleBandit {
+    type Action = i64;
+
     fn reset(&mut self) {
         // Random start state (0 or 1)
         self.state = self.rng.gen_range(0..2) as f32;

--- a/src/env/games/snake/environment.rs
+++ b/src/env/games/snake/environment.rs
@@ -526,6 +526,8 @@ impl SnakeEnv {
 }
 
 impl Environment for SnakeEnv {
+    type Action = i64;
+
     fn reset(&mut self) {
         self.reset();
     }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -2,11 +2,68 @@
 //!
 //! This module defines the core environment interface and provides
 //! built-in environments for reinforcement learning.
+//!
+//! # Action types and continuous (Box) action spaces
+//!
+//! The `Environment` trait exposes its action type as an associated
+//! type `Environment::Action`. Discrete envs (CartPole, Snake, Pong,
+//! SimpleBandit, BucketBrigade) set `type Action = i64;`. Continuous
+//! envs set `type Action = Vec<f32>;` (or another float type for
+//! single-dim cases). See `games::continuous_lqr::ContinuousLqr` for
+//! a minimal continuous-action existence proof.
+//!
+//! ## Why the associated-type strategy (Strategy A)?
+//!
+//! When this trait was extended to support continuous-control
+//! algorithms (SAC, TD3, DDPG, PPO with Gaussian heads), there were
+//! two candidate designs:
+//!
+//! - **A. Associated `Action` type on `Environment`** (chosen). One trait,
+//!   parameterised by the action type. Discrete envs default to `type Action =
+//!   i64;` so existing call sites and trainers migrate by adding a single line
+//!   per env impl.
+//! - **B. Parallel `ContinuousEnvironment` trait.** Two distinct traits; envs
+//!   implement one or the other (or both). The trainer dispatches per-trait.
+//!
+//! Strategy A was picked because:
+//!
+//! 1. **One trait.** Downstream code (snapshot/restore, pool, multi-agent
+//!    simulator) does not have to branch on which trait an env implements.
+//!    There is exactly one `Environment` to reason about.
+//! 2. **Cheap default for the common case.** Every discrete env in the repo
+//!    today gets `type Action = i64;` as a one-line addition. Continuous envs
+//!    opt in to `Vec<f32>`.
+//! 3. **Orthogonal to other trait extensions.** The associated-type approach
+//!    composes cleanly with planned additions like a `type State` slot for env
+//!    snapshotting (issue #62 / clone_state / restore_state). Strategy B would
+//!    have forced snapshot machinery to be implemented twice or behind a third
+//!    trait.
+//! 4. **Generic trainers stay generic.** Discrete trainers add a `<Action =
+//!    i64>` bound on their `E: Environment` type parameter, which is purely
+//!    additive.
+//!
+//! The trade-off: any code that wants to handle *both* discrete and
+//! continuous actions polymorphically must either be parametric on
+//! `E::Action` or use a sum-type wrapper. Until SAC lands, no such
+//! call site exists in Thrust.
 
 use anyhow::Result;
 
 /// Core trait for RL environments
 pub trait Environment {
+    /// Action type accepted by [`Environment::step`].
+    ///
+    /// - **Discrete envs** set this to `i64`. The index identifies which of the
+    ///   [`SpaceType::Discrete`] options was chosen.
+    /// - **Continuous envs** set this to `Vec<f32>` (or `f32` for a single-dim
+    ///   Box action). Each element is a real-valued coordinate of the
+    ///   [`SpaceType::Box`] action vector.
+    ///
+    /// Existing call sites that bind actions as `i64` should
+    /// constrain `E: Environment<Action = i64>` to keep the
+    /// type signature compatible.
+    type Action;
+
     /// Reset the environment and return initial observation
     fn reset(&mut self);
 
@@ -14,7 +71,7 @@ pub trait Environment {
     fn get_observation(&self) -> Vec<f32>;
 
     /// Step the environment with an action
-    fn step(&mut self, action: i64) -> StepResult;
+    fn step(&mut self, action: Self::Action) -> StepResult;
 
     /// Get the observation space dimensions
     fn observation_space(&self) -> SpaceInfo;
@@ -78,7 +135,10 @@ pub struct StepInfo {
 pub mod games;
 
 // Re-export game environments for backwards compatibility
-pub use games::{CartPole, Pong, SimpleBandit, SnakeEnv, cartpole, pong, simple_bandit, snake};
+pub use games::{
+    CartPole, ContinuousLqr, Pong, SimpleBandit, SnakeEnv, cartpole, continuous_lqr, pong,
+    simple_bandit, snake,
+};
 
 // Training utilities
 #[cfg(feature = "training")]

--- a/src/env/pool.rs
+++ b/src/env/pool.rs
@@ -38,6 +38,15 @@ use crate::env::{Environment, StepResult};
 ///
 /// This can provide 10-100x speedups depending on environment complexity
 /// and number of CPU cores available.
+///
+/// # Action type
+///
+/// `EnvPool` is currently restricted to discrete-action envs
+/// (`E::Action = i64`). The pool's `step` signature passes
+/// `&[i64]` because every existing trainer and example expects a
+/// dense vector of integer action indices. Adding pool support for
+/// continuous-action envs (e.g. SAC) is a separate follow-up; see
+/// issue #61 for the rationale behind the associated-type design.
 pub struct EnvPool<E: Environment> {
     /// Vector of environment instances
     envs: Vec<E>,
@@ -46,7 +55,7 @@ pub struct EnvPool<E: Environment> {
     num_envs: usize,
 }
 
-impl<E: Environment + Send> EnvPool<E> {
+impl<E: Environment<Action = i64> + Send> EnvPool<E> {
     /// Create a new environment pool
     ///
     /// # Arguments
@@ -184,7 +193,7 @@ pub struct PoolStepResult<O> {
     pub truncated: Vec<bool>,
 }
 
-impl<E: Environment + Send> EnvPool<E> {
+impl<E: Environment<Action = i64> + Send> EnvPool<E> {
     /// Step all environments and return structured result
     ///
     /// This is a convenience method that unpacks individual StepResults

--- a/src/multi_agent/simulator.rs
+++ b/src/multi_agent/simulator.rs
@@ -283,6 +283,8 @@ mod tests {
     }
 
     impl Environment for MockEnv {
+        type Action = i64;
+
         fn reset(&mut self) {}
 
         fn get_observation(&self) -> Vec<f32> {


### PR DESCRIPTION
## Summary

Implements Strategy A from issue #61: add a `type Action` associated type to the `Environment` trait. Every existing (discrete) env adds `type Action = i64;` and keeps its `step` body unchanged. The pool constrains its impls to `E: Environment<Action = i64>` so the existing `&[i64]` step signature is preserved end-to-end.

A minimal continuous-action env (`ContinuousLqr`, 1D LQR with `type Action = Vec<f32>;`) is added as an existence proof that the trait compiles with non-`i64` actions. SAC, TD3, and any continuous-action policy/trainer are explicitly out of scope and tracked as follow-ups.

## Strategy choice (A vs B)

Strategy A (associated `Action` type) was picked over Strategy B (parallel `ContinuousEnvironment` trait) because:

1. **One trait.** Downstream code (snapshot/restore, `EnvPool`, multi-agent simulator) does not have to branch on which trait an env implements.
2. **Cheap default for the common case.** Every discrete env in the repo gets `type Action = i64;` as a one-line addition — no behaviour change, no per-env logic forks.
3. **Orthogonal to other trait extensions.** Composes cleanly with the planned `type State` slot for env snapshotting (issue #62). Strategy B would have forced snapshot machinery to live behind a third trait or be duplicated.
4. **Generic trainers stay generic.** Discrete trainers add an `<Action = i64>` bound on their `E: Environment` parameter, which is purely additive.

Trade-off: any future call site that wants to handle *both* discrete and continuous actions polymorphically must be parametric on `E::Action` or use a sum-type wrapper. Until SAC lands, no such call site exists.

The rationale is documented in the module-level doc comment on `src/env/mod.rs`.

## Files touched

- `src/env/mod.rs` — trait gains `type Action`; module doc-comment explains Strategy A.
- `src/env/games/{cartpole,simple_bandit,pong,bucket_brigade}.rs` and `src/env/games/snake/environment.rs` — each gains `type Action = i64;`.
- `src/env/games/continuous_lqr.rs` — new ~190-line file (env + 5 unit tests).
- `src/env/games/mod.rs` — registers the new module and re-exports `ContinuousLqr`.
- `src/env/pool.rs` — constrains pool impls to `Action = i64`; documents the restriction.
- `src/multi_agent/simulator.rs` — test-only `MockEnv` gains `type Action = i64;`.

## Coordination with issue #62

Issue #62 (clone_state / restore_state) touches the same `Environment` trait and the same env impls. Both changes are additive at the trait level (#62 adds another associated type, #61 adds `type Action`), so merge order is irrelevant. A trivial textual conflict on adjacent lines in `src/env/mod.rs` is the only expected friction — Doctor's lane to resolve at merge time, not Builder's.

## Out of scope (intentionally)

Per the issue body:

- SAC / TD3 / DDPG trainer.
- Migrating `MlpPolicy` to a Gaussian head.
- Continuous-action support in WASM inference.
- A pool variant for continuous-action envs.

## Test plan

- [x] `cargo build --features training --release` — succeeds.
- [x] `cargo build --features training --examples` — succeeds (all existing examples unchanged).
- [x] `cargo build --features training,env-bucket-brigade` — succeeds.
- [x] `cargo test --features training --lib` — 203 passed (5 new `continuous_lqr` tests included).
- [x] `cargo test --features training,env-bucket-brigade` — 203 passed.
- [x] `cargo +nightly fmt --check` — clean.
- [x] `cargo +nightly doc --no-deps --all-features` with `RUSTDOCFLAGS="-D warnings"` — zero warnings.

Closes #61