### PR TITLE
Add Environment::clone_state / restore_state for MCTS and replay

### DIFF
--- a/src/env/games/bucket_brigade.rs
+++ b/src/env/games/bucket_brigade.rs
@@ -146,6 +146,14 @@ impl BucketBrigadeMaEnv {
 impl Environment for BucketBrigadeMaEnv {
     type Action = i64;
 
+    /// Snapshot type for the single-agent `Environment` adapter.
+    ///
+    /// **Stub**: `bucket_brigade_core::BucketBrigade` does not expose a
+    /// snapshot/restore API, so this implementation is currently a no-op.
+    /// `clone_state` returns `()` and `restore_state` does nothing. Wiring up
+    /// real snapshots requires upstream support in `bucket_brigade_core`.
+    type State = ();
+
     fn reset(&mut self) {
         let _ = BucketBrigadeMaEnv::reset(self, None);
     }
@@ -186,6 +194,15 @@ impl Environment for BucketBrigadeMaEnv {
     }
 
     fn close(&mut self) {}
+
+    /// Stub: returns `()`. The underlying `bucket_brigade_core::BucketBrigade`
+    /// engine does not currently expose snapshot/restore; calling this is a
+    /// no-op for now and the returned snapshot cannot meaningfully be used
+    /// with `restore_state`.
+    fn clone_state(&self) {}
+
+    /// Stub: does nothing. See [`Self::clone_state`] for the limitation.
+    fn restore_state(&mut self, _state: &()) {}
 }
 
 // -------- Multi-agent factored action surface --------

--- a/src/env/games/cartpole.rs
+++ b/src/env/games/cartpole.rs
@@ -23,10 +23,37 @@ use rand::Rng;
 
 use crate::env::{Environment, SpaceInfo, SpaceType, StepInfo, StepResult};
 
+/// Snapshot of CartPole's simulation state.
+///
+/// CartPole is fully deterministic on a per-step basis (the only RNG use is
+/// inside `reset_state`, which is not called during stepping), so
+/// `restore_state` followed by `step(a)` reproduces the same [`StepResult`]
+/// as the original step at the time of snapshot.
+#[derive(Debug, Clone)]
+pub struct CartPoleState {
+    /// Cart position
+    pub x: f32,
+    /// Cart velocity
+    pub x_dot: f32,
+    /// Pole angle (radians)
+    pub theta: f32,
+    /// Pole angular velocity
+    pub theta_dot: f32,
+    /// Step counter
+    pub steps: usize,
+}
+
 /// CartPole-v1 environment
 ///
 /// A pole is attached to a cart moving along a frictionless track.
 /// The goal is to balance the pole by applying forces to the cart.
+///
+/// # Snapshot semantics
+///
+/// CartPole's [`Environment::clone_state`] / [`Environment::restore_state`]
+/// pair is **fully deterministic**: restoring a snapshot and calling
+/// `step(action)` produces the exact same [`StepResult`] as the original
+/// step. CartPole only consumes RNG during `reset()`, not during stepping.
 #[derive(Debug)]
 pub struct CartPole {
     // State variables
@@ -183,6 +210,7 @@ impl Default for CartPole {
 
 impl Environment for CartPole {
     type Action = i64;
+    type State = CartPoleState;
 
     fn reset(&mut self) {
         self.reset_state();
@@ -231,6 +259,24 @@ impl Environment for CartPole {
 
     fn close(&mut self) {
         // Nothing to clean up
+    }
+
+    fn clone_state(&self) -> CartPoleState {
+        CartPoleState {
+            x: self.x,
+            x_dot: self.x_dot,
+            theta: self.theta,
+            theta_dot: self.theta_dot,
+            steps: self.steps,
+        }
+    }
+
+    fn restore_state(&mut self, state: &CartPoleState) {
+        self.x = state.x;
+        self.x_dot = state.x_dot;
+        self.theta = state.theta;
+        self.theta_dot = state.theta_dot;
+        self.steps = state.steps;
     }
 }
 
@@ -364,6 +410,31 @@ mod tests {
         // spaces are not strictly defined.
         assert_eq!(action_space.shape, vec![2]);
         assert!(matches!(action_space.space_type, SpaceType::Discrete(2)));
+    }
+
+    #[test]
+    fn clone_restore_round_trips() {
+        let mut env = CartPole::new();
+        env.reset();
+
+        // Step a few times to a non-initial state.
+        for i in 0..5 {
+            env.step((i % 2) as i64);
+        }
+        let snap = env.clone_state();
+
+        // Take an experimental step.
+        let r1 = env.step(1);
+
+        // Restore and take the same step again.
+        env.restore_state(&snap);
+        let r2 = env.step(1);
+
+        // CartPole is fully deterministic — observation and reward must match.
+        assert_eq!(r1.observation, r2.observation);
+        assert_eq!(r1.reward, r2.reward);
+        assert_eq!(r1.terminated, r2.terminated);
+        assert_eq!(r1.truncated, r2.truncated);
     }
 
     #[test]

--- a/src/env/games/continuous_lqr.rs
+++ b/src/env/games/continuous_lqr.rs
@@ -18,6 +18,21 @@
 
 use crate::env::{Environment, SpaceInfo, SpaceType, StepInfo, StepResult};
 
+/// Snapshot of [`ContinuousLqr`]'s simulation state.
+///
+/// `ContinuousLqr` is fully deterministic (no internal RNG), so
+/// [`Environment::restore_state`] followed by [`Environment::step`] reproduces
+/// every subsequent [`StepResult`] bit-for-bit.
+#[derive(Debug, Clone)]
+pub struct ContinuousLqrState {
+    /// Position scalar.
+    pub position: f32,
+    /// Velocity scalar.
+    pub velocity: f32,
+    /// Step counter.
+    pub steps: usize,
+}
+
 /// Force clamp range applied to the 1D action input.
 const ACTION_CLAMP: f32 = 1.0;
 
@@ -79,6 +94,10 @@ impl Environment for ContinuousLqr {
     /// `[-ACTION_CLAMP, ACTION_CLAMP]` are clamped.
     type Action = Vec<f32>;
 
+    /// Snapshot type. `ContinuousLqr` is deterministic (no RNG), so
+    /// restore + step reproduces subsequent results exactly.
+    type State = ContinuousLqrState;
+
     fn reset(&mut self) {
         self.position = 0.5;
         self.velocity = 0.0;
@@ -130,6 +149,16 @@ impl Environment for ContinuousLqr {
     }
 
     fn close(&mut self) {}
+
+    fn clone_state(&self) -> ContinuousLqrState {
+        ContinuousLqrState { position: self.position, velocity: self.velocity, steps: self.steps }
+    }
+
+    fn restore_state(&mut self, state: &ContinuousLqrState) {
+        self.position = state.position;
+        self.velocity = state.velocity;
+        self.steps = state.steps;
+    }
 }
 
 #[cfg(test)]

--- a/src/env/games/pong.rs
+++ b/src/env/games/pong.rs
@@ -18,8 +18,46 @@ const OPPONENT_SPEED: f32 = 0.015;
 const MAX_SCORE: u32 = 7;
 const MAX_STEPS: usize = 2000;
 
+/// Snapshot of a [`Pong`] instance's simulation state.
+///
+/// Captures ball position/velocity, paddle positions, scores, and step
+/// counter. Does **not** capture the thread-local RNG used by `serve` (which
+/// fires on every scoring event). After `restore_state`, a step that does
+/// not trigger a serve is fully reproducible; a step that scores will
+/// produce a serve toward a freshly sampled direction.
+#[derive(Debug, Clone)]
+pub struct PongState {
+    /// Ball x position
+    pub ball_x: f32,
+    /// Ball y position
+    pub ball_y: f32,
+    /// Ball x velocity
+    pub ball_dx: f32,
+    /// Ball y velocity
+    pub ball_dy: f32,
+    /// Left paddle y position
+    pub left_y: f32,
+    /// Right paddle y position
+    pub right_y: f32,
+    /// Left score
+    pub left_score: u32,
+    /// Right score
+    pub right_score: u32,
+    /// Step counter
+    pub steps: usize,
+}
+
 /// Single-player Pong: agent controls left paddle, rule-based opponent on
 /// right.
+///
+/// # Snapshot semantics
+///
+/// `clone_state` / `restore_state` capture ball state, paddles, scores and
+/// step counter, but **not** the thread-local RNG used by `serve` (the
+/// random ball direction/height sampled after every score). Trajectories
+/// that do not score (no ball exiting through either edge) are fully
+/// reproducible after `restore_state`; scoring steps will redraw a new
+/// random serve and so are *not* reproduced bit-for-bit.
 pub struct Pong {
     ball_x: f32,
     ball_y: f32,
@@ -193,6 +231,7 @@ impl Default for Pong {
 
 impl Environment for Pong {
     type Action = i64;
+    type State = PongState;
 
     fn reset(&mut self) {
         self.left_y = 0.5;
@@ -305,6 +344,32 @@ impl Environment for Pong {
     }
 
     fn close(&mut self) {}
+
+    fn clone_state(&self) -> PongState {
+        PongState {
+            ball_x: self.ball_x,
+            ball_y: self.ball_y,
+            ball_dx: self.ball_dx,
+            ball_dy: self.ball_dy,
+            left_y: self.left_y,
+            right_y: self.right_y,
+            left_score: self.left_score,
+            right_score: self.right_score,
+            steps: self.steps,
+        }
+    }
+
+    fn restore_state(&mut self, state: &PongState) {
+        self.ball_x = state.ball_x;
+        self.ball_y = state.ball_y;
+        self.ball_dx = state.ball_dx;
+        self.ball_dy = state.ball_dy;
+        self.left_y = state.left_y;
+        self.right_y = state.right_y;
+        self.left_score = state.left_score;
+        self.right_score = state.right_score;
+        self.steps = state.steps;
+    }
 }
 
 #[cfg(test)]
@@ -364,6 +429,49 @@ mod tests {
         for (a, b) in obs.iter().zip(unmirrored.iter()) {
             assert!((a - b).abs() < 1e-7, "round-trip mismatch: {a} vs {b}");
         }
+    }
+
+    /// Snapshotting Pong on a step that does not score must round-trip
+    /// exactly: replaying `step(action)` after `restore_state` gives the same
+    /// StepResult.
+    #[test]
+    fn clone_restore_round_trips() {
+        let mut env = Pong::new();
+        env.reset();
+
+        // Set ball state explicitly to a configuration that won't score in
+        // one step: the ball is centered with a small velocity, so scoring
+        // cannot happen in a few steps regardless of paddle action.
+        env.ball_x = 0.5;
+        env.ball_y = 0.5;
+        env.ball_dx = BALL_SPEED;
+        env.ball_dy = 0.0;
+        env.left_y = 0.5;
+        env.right_y = 0.5;
+        env.left_score = 0;
+        env.right_score = 0;
+        env.steps = 0;
+
+        // Step a few times to reach a non-initial state, still far from
+        // scoring.
+        for _ in 0..3 {
+            env.step(1);
+        }
+        let snap = env.clone_state();
+
+        // Take an experimental step.
+        let r1 = env.step(2);
+
+        // Restore and take the same step again.
+        env.restore_state(&snap);
+        let r2 = env.step(2);
+
+        // No scoring event => fully deterministic: observation, reward,
+        // termination must all match.
+        assert_eq!(r1.observation, r2.observation);
+        assert_eq!(r1.reward, r2.reward);
+        assert_eq!(r1.terminated, r2.terminated);
+        assert_eq!(r1.truncated, r2.truncated);
     }
 
     /// The mirror transformation must negate x components and swap paddle

--- a/src/env/games/simple_bandit.rs
+++ b/src/env/games/simple_bandit.rs
@@ -15,7 +15,33 @@ use rand::{Rng, SeedableRng};
 
 use crate::env::{Environment, SpaceInfo, SpaceType, StepInfo, StepResult};
 
-/// Simple contextual bandit for testing PPO correctness
+/// Snapshot of SimpleBandit's simulation state.
+///
+/// Captures the visible state (current context and step counter) but **not**
+/// the internal RNG. After `restore_state`, the next `step` will compute the
+/// reward using the restored `state`, and `terminated` matches the original
+/// trajectory. However, the *next sampled state* (drawn from the bandit's
+/// internal RNG inside `step`) is **not** reproduced: see the per-env
+/// snapshot semantics in [`SimpleBandit`].
+#[derive(Debug, Clone)]
+pub struct SimpleBanditState {
+    /// Current context (0.0 or 1.0)
+    pub state: f32,
+    /// Step counter
+    pub steps: usize,
+}
+
+/// Simple contextual bandit for testing PPO correctness.
+///
+/// # Snapshot semantics
+///
+/// `clone_state` / `restore_state` capture the current context and step
+/// counter, so the next `step(action)` produces the same `reward` and
+/// `terminated` flag it would have at snapshot time. The bandit's internal
+/// `StdRng` is **not** captured: the *next* state sampled inside `step` will
+/// differ between the snapshotted run and the restored run, so the
+/// `observation` returned by `step` is not reproduced bit-for-bit. The reward
+/// for the action taken at the snapshot point is still deterministic.
 #[derive(Debug)]
 pub struct SimpleBandit {
     state: f32,
@@ -39,6 +65,7 @@ impl Default for SimpleBandit {
 
 impl Environment for SimpleBandit {
     type Action = i64;
+    type State = SimpleBanditState;
 
     fn reset(&mut self) {
         // Random start state (0 or 1)
@@ -94,6 +121,15 @@ impl Environment for SimpleBandit {
     fn close(&mut self) {
         // Nothing to clean up
     }
+
+    fn clone_state(&self) -> SimpleBanditState {
+        SimpleBanditState { state: self.state, steps: self.steps }
+    }
+
+    fn restore_state(&mut self, state: &SimpleBanditState) {
+        self.state = state.state;
+        self.steps = state.steps;
+    }
 }
 
 #[cfg(test)]
@@ -118,6 +154,36 @@ mod tests {
         env.state = 1.0;
         let result = env.step(0);
         assert_eq!(result.reward, 0.0);
+    }
+
+    #[test]
+    fn clone_restore_round_trips() {
+        let mut env = SimpleBandit::new();
+        env.reset();
+
+        // Step a few times to a non-initial state.
+        for _ in 0..5 {
+            env.step(0);
+        }
+        let snap = env.clone_state();
+        let pre_state = env.state;
+        let pre_steps = env.steps;
+
+        // Take an experimental step.
+        let r1 = env.step(pre_state as i64);
+
+        // Restore and take the same step again.
+        env.restore_state(&snap);
+        assert_eq!(env.state, pre_state, "state must round-trip");
+        assert_eq!(env.steps, pre_steps, "steps must round-trip");
+
+        let r2 = env.step(pre_state as i64);
+
+        // Reward depends only on (state, action) and is fully deterministic.
+        assert_eq!(r1.reward, r2.reward);
+        assert_eq!(r1.terminated, r2.terminated);
+        // observation reflects the *next* random state, which is not
+        // reproduced by restore_state (RNG is not snapshotted).
     }
 
     #[test]

--- a/src/env/games/snake/environment.rs
+++ b/src/env/games/snake/environment.rs
@@ -12,7 +12,45 @@ use super::{
 };
 use crate::env::{Environment, SpaceInfo, SpaceType, StepInfo, StepResult};
 
-/// Multi-agent Snake environment
+/// Snapshot of a [`SnakeEnv`]'s simulation state.
+///
+/// Captures every visible field of the env (grid, snake positions, food
+/// position, score, step count, done flag) but **not** the RNG used by
+/// `thread_rng()` inside `step` for food respawn. After `restore_state`, any
+/// step that triggers a food respawn will sample a different food location
+/// than the original trajectory.
+#[derive(Debug, Clone)]
+pub struct SnakeEnvState {
+    /// Grid width
+    pub width: i32,
+    /// Grid height
+    pub height: i32,
+    /// All snakes
+    pub snakes: Vec<super::snake::Snake>,
+    /// Number of agents
+    pub num_agents: usize,
+    /// Food position
+    pub food: Position,
+    /// Episode counter
+    pub episode: usize,
+    /// Step counter
+    pub steps: usize,
+    /// Maximum steps per episode
+    pub max_steps: usize,
+    /// Done flag
+    pub done: bool,
+}
+
+/// Multi-agent Snake environment.
+///
+/// # Snapshot semantics
+///
+/// `clone_state` / `restore_state` capture every visible env field (grid,
+/// snake bodies, food location, score, step count, done flag). They do
+/// **not** capture the thread-local RNG used by `step` to respawn food: if
+/// the restored trajectory triggers a food respawn, the new food spawns at a
+/// different location than in the original. Trajectories that do not eat
+/// food are fully reproducible.
 #[derive(Debug, Clone)]
 pub struct SnakeEnv {
     /// Grid width
@@ -527,6 +565,7 @@ impl SnakeEnv {
 
 impl Environment for SnakeEnv {
     type Action = i64;
+    type State = SnakeEnvState;
 
     fn reset(&mut self) {
         self.reset();
@@ -560,5 +599,75 @@ impl Environment for SnakeEnv {
 
     fn close(&mut self) {
         // Nothing to clean up
+    }
+
+    fn clone_state(&self) -> SnakeEnvState {
+        SnakeEnvState {
+            width: self.width,
+            height: self.height,
+            snakes: self.snakes.clone(),
+            num_agents: self.num_agents,
+            food: self.food,
+            episode: self.episode,
+            steps: self.steps,
+            max_steps: self.max_steps,
+            done: self.done,
+        }
+    }
+
+    fn restore_state(&mut self, state: &SnakeEnvState) {
+        self.width = state.width;
+        self.height = state.height;
+        self.snakes = state.snakes.clone();
+        self.num_agents = state.num_agents;
+        self.food = state.food;
+        self.episode = state.episode;
+        self.steps = state.steps;
+        self.max_steps = state.max_steps;
+        self.done = state.done;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clone_restore_round_trips() {
+        let mut env = SnakeEnv::new(10, 10);
+        env.reset();
+
+        // Step a few times to a non-initial state.
+        for i in 0..5 {
+            env.step((i % 4) as i64);
+        }
+        let snap = env.clone_state();
+
+        // Snapshot must capture every visible field.
+        assert_eq!(env.steps, snap.steps);
+        assert_eq!(env.food, snap.food);
+        assert_eq!(env.snakes.len(), snap.snakes.len());
+
+        // Take an experimental step.
+        let r1 = env.step(0);
+        let post_food_1 = env.food;
+        let post_steps_1 = env.steps;
+
+        // Restore and take the same step again.
+        env.restore_state(&snap);
+        assert_eq!(env.steps, snap.steps);
+        assert_eq!(env.food, snap.food);
+
+        let r2 = env.step(0);
+
+        // Snake's `step` is deterministic except for food respawn, which only
+        // fires when food is eaten. With identical action and snapshot the
+        // observation/reward must match.
+        assert_eq!(r1.observation, r2.observation);
+        assert_eq!(r1.reward, r2.reward);
+        assert_eq!(r1.terminated, r2.terminated);
+        assert_eq!(r1.truncated, r2.truncated);
+        assert_eq!(env.food, post_food_1);
+        assert_eq!(env.steps, post_steps_1);
     }
 }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -46,6 +46,19 @@
 //! continuous actions polymorphically must either be parametric on
 //! `E::Action` or use a sum-type wrapper. Until SAC lands, no such
 //! call site exists in Thrust.
+//!
+//! # Env state snapshots (`type State` / `clone_state` / `restore_state`)
+//!
+//! The `Environment` trait also exposes a `type State` associated type
+//! plus `clone_state` / `restore_state` methods so callers (MCTS-style
+//! search, replay tooling) can snapshot env state and roll out
+//! hypothetical trajectories without restarting from `reset()`. The
+//! determinism contract is per-env: fully deterministic envs (e.g.
+//! CartPole, ContinuousLqr) reproduce every subsequent step bit-for-bit
+//! after restore; envs that consume internal RNG (Snake food respawn,
+//! Pong ball serve) snapshot the simulation step but not the RNG, so
+//! reproduction is deterministic only across steps that do not draw
+//! from the RNG. Per-env docs spell out the exact guarantee.
 
 use anyhow::Result;
 
@@ -63,6 +76,19 @@ pub trait Environment {
     /// constrain `E: Environment<Action = i64>` to keep the
     /// type signature compatible.
     type Action;
+
+    /// Snapshot type for this env. For fully deterministic envs without
+    /// internal RNG, this is the complete env state and `restore_state`
+    /// reproduces every subsequent step exactly. For envs that consume an
+    /// internal RNG (e.g. ball serve direction, food placement), the snapshot
+    /// captures the simulation step but not the RNG; see the env-level
+    /// documentation for which fields are preserved.
+    ///
+    /// This associated type lets callers (MCTS-style search, replay tooling)
+    /// snapshot and later restore env state without re-running from
+    /// [`Environment::reset`]. The exact determinism guarantee is documented
+    /// per env.
+    type State;
 
     /// Reset the environment and return initial observation
     fn reset(&mut self);
@@ -84,6 +110,25 @@ pub trait Environment {
 
     /// Close the environment
     fn close(&mut self);
+
+    /// Snapshot the current env state for later restoration.
+    ///
+    /// The returned value can be passed back to
+    /// [`Environment::restore_state`] to rewind the env. For envs with
+    /// internal RNG this captures the simulation step only — the determinism
+    /// guarantee is documented per env.
+    fn clone_state(&self) -> Self::State;
+
+    /// Restore the env to a previously-snapshotted state.
+    ///
+    /// After this call, the env's observable state (the value returned by
+    /// [`Environment::get_observation`]) matches the state at the time of the
+    /// snapshot. For purely deterministic envs, the next call to
+    /// [`Environment::step`] with a given action produces the same
+    /// [`StepResult`] as it would have at the time the snapshot was taken.
+    /// For envs with internal RNG, see per-env docs for the exact
+    /// reproducibility contract.
+    fn restore_state(&mut self, state: &Self::State);
 }
 
 /// Result of an environment step

--- a/src/multi_agent/simulator.rs
+++ b/src/multi_agent/simulator.rs
@@ -284,6 +284,7 @@ mod tests {
 
     impl Environment for MockEnv {
         type Action = i64;
+        type State = ();
 
         fn reset(&mut self) {}
 
@@ -314,6 +315,10 @@ mod tests {
         }
 
         fn close(&mut self) {}
+
+        fn clone_state(&self) {}
+
+        fn restore_state(&mut self, _state: &()) {}
     }
 
     impl MultiAgentEnvironment for MockEnv {

--- a/tests/test_env_state.rs
+++ b/tests/test_env_state.rs
@@ -1,0 +1,79 @@
+//! Smoke tests for the `Environment::clone_state` /
+//! `Environment::restore_state` pair added in issue #62.
+//!
+//! These exercise the snapshot/restore contract from the perspective of a
+//! caller that would build a real MCTS-style rollout-and-return loop on top of
+//! the trait.
+
+use thrust_rl::env::{CartPole, Environment};
+
+/// MCTS-like rollout: snapshot, take a few steps, restore, replay the first
+/// step from the snapshot, and verify it matches the first step of the
+/// rollout. CartPole is deterministic per step, so observation, reward,
+/// terminated, and truncated must all match exactly.
+#[test]
+fn cartpole_mcts_like_rollout() {
+    let mut env = CartPole::new();
+    env.reset();
+
+    // Drive the env into a deterministic, non-initial state by stepping past
+    // the random `reset_state` perturbation a few times.
+    for _ in 0..3 {
+        env.step(1);
+    }
+
+    let snap = env.clone_state();
+
+    // Rollout: 3 deterministic actions from the snapshot.
+    let actions = [1_i64, 0, 1];
+    let mut results = Vec::with_capacity(actions.len());
+    for &a in &actions {
+        results.push(env.step(a));
+    }
+
+    // Restore and verify a single step from the original snapshot produces
+    // the same first result as the rollout.
+    env.restore_state(&snap);
+    let same_first = env.step(actions[0]);
+
+    assert_eq!(same_first.observation, results[0].observation);
+    assert_eq!(same_first.reward, results[0].reward);
+    assert_eq!(same_first.terminated, results[0].terminated);
+    assert_eq!(same_first.truncated, results[0].truncated);
+}
+
+/// Snapshot must allow multiple independent rollouts from the same base state
+/// (the canonical MCTS use case). Each rollout must produce identical results
+/// when given the same action sequence.
+#[test]
+fn cartpole_repeated_rollouts_from_snapshot() {
+    let mut env = CartPole::new();
+    env.reset();
+    for _ in 0..2 {
+        env.step(0);
+    }
+    let snap = env.clone_state();
+
+    let actions = [1_i64, 1, 0, 0, 1];
+
+    // Rollout #1
+    let mut run1 = Vec::with_capacity(actions.len());
+    for &a in &actions {
+        run1.push(env.step(a));
+    }
+
+    // Restore and roll out a second time with the same actions.
+    env.restore_state(&snap);
+    let mut run2 = Vec::with_capacity(actions.len());
+    for &a in &actions {
+        run2.push(env.step(a));
+    }
+
+    assert_eq!(run1.len(), run2.len());
+    for (i, (a, b)) in run1.iter().zip(run2.iter()).enumerate() {
+        assert_eq!(a.observation, b.observation, "obs mismatch at step {}", i);
+        assert_eq!(a.reward, b.reward, "reward mismatch at step {}", i);
+        assert_eq!(a.terminated, b.terminated, "terminated mismatch at step {}", i);
+        assert_eq!(a.truncated, b.truncated, "truncated mismatch at step {}", i);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an associated `State` type and `clone_state` / `restore_state` methods to the `Environment` trait so callers (MCTS-style search, replay tooling) can snapshot env state and roll out hypothetical trajectories without re-running from `reset()`. Implements the new methods for every existing env.

Closes #62.

## Per-env snapshot semantics

| Env | Restore guarantee | RNG capture |
|---|---|---|
| `CartPole` | Fully deterministic per step (RNG only in `reset`) | n/a |
| `SimpleBandit` | Reward for next step is reproduced; observation (next sampled context) is not | No (`StdRng` not snapshotted) |
| `SnakeEnv` | Deterministic on steps that don't respawn food | No (`thread_rng()` not snapshotted) |
| `Pong` | Deterministic on steps that don't score | No (`thread_rng()` not snapshotted) |
| `BucketBrigadeMaEnv` | Stub: `type State = ()`, both methods no-op | n/a (engine has no snapshot API) |

The caveat in each env that uses RNG is documented in the env's docstring as well as on its `State` struct.

## Tests

- Per-env unit tests `clone_restore_round_trips` covering the round-trip invariant under each env's documented determinism contract (CartPole, SimpleBandit, Pong, SnakeEnv).
- New integration tests in `tests/test_env_state.rs` exercising the MCTS-like rollout pattern on CartPole:
  - `cartpole_mcts_like_rollout` — snapshot, rollout 3 steps, restore, replay first step, assert equality with the original first rollout step.
  - `cartpole_repeated_rollouts_from_snapshot` — two identical rollouts from the same snapshot must produce identical results.

## Coordination with #61

Both this PR and #61 (continuous Box action spaces) add an associated type to the same `Environment` trait and touch every env's `impl Environment` block. The merge conflict is purely additive — resolution is to keep **both** `type Action = ...;` (from #61) and `type State = ...;` (this PR) inside each impl. No semantic conflict; nothing in this PR touches action-related code.

## Out of scope (per issue body)

- MCTS algorithm itself (separate follow-up).
- Continuous action support (#61).
- Persisting / serializing snapshots to disk.

## Test plan

- [x] `cargo build --features training --release`
- [x] `cargo build --features env-bucket-brigade`
- [x] `cargo test --features training` (all 202 lib tests + integration tests pass; new tests run green)
- [x] `cargo test --all-features` passes
- [x] `cargo +nightly fmt --check` clean
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo +nightly doc --no-deps --all-features` produces 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)