### PR TITLE
chore(web): ignore wasm-pack output and lockfile from npm

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -12,6 +12,12 @@ dist
 dist-ssr
 *.local
 
+# Build artifacts
+public/pkg/
+
+# Wrong package manager — this repo uses pnpm
+package-lock.json
+
 # Playwright
 /test-results/
 /playwright-report/


### PR DESCRIPTION
## Summary
- Adds `web/public/pkg/` (wasm-pack output, regenerated by CI on every deploy) to `web/.gitignore`
- Adds `web/package-lock.json` — repo uses pnpm, so an npm lockfile shouldn't ever land

## Test plan
- [ ] Confirm `pnpm install` in `web/` still works as expected
- [ ] Confirm CI deploy still publishes wasm-pack output