### PR TITLE
Pong web demo: prefer self-play model with rule-based fallback

### DIFF
--- a/web/src/components/Pong/loadPongModel.ts
+++ b/web/src/components/Pong/loadPongModel.ts
@@ -1,0 +1,50 @@
+// Shared helper for resolving which Pong model JSON to load.
+//
+// Prefers the self-play artifact (`pong_self_play_model.json`) when it is
+// present, and transparently falls back to the rule-based artifact
+// (`pong_model.json`) otherwise. The raw JSON text is returned so callers can
+// either feed it into the WASM policy loader (`load_policy_json`) or parse it
+// for metadata display.
+
+export type PongModelSource = "self-play" | "rule-based";
+
+export interface PongModelResult {
+	json: string;
+	source: PongModelSource;
+}
+
+const SELF_PLAY_FILENAME = "pong_self_play_model.json";
+const RULE_BASED_FILENAME = "pong_model.json";
+
+export async function fetchPongModelJson(
+	baseUrl: string,
+): Promise<PongModelResult> {
+	// Try self-play first.
+	try {
+		const response = await fetch(`${baseUrl}${SELF_PLAY_FILENAME}`);
+		if (response.ok) {
+			const json = await response.text();
+			console.log(`Pong model loaded: ${SELF_PLAY_FILENAME} (self-play)`);
+			return { json, source: "self-play" };
+		}
+		// Non-OK (e.g. 404) — fall through to rule-based.
+		console.log(
+			`No ${SELF_PLAY_FILENAME} (HTTP ${response.status}); falling back to ${RULE_BASED_FILENAME}`,
+		);
+	} catch (e) {
+		console.warn(
+			`Error fetching ${SELF_PLAY_FILENAME}; falling back to ${RULE_BASED_FILENAME}:`,
+			e,
+		);
+	}
+
+	// Fallback: rule-based artifact. Let the caller handle errors here so the
+	// "no model file" path can still surface a heuristic agent.
+	const response = await fetch(`${baseUrl}${RULE_BASED_FILENAME}`);
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status}`);
+	}
+	const json = await response.text();
+	console.log(`Pong model loaded: ${RULE_BASED_FILENAME} (rule-based)`);
+	return { json, source: "rule-based" };
+}

--- a/web/src/components/Pong/usePong.ts
+++ b/web/src/components/Pong/usePong.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { WasmPong } from "../../lib/wasm";
 import { initWasm } from "../../lib/wasm";
+import { fetchPongModelJson, type PongModelSource } from "./loadPongModel";
 
 export interface PongState {
 	ballX: number;
@@ -21,6 +22,7 @@ export interface UsePongResult {
 	speed: number;
 	actualFps: number;
 	modelLoaded: boolean;
+	modelSource: PongModelSource | null;
 	start: () => void;
 	pause: () => void;
 	reset: () => void;
@@ -42,6 +44,7 @@ export function usePong(): UsePongResult {
 	const [speed, setSpeed] = useState(1);
 	const [actualFps, setActualFps] = useState(0);
 	const [modelLoaded, setModelLoaded] = useState(false);
+	const [modelSource, setModelSource] = useState<PongModelSource | null>(null);
 
 	const envRef = useRef<WasmPong | null>(null);
 	const frameIdRef = useRef<number | null>(null);
@@ -59,14 +62,13 @@ export function usePong(): UsePongResult {
 				envRef.current = new wasm.WasmPong();
 
 				try {
-					const response = await fetch(
-						`${import.meta.env.BASE_URL}pong_model.json`,
+					const { json, source } = await fetchPongModelJson(
+						import.meta.env.BASE_URL,
 					);
-					if (!response.ok) throw new Error(`HTTP ${response.status}`);
-					const modelJson = await response.text();
-					envRef.current.load_policy_json(modelJson);
+					envRef.current.load_policy_json(json);
 					setModelLoaded(true);
-					console.log("Pong policy loaded");
+					setModelSource(source);
+					console.log(`Pong policy loaded (${source})`);
 				} catch (e) {
 					console.warn("No Pong policy found, using heuristic:", e);
 				}
@@ -206,6 +208,7 @@ export function usePong(): UsePongResult {
 		speed,
 		actualFps,
 		modelLoaded,
+		modelSource,
 		start,
 		pause,
 		reset,

--- a/web/src/pages/PongPage.tsx
+++ b/web/src/pages/PongPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import PongCanvas from "../components/Pong/PongCanvas";
 import PongControls from "../components/Pong/PongControls";
+import { fetchPongModelJson } from "../components/Pong/loadPongModel";
 import { usePong } from "../components/Pong/usePong";
 import GamePageLayout from "../components/GamePageLayout";
 
@@ -32,9 +33,8 @@ export default function PongPage() {
 	useEffect(() => {
 		async function loadModelInfo() {
 			try {
-				const response = await fetch(`${import.meta.env.BASE_URL}pong_model.json`);
-				if (!response.ok) throw new Error(`HTTP ${response.status}`);
-				setModelInfo(await response.json());
+				const { json } = await fetchPongModelJson(import.meta.env.BASE_URL);
+				setModelInfo(JSON.parse(json));
 			} catch (e) {
 				console.warn("Failed to load Pong model info:", e);
 			}
@@ -54,12 +54,17 @@ export default function PongPage() {
 
 	const controls = <PongControls pong={pong} />;
 
+	const opponentDescription =
+		pong.modelSource === "self-play"
+			? "a copy of itself (red, right)"
+			: "the rule-based opponent (red, right)";
+
 	const gameDynamics = (
 		<>
 			<p className="text-gray-600 mb-4">
-				Classic Pong: the agent (blue, left) must return the ball past the
-				rule-based opponent (red, right). First to 7 points wins, or the episode
-				ends at 2000 steps.
+				Classic Pong: the agent (blue, left) must return the ball past{" "}
+				{opponentDescription}. First to 7 points wins, or the episode ends at
+				2000 steps.
 			</p>
 
 			<div className="grid md:grid-cols-2 gap-6">
@@ -157,7 +162,7 @@ export default function PongPage() {
 		<>
 			<p className="text-gray-600 mb-4">
 				{modelInfo?.metadata?.algorithm ?? "PPO (Proximal Policy Optimization)"}{" "}
-				agent trained against a rule-based opponent.
+				agent plays the left paddle.
 			</p>
 
 			<div className="grid md:grid-cols-2 gap-6">
@@ -244,7 +249,9 @@ export default function PongPage() {
 				<p className="text-sm text-blue-900">
 					<strong>Status:</strong>{" "}
 					{pong.modelLoaded
-						? "Model loaded — PPO policy active"
+						? pong.modelSource === "self-play"
+							? "PPO policy active (self-play trained)"
+							: "PPO policy active (rule-based opponent)"
 						: "No model file — using heuristic agent"}
 				</p>
 				{modelInfo?.metadata?.notes && (


### PR DESCRIPTION
## Summary

- Adds `web/src/components/Pong/loadPongModel.ts`, a shared helper that fetches `pong_self_play_model.json` first and falls back to `pong_model.json` on any non-OK response. Returns `{ json, source: 'self-play' | 'rule-based' }` so both the page (which needs parsed `ModelInfo`) and the hook (which feeds raw text into `load_policy_json`) can share resolution logic.
- `usePong` now exposes `modelSource: PongModelSource | null` alongside `modelLoaded`, so consumers can distinguish which variant is active.
- `PongPage.tsx`: (1) the game-dynamics blurb is conditional on the source ("a copy of itself" vs "the rule-based opponent"), (2) the algorithm intro is generalized to "agent plays the left paddle" (the specific algorithm string is already driven by `modelInfo.metadata.algorithm`, so the page automatically shows "PPO + self-play" once the new artifact is deployed), and (3) the bottom Status box now distinguishes three states: self-play trained / rule-based opponent / heuristic agent.

No artifact required to merge: when only `pong_model.json` is present (the current state), the fetch for `pong_self_play_model.json` returns 404 and the helper transparently uses the rule-based file — exactly the same behavior as before this PR. When the companion training-run issue lands the artifact, the page picks it up automatically.

## Test plan

- [x] `cd web && pnpm run build` — clean (TypeScript + Vite, no errors related to this change)
- [x] `cd web && pnpm run lint` — only pre-existing errors in `web/src/vite-env.d.ts` and `web/tests/*.spec.ts`, unrelated to this change
- [ ] Manual: `pnpm run dev`, open Pong page, confirm console logs which artifact loaded and status box shows "PPO policy active (rule-based opponent)" with the current artifact set
- [ ] Manual: copy `web/public/pong_model.json` to `web/public/pong_self_play_model.json` with `metadata.algorithm` edited to `"PPO + self-play"`, reload, confirm status box shows "PPO policy active (self-play trained)" and game-dynamics blurb mentions "a copy of itself"
- [ ] Manual: temporarily remove `web/public/pong_model.json` to confirm the "No model file — using heuristic agent" status path still works

Closes #74

Generated with [Claude Code](https://claude.com/claude-code)