### PR TITLE
Set up release machinery for v0.1.0

### DIFF
--- a/.claude/commands/loom/release.md
+++ b/.claude/commands/loom/release.md
@@ -1,170 +1,290 @@
-# Release Manager
+# Release Manager (thrust-rl)
 
-You are preparing a release of **Loom** from the {{workspace}} repository.
+You are preparing a release of **thrust-rl** from the {{workspace}}
+repository for upload to crates.io.
 
-## Overview
+This skill guides a careful, interactive release process. Every release
+must:
 
-This skill guides a careful, interactive release process. Every release must:
-1. Verify CI is green on main
-2. Analyze what changed since the last release
-3. Help the user decide the correct semver bump
-4. Draft and refine the CHANGELOG entry
-5. Update version across all 7 version-bearing files
-6. Commit, tag, and (with confirmation) push
-7. Create a GitHub Release to trigger the build workflow
+1. Verify CI is green on `main`.
+2. Analyze what changed since the last release tag.
+3. Help the user pick the correct semver bump
+   (pre-1.0: breaking changes go to MINOR, not MAJOR).
+4. Draft and refine the `CHANGELOG.md` entry.
+5. Update the single version-bearing file: the root `Cargo.toml`.
+6. Validate via `cargo publish --dry-run` and `cargo package --list`.
+7. Commit, tag, and (with confirmation) push.
+8. Create a GitHub Release.
+9. Hand off to the maintainer for the actual `cargo publish`.
 
-**Do not rush. Each phase requires user confirmation before proceeding.**
+**Do not rush. Each phase requires user confirmation before
+proceeding.**
 
-## Phase 1: Pre-flight Checks
+The canonical written procedure is [`docs/RELEASING.md`](../../../docs/RELEASING.md).
+This skill walks the user through it interactively.
 
-Before starting, verify the release is safe to cut:
+## Phase 1: Pre-flight checks
 
 ```bash
-# Check CI status on main
+# CI status on main
 gh run list --branch main --limit 5 --json name,conclusion --jq '.[] | "\(.name): \(.conclusion)"'
 
-# Check for open PRs that might need to land first
+# Open PRs that might need to land first
 gh pr list --state open --json number,title --jq '.[] | "#\(.number) \(.title)"'
 
-# Check for uncommitted changes
+# Working tree
 git status
+git branch --show-current
 ```
 
-Present findings to the user. If CI is failing, stop and fix first. If there are open PRs, ask if they should land before the release.
+Present findings. If CI is failing, stop and fix first. If there are
+open PRs the user thinks should land in this release, stop and let them
+land.
 
-## Phase 2: Gather Changes
+## Phase 2: Gather changes
 
 ```bash
-# Find the last release tag
+# Last release tag (empty if this is the first-ever release)
 git tag --sort=-v:refname | head -1
 
-# Show current version
-./scripts/version.sh
+# Current declared version in Cargo.toml
+grep -m1 '^version' Cargo.toml
 
-# List all commits since that tag
-git log <last-tag>..HEAD --oneline
-
-# Show the full diff stats
-git diff <last-tag>..HEAD --stat
+# Commits since that tag (or all commits if no tag)
+LAST_TAG=$(git tag --sort=-v:refname | head -1)
+if [ -n "$LAST_TAG" ]; then
+    git log "$LAST_TAG"..HEAD --oneline
+    git diff "$LAST_TAG"..HEAD --stat
+else
+    git log --oneline
+fi
 ```
 
-Present the user with:
-- **Last release**: tag name, date, and version
-- **Commits since release**: count and full list
-- **Change summary**: categorized by conventional commit prefix (feat, fix, refactor, docs, test, chore)
-- **Files changed**: high-level summary of which subsystems were touched
+Present:
+- Last release tag, date, version (or "first release" if none).
+- Commit count since the last release.
+- Categorized commit summary by conventional-commit prefix
+  (`feat`, `fix`, `refactor`, `docs`, `test`, `chore`, etc.) when the
+  repo uses them, otherwise by subsystem (algorithms, environments,
+  multi-agent, WASM, docs, infra).
 
-If there are zero commits since the last tag, stop and tell the user there's nothing to release.
+If there are zero commits since the last tag, stop and tell the user
+there is nothing to release.
 
-## Phase 3: Semver Decision
+## Phase 3: Semver decision (pre-1.0)
 
-Present a semver analysis. Reference https://semver.org:
+Until `1.0.0`, **breaking changes bump MINOR**, not MAJOR. The MAJOR
+slot is reserved for the first stable release.
 
-### Breaking Changes (MAJOR bump)
+Present an analysis. Reference https://semver.org and the pre-1.0
+convention documented in `docs/RELEASING.md`.
+
+### Breaking changes (MINOR bump while pre-1.0)
 Scan for:
-- Removed or renamed public API functions/types
-- Changed ForgeClient protocol methods
-- Changed CLI command flags/behavior
-- Changed MCP tool interfaces
-- Removed or renamed daemon commands
-- Changed config file format
+- Removed or renamed public API items
+  (functions, types, traits, methods, public fields).
+- Changed function signatures (return type, parameter type).
+- Changed default behavior of `Environment::step`, `reset`,
+  `clone_state` / `restore_state`, or `MultiAgentEnvironment`.
+- Changed `PolicyLearner` / `JointMultiAgentTrainer` constructor
+  or `train_step` shape.
+- Changes to the `ExportedModel` JSON format consumed by WASM
+  inference (this would break already-deployed browser demos).
+- Changes to `Cargo.toml` features (added/removed feature names,
+  changed feature contents).
+- Bumping the minimum supported `rustc` version (MSRV).
 
-### New Capabilities (MINOR bump)
-- New forge support (e.g., Gitea, GitLab)
-- New CLI commands (`loom-forge`, `loom-auto-merge`)
-- New agent roles or orchestration features
-- New MCP tools
-- New configuration options
+### Additive new capabilities (MINOR bump too, pre-1.0)
+- New environments, new policy heads, new training algorithms.
+- New CLI examples or scripts.
+- New optional dependencies / features.
+- New optional configuration fields.
 
-### Bug Fixes / Internal (PATCH bump)
-- Bug fixes that don't change API
-- Performance improvements
-- Internal refactoring
-- Documentation updates
-- Dependency bumps
+### Bug fixes / internal / docs (PATCH bump)
+- Bug fixes that don't change public API shape.
+- Performance improvements.
+- Internal refactoring.
+- Documentation-only updates.
+- Dependency bumps that don't break consumers.
 
-Present your recommendation and **ask the user to confirm or override**. Do not proceed until confirmed.
+Present your recommendation and **ask the user to confirm or
+override.** Do not proceed until confirmed.
 
-## Phase 4: Draft CHANGELOG
+## Phase 4: Draft CHANGELOG entry
 
-Draft a CHANGELOG entry following the existing format in `CHANGELOG.md`. Study existing entries to match style.
+Study the existing entries in `CHANGELOG.md` for style. The first
+release (`0.1.0`) uses these subsections, in order, omitting empty
+ones:
+
+- `### Added`
+  - subgroup `#### Algorithms`
+  - `#### Environments`
+  - `#### Multi-agent infrastructure`
+  - `#### WASM and browser demos`
+  - `#### Hyperparameter optimization`
+  - `#### Documentation`
+  - `#### Tooling`
+- `### Changed`
+- `### Fixed`
+- `### Removed`
+- `### Deprecated`
+- `### Security`
+- `### Known limitations`
 
 Key formatting rules:
-- Use `## [X.Y.Z] - YYYY-MM-DD` header with today's date
-- Start with a `### Summary` paragraph describing the release theme
-- Group changes under `### Added`, `### Changed`, `### Fixed`, `### Removed`, `### Renamed` as appropriate
-- Reference issue numbers with `(#NNN)` format
-- Keep descriptions concise but informative
-- Omit empty sections
+- Use `## [X.Y.Z] - YYYY-MM-DD` header with today's date in UTC.
+- Reference PR/issue numbers with `(#NNN)` format.
+- Keep descriptions short but specific (one line per change is fine).
+- Always update the link references at the bottom:
+  ```text
+  [Unreleased]: https://github.com/rjwalters/thrust/compare/vX.Y.Z...HEAD
+  [X.Y.Z]: https://github.com/rjwalters/thrust/releases/tag/vX.Y.Z
+  ```
 
-Present the draft and ask for revisions. Iterate until approved.
+Present the draft. Iterate with the user until approved.
 
-## Phase 5: Apply Changes
+## Phase 5: Apply changes
 
-Once the user approves:
+Once approved:
 
-1. **Update CHANGELOG.md**: Insert the new entry below `## [Unreleased]`
-2. **Bump version**: Run `./scripts/version.sh bump <level> --tag`
-   - This updates all 5 files: `package.json`, `mcp-loom/package.json`, 2 `Cargo.toml` files (`loom-daemon`, `loom-api`), `CLAUDE.md`
-   - Plus `Cargo.lock`
-   - Creates the commit and tag automatically
-3. **Verify**: `./scripts/version.sh check`
+1. **Update `CHANGELOG.md`**:
+   - Move `[Unreleased]` content into a new `[X.Y.Z]` section.
+   - Add the new draft content.
+   - Update the link references at the bottom.
 
-Note: The version bump script creates the commit, so commit the CHANGELOG first:
+2. **Bump `Cargo.toml`** (single version-bearing file):
+   - Edit `[package].version = "X.Y.Z"`.
+
+3. **Refresh `Cargo.lock`**:
+   ```bash
+   cargo check --no-default-features
+   ```
+   (`Cargo.lock` is gitignored in this repo, so this step is just
+   sanity to make sure nothing broke.)
+
+4. **Validate the manifest**:
+   ```bash
+   cargo publish --dry-run --no-default-features --allow-dirty
+   cargo package --list
+   ```
+
+   For the full check (requires libtorch on PATH):
+   ```bash
+   LIBTORCH_USE_PYTORCH=1 cargo publish --dry-run --allow-dirty
+   ```
+
+   If `cargo publish --dry-run` reports any errors (path-only
+   dependencies without versions, missing required metadata,
+   tarball-size limit exceeded, etc.), stop and fix.
+
+5. **Inspect tarball contents**:
+   - Check `cargo package --list` output. Confirm no model
+     checkpoints (`*.pt`, `*.safetensors`), no `web/`, no
+     `web-old/`, no `envs/bucket-brigade/`, no `scripts/`,
+     no `.loom/`, no `.claude/`, no `.github/`.
+   - If something unwanted slipped in, update the `exclude`
+     field in `Cargo.toml`'s `[package]` section.
+
+Show the user the result and ask for confirmation before committing.
+
+## Phase 6: Commit, tag, push
+
 ```bash
+# CHANGELOG first
 git add CHANGELOG.md
-git commit -m "docs: add X.Y.Z changelog entry"
-./scripts/version.sh bump <level> --tag
-# Move tag to include both commits
-git tag -f vX.Y.Z
+git commit -m "docs: prepare CHANGELOG for vX.Y.Z"
+
+# Then Cargo.toml
+git add Cargo.toml
+git commit -m "chore: bump version to vX.Y.Z"
+
+# Push to main and wait for CI
+git push origin main
 ```
 
-Show the user the result and ask for final confirmation.
+Wait for the GitHub Actions runs on the head of `main` to go green.
 
-## Phase 6: Push and Release
+```bash
+gh run watch  # or: gh run list --branch main --limit 1
+```
 
-After final confirmation:
+Then tag:
 
-1. **Push commits and tag**:
-   ```bash
-   git push origin main --tags
-   ```
+```bash
+git tag -a vX.Y.Z -m "thrust-rl vX.Y.Z"
+git push origin vX.Y.Z
+```
 
-2. **Create GitHub Release** (this triggers the build workflow):
-   ```bash
-   gh release create vX.Y.Z --title "vX.Y.Z" --notes-file - <<< "$(changelog excerpt)"
-   ```
-   Use the CHANGELOG entry as the release notes.
+## Phase 7: Create the GitHub Release
 
-3. **Verify build triggered**:
-   ```bash
-   gh run list --workflow=release.yml --limit 1
-   ```
+```bash
+gh release create vX.Y.Z \
+    --title "vX.Y.Z" \
+    --notes-file <(awk '/^## \[X\.Y\.Z\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md)
+```
 
-**Do not push or create the release without explicit user confirmation.**
+(Replace `X\.Y\.Z` in the awk pattern with the literal version, e.g.
+`/^## \[0\.1\.0\]/`. Don't forget the backslashes --- awk treats `.`
+as a metachar.)
 
-## Phase 7: Post-Release Summary
+No binary artifacts are attached today. The release notes are the
+deliverable; consumers `cargo install` if they want the code.
 
-Present a summary:
+## Phase 8: Hand off to the maintainer for `cargo publish`
+
+**Do not run `cargo publish` from an agent.** That requires a
+crates.io API token, which should not be in agent reach.
+
+Tell the user:
+
+> The repo is now in a publish-ready state. To finish the release,
+> from a clean checkout of `vX.Y.Z`:
+>
+> ```bash
+> git checkout vX.Y.Z
+> LIBTORCH_USE_PYTORCH=1 cargo publish
+> # or: cargo publish --no-verify
+> ```
+>
+> Then verify:
+> - `https://crates.io/crates/thrust-rl` shows version `X.Y.Z`.
+> - `https://docs.rs/thrust-rl/X.Y.Z/` is building (or has built).
+
+## Phase 9: Post-release summary
+
+Present:
 
 ```
 ## Release Complete
 
 - Version: vX.Y.Z
 - Commit: <sha>
-- Tag: vX.Y.Z
+- Tag: vX.Y.Z (pushed)
 - GitHub Release: created
-- Build workflow: [triggered / status]
-- CHANGELOG: updated with N items
-- Version files: 5 files + Cargo.lock updated
+- CHANGELOG entry: N items
+- Tarball size: <size> (cargo package --list count)
+- Pending maintainer action: cargo publish from main at vX.Y.Z
 ```
 
-## Important Notes
+## Important notes
 
-- **Version script**: `scripts/version.sh` is the single source of truth for version management. Never manually edit version numbers.
-- **5 version-bearing files**: `package.json`, `mcp-loom/package.json`, `loom-daemon/Cargo.toml`, `loom-api/Cargo.toml`, `CLAUDE.md`
-- **Release workflow trigger**: The build workflow (`.github/workflows/release.yml`) triggers on GitHub Release creation (`release: types: [created]`), NOT on tag push. You must create a GitHub Release via `gh release create`.
-- **Conventional commits**: This project uses conventional commit prefixes (`feat:`, `fix:`, `chore:`, etc.).
-- **Build output**: The release workflow builds `loom-daemon` binaries (Apple Silicon + Intel) and attaches them to the GitHub Release.
-- **CLAUDE.md update**: The version script updates the `**Loom Version**` line in CLAUDE.md automatically.
-- **Branch protection**: Direct pushes to main will show a ruleset bypass warning — this is expected for release commits.
+- **Single version-bearing file.** The root `Cargo.toml` is the only
+  place to edit the version. There is no `scripts/version.sh`.
+- **`Cargo.lock` is gitignored** in this repo, so version-bump commits
+  contain only `Cargo.toml` changes. That's intentional.
+- **Pre-1.0 semver.** Breaking changes go to MINOR
+  (`0.1.x -> 0.2.0`), not MAJOR. MAJOR is reserved for `1.0.0`.
+- **`env-bucket-brigade` is intentionally disabled in v0.1.0** because
+  the upstream `bucket-brigade-core` crate is path-only and not on
+  crates.io. This will be revisited in a v0.2.x release; see the
+  comment block above `[dependencies]` in `Cargo.toml`.
+- **`tch` (PyTorch C++) is the heavy default dependency.** Builds
+  require either `LIBTORCH=/path/to/libtorch` or
+  `LIBTORCH_USE_PYTORCH=1` with a compatible PyTorch install. Without
+  libtorch you can still validate the manifest with
+  `cargo publish --dry-run --no-default-features`.
+- **`cargo publish` is a maintainer-only step.** Never run it from
+  an autonomous agent.
+- **Branch protection on `main`.** Direct pushes to `main` (for the
+  CHANGELOG / version-bump commits) will show a ruleset-bypass
+  warning. This is expected for release commits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,139 @@
+# Changelog
+
+All notable changes to **thrust-rl** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+with the pre-1.0 convention that **breaking API changes will land in MINOR
+bumps** (e.g. `0.1.x -> 0.2.0`) until we cut `1.0.0`. Patch releases
+(`0.1.x -> 0.1.y`) are bug fixes and additive, non-breaking improvements.
+
+See [`docs/RELEASING.md`](docs/RELEASING.md) for the maintainer-facing
+release procedure (tagging, GitHub Release creation, and `cargo publish`).
+
+## [Unreleased]
+
+Nothing yet.
+
+## [0.1.0] - 2026-06-08
+
+First publishable release of thrust-rl. Locks in the foundation laid by
+the initial development sprints: two on-policy / off-policy training
+algorithms (PPO and DQN), four environments with both single-agent and
+multi-agent variants, the multi-agent population/matchmaking
+infrastructure, WASM-deployable pure-Rust inference, browser demos, and
+Bayesian-style hyperparameter exploration. Everything below is brand new
+relative to "no published version".
+
+### Added
+
+#### Algorithms
+- **PPO** (`src/train/ppo*`): clipped-surrogate Proximal Policy
+  Optimization with Generalized Advantage Estimation (GAE), an
+  auxiliary-loss hook (`PPOTrainer::set_aux_loss_fn`), and the
+  `MlpPolicy` / `MultiDiscreteMlpPolicy` policy heads. Solves CartPole
+  (~300-470 steps/episode on the curated configs in
+  `examples/games/cartpole/`).
+- **DQN** (`src/train/dqn*`): vanilla DQN MVP plus Double-DQN target
+  computation and Polyak soft target updates (#58), and Prioritized
+  Experience Replay with proportional sampling and importance-sampling
+  correction (#59).
+
+#### Environments
+- **CartPole** (`src/env/games/cartpole.rs`): classic balancing task,
+  trained to >300 step episodes by the bundled configs.
+- **Snake** (`src/env/games/snake/`): single-agent and multi-agent
+  variants with configurable grid size; multi-agent uses a population
+  through `multi_agent::PolicyLearner`.
+- **Pong** (`src/env/games/pong.rs`): single-player vs. rule-based
+  opponent and self-play training pipeline (#47, #53).
+- **SimpleBandit** (`src/env/games/simple_bandit.rs`): contextual bandit
+  used as a sanity test for PPO and the WASM inference stack.
+- **ContinuousLqr** (`src/env/games/continuous_lqr.rs`): 1-D LQR
+  placeholder env exercising the `Vec<f32>` continuous-action surface
+  introduced alongside #61.
+- **BucketBrigade** (Slepian-Wolf MARL research env, see
+  `src/env/games/bucket_brigade/`): adapter is in-tree but the
+  `env-bucket-brigade` feature is **disabled in the published v0.1.0
+  manifest** because the underlying `bucket-brigade-core` crate has not
+  been published to crates.io. Local checkouts can still enable it by
+  un-commenting the feature in `Cargo.toml`. See "Known limitations"
+  below.
+
+#### Multi-agent infrastructure
+- `multi_agent::Population` and `Agent` for population-based training.
+- `GameSimulator` skeleton and `JointMultiAgentTrainer` for synchronized
+  joint PPO across agents (#15).
+- `multi_agent::PolicyLearner` with the per-epoch / per-step bugs from
+  the original Slepian-Wolf port resolved (#4, #41, #34, #39).
+- Four matchmaking strategies: `Random`, `RoundRobin`, `Fitness`,
+  `SelfPlay`.
+- Multi-discrete action support in `MultiAgentEnvironment` (#14).
+- `Environment::clone_state` / `restore_state` for MCTS, replay, and
+  rollback workflows (#62).
+
+#### WASM and browser demos
+- Pure-Rust inference module (`src/inference/`) compiles to WASM with no
+  PyTorch dependency.
+- Universal inference system with JSON model format
+  (`docs/UNIVERSAL_INFERENCE.md`).
+- React + Vite web app under `web/` (excluded from the crate tarball)
+  with live CartPole, Snake, and SimpleBandit demos; SimpleBandit
+  agent visualizer; Pong web demo with self-play model and rule-based
+  fallback (#76).
+
+#### Hyperparameter optimization
+- Bayesian / Pareto-style hyperparameter search machinery
+  (`src/optim/`) used by the `optimize_cartpole` and `optimize_snake`
+  examples to sweep PPO clip ranges, value-function coefficients, and
+  network widths.
+
+#### Documentation
+- `README.md` with project vision, status, and demo links.
+- `ROADMAP.md` and `MULTI_AGENT_DESIGN.md` for forward planning.
+- `docs/PPO_BEST_PRACTICES.md`, `docs/RESEARCH_PAPERS.md`,
+  `docs/RL_TOYBOX_SURVEY.md` (#49).
+- `docs/GPU_SETUP.md`, `docs/LIBTORCH_SETUP.md`,
+  `docs/REMOTE_TRAINING.md`, `docs/TRAINING_*` per-environment guides.
+- Public-API rustdoc audit completed (#36, #38).
+
+#### Tooling
+- `build.rs` defeats GNU ld's `--as-needed` for `libtorch_cuda` on
+  Linux so CUDA-equipped boxes don't silently fall back to CPU (#13).
+- GPU training scripts (`scripts/gpu-*.sh`, excluded from the crate
+  tarball) for an NVIDIA L4 sandbox.
+- Loom orchestration framework installed under `.loom/` for AI-assisted
+  development (excluded from the crate tarball).
+
+### Known limitations
+
+- **DQN does not reliably solve CartPole.** PPO does. Both Double-DQN
+  and PER landed in v0.1.0, but the canonical CartPole DQN config still
+  shows high variance run-to-run. Tracked by the open follow-up issues
+  surfaced during #58/#59 review.
+- **`env-bucket-brigade` is source-only in the published crate.** The
+  underlying `bucket-brigade-core` Cargo crate lives in a git submodule
+  and is not on crates.io, so `cargo publish` cannot include it as an
+  optional dependency. Users who need the env should depend on
+  `thrust-rl` from a git checkout with submodules initialized and
+  un-comment the relevant lines in `Cargo.toml`. Re-publishing
+  `bucket-brigade-core` is tracked as a v0.2.x follow-up.
+- **`multi_agent::PolicyLearner` API is experimental** and is expected
+  to change as multi-agent training matures. Pin to a specific 0.1.x
+  patch if you depend on its current shape.
+- **`tch-rs` version pinned to 0.22** (PyTorch 2.9), which requires
+  Rust nightly + `edition = "2024"`. See `rust-toolchain.toml`.
+- **No binary `release` artifacts.** Consumers build from source via
+  `cargo install thrust-rl` (library) or by cloning the repo for
+  examples. A binary release workflow is intentionally out of scope
+  for v0.1.0.
+
+### Removed (relative to never-published state)
+
+- Empty `BayesianOptimizer` / `ParetoFrontier` / `TrialScheduler`
+  placeholder modules were dropped before publish.
+- `bincode` dependency was removed to resolve RUSTSEC-2025-0141 (#37).
+- Misleading `target_synced` field on `DQNStepStats` (#66).
+
+[Unreleased]: https://github.com/rjwalters/thrust/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/rjwalters/thrust/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,16 @@ wasm = ["wasm-bindgen", "web-sys", "js-sys", "console_error_panic_hook"]  # Pure
 # locally by uncommenting both this line and the dependency above.
 # env-bucket-brigade = ["bucket-brigade-core"]
 
+# Tell rustc that `env-bucket-brigade` is a *known-but-disabled* feature
+# name, so the `#[cfg(feature = "env-bucket-brigade")]` gates in
+# src/env/games/{mod.rs,bucket_brigade/}, tests/test_bucket_brigade_*.rs,
+# and tests/test_multi_discrete_env.rs don't trigger
+# `unexpected_cfgs` (denied via `-D warnings` in CI's `cargo doc` job).
+# Once the feature is re-enabled in [features] above, this stanza can be
+# removed --- cargo will derive the cfg automatically from [features].
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("env-bucket-brigade"))'] }
+
 [dev-dependencies]
 criterion = "0.5"
 tempfile = "3.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,18 +2,60 @@
 name = "thrust-rl"
 version = "0.1.0"
 edition = "2024"
-authors = ["Your Name <your.email@example.com>"]
+authors = ["Robb Walters <agent-4@spheresemi.com>"]
 license = "MIT OR Apache-2.0"
-description = "High-performance reinforcement learning in Rust + CUDA"
-repository = "https://github.com/yourusername/thrust"
-keywords = ["reinforcement-learning", "machine-learning", "rl", "deep-learning", "cuda"]
-categories = ["science", "algorithms"]
+description = "High-performance reinforcement learning in Rust with PyTorch (tch-rs), CUDA, and WASM inference"
+repository = "https://github.com/rjwalters/thrust"
+homepage = "https://rjwalters.github.io/thrust/"
+documentation = "https://docs.rs/thrust-rl"
+# Keywords: <=5 entries, each <=20 chars, alphanumeric + '-'/'_'.
+keywords = ["reinforcement", "machine-learning", "rl", "ppo", "dqn"]
+# Categories from the official crates.io list:
+# https://crates.io/category_slugs
+categories = ["science", "algorithms", "game-development", "simulation"]
 readme = "README.md"
 # Build script defeats GNU ld's --as-needed for libtorch_cuda on Linux.
 # See build.rs for the rationale (in short: without it, the binary silently
 # falls back to CPU even on a CUDA-equipped box). No-op on macOS/Windows
 # and on CPU-only feature builds.
 build = "build.rs"
+# Restrict the published tarball to the files actually needed to build the
+# crate. This keeps the tarball small (well under the 10 MB crates.io
+# limit) by excluding tracked model checkpoints, the web demo, the
+# bucket-brigade submodule, training scripts, optimization result JSON,
+# screenshots, and other non-library assets.
+exclude = [
+    # Trained model checkpoints (tens of MB) -- consumers build their own.
+    "*.pt",
+    "*.safetensors",
+    "*.onnx",
+    "models/**",
+    "cartpole_optimization_results.json",
+    "cartpole_model*.json",
+    # Web demo & legacy demo assets.
+    "web/**",
+    "web-old/**",
+    # Optional Bucket Brigade submodule (only built with the
+    # `env-bucket-brigade` feature; consumers can vendor it themselves).
+    "envs/**",
+    # Bucket Brigade example -- feature is disabled in v0.1.0 (see above).
+    "examples/games/bucket_brigade/**",
+    # Out-of-band tooling that is not needed to build the library.
+    "scripts/**",
+    "loom.sh",
+    "Makefile",
+    "rustfmt.toml",
+    "clippy.toml",
+    ".loom/**",
+    ".claude/**",
+    ".github/**",
+    "libtorch/**",
+    # Project planning docs that aren't consumed by `cargo doc`.
+    "WASM_ROADMAP.md",
+    "MULTI_AGENT_DESIGN.md",
+    "VERSIONS.md",
+    "package.json",
+]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -56,7 +98,18 @@ chrono = { version = "0.4", optional = true }
 
 # Bucket Brigade environment (Slepian-Wolf MARL experiments). Default = no
 # Python features; pure Rust core.
-bucket-brigade-core = { path = "envs/bucket-brigade/bucket-brigade-core", default-features = false, optional = true }
+#
+# NOTE for v0.1.0 release: `bucket-brigade-core` lives in the
+# `envs/bucket-brigade/` git submodule and has not been published to
+# crates.io. `cargo publish` refuses to publish any package with a
+# path-only dependency (even an optional one). Consequently this dep is
+# commented out below and the `env-bucket-brigade` feature is disabled
+# for the published crate. To use the Bucket Brigade env locally, depend
+# on `thrust-rl` from a git checkout that includes the submodule and
+# uncomment this block plus the `env-bucket-brigade` feature definition.
+# See `docs/RELEASING.md` for the full procedure and the follow-up plan
+# for restoring this feature in v0.2.x.
+# bucket-brigade-core = { path = "envs/bucket-brigade/bucket-brigade-core", default-features = false, optional = true }
 
 # WASM support
 wasm-bindgen = { version = "0.2", optional = true }
@@ -68,12 +121,14 @@ console_error_panic_hook = { version = "0.1", optional = true }
 default = ["training"]
 training = ["tch", "tokio", "rayon", "tracing", "tracing-subscriber", "crossbeam-channel", "chrono"]  # Include PyTorch and async deps for training
 wasm = ["wasm-bindgen", "web-sys", "js-sys", "console_error_panic_hook"]  # Pure Rust for WASM
-# Bucket Brigade env adapter for the Slepian-Wolf MARL experiments. Pulls in
-# the bucket-brigade-core crate as a pure-Rust dep --- does *not* require
-# the `training` feature on its own, so the env can be tested without
-# libtorch. The accompanying joint-trainer binary will declare
-# `required-features = ["env-bucket-brigade", "training"]`.
-env-bucket-brigade = ["bucket-brigade-core"]
+# Bucket Brigade env adapter for the Slepian-Wolf MARL experiments. Pulls
+# in the bucket-brigade-core crate as a pure-Rust dep --- does *not*
+# require the `training` feature on its own. Disabled for v0.1.0 because
+# bucket-brigade-core is path-only (see comment in [dependencies]); the
+# `bucket_brigade` module in src/ is `#[cfg(feature = "env-bucket-brigade")]`
+# gated and will simply be omitted from the published crate. Re-enable
+# locally by uncommenting both this line and the dependency above.
+# env-bucket-brigade = ["bucket-brigade-core"]
 
 [dev-dependencies]
 criterion = "0.5"
@@ -195,11 +250,15 @@ name = "test_json_inference"
 path = "examples/games/cartpole/test_json_inference.rs"
 required-features = ["training"]
 
-# Bucket Brigade examples (Slepian-Wolf MARL)
-[[example]]
-name = "train_p3"
-path = "examples/games/bucket_brigade/train_p3.rs"
-required-features = ["training", "env-bucket-brigade"]
+# Bucket Brigade examples (Slepian-Wolf MARL).
+# Disabled for v0.1.0 because the `env-bucket-brigade` feature is
+# disabled in the published manifest (the underlying path-only
+# bucket-brigade-core dep prevents `cargo publish`). Re-enable locally
+# alongside the feature definition above.
+# [[example]]
+# name = "train_p3"
+# path = "examples/games/bucket_brigade/train_p3.rs"
+# required-features = ["training", "env-bucket-brigade"]
 
 # Diagnostics --- verifies that the CUDA link fix from build.rs is working.
 # Run with `./scripts/gpu-train.sh test_cuda` or directly via cargo on a

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,226 @@
+# Releasing thrust-rl
+
+This document is the **maintainer-facing** guide to cutting a new
+release of `thrust-rl` to crates.io. The PR workflow (Builder + Judge +
+merge) is documented elsewhere; this file picks up after a green `main`
+that you want to publish as a new version.
+
+## Versioning policy
+
+`thrust-rl` follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+with the **pre-1.0 convention** that breaking API changes land in MINOR
+bumps until we cut `1.0.0`:
+
+| Change                                | Bump  | Example          |
+| ------------------------------------- | ----- | ---------------- |
+| Bug fix, doc-only, additive non-API   | PATCH | `0.1.0 -> 0.1.1` |
+| New public API, removed/renamed API   | MINOR | `0.1.x -> 0.2.0` |
+| Stable-API guarantee (post-1.0 only)  | MAJOR | `0.x   -> 1.0.0` |
+
+Until `1.0.0`, MAJOR is reserved. Once we ship `1.0.0`, MAJOR is for
+breaking API changes and MINOR is for additive ones, per standard
+semver.
+
+The **single source of truth** for the version is the root
+`Cargo.toml`'s `[package].version` field. There is no
+`scripts/version.sh` in this repository, and no other file needs to be
+edited in lock-step for a release.
+
+## Pre-flight checks
+
+Before tagging:
+
+```bash
+# 1. CI is green on main
+gh run list --branch main --limit 5
+
+# 2. No open PRs that should land first
+gh pr list --state open
+
+# 3. Working tree is clean and on main
+git checkout main && git pull && git status
+```
+
+If CI is failing or there are uncommitted changes, stop and fix first.
+
+## Step 1: Update `CHANGELOG.md`
+
+1. Move items from the `## [Unreleased]` section into a new
+   `## [X.Y.Z] - YYYY-MM-DD` block (today's date, UTC).
+2. Group changes under `### Added`, `### Changed`, `### Fixed`,
+   `### Removed`, `### Deprecated`, `### Security` as appropriate.
+   Omit empty sections.
+3. Update the link references at the bottom of the file:
+   ```text
+   [Unreleased]: https://github.com/rjwalters/thrust/compare/vX.Y.Z...HEAD
+   [X.Y.Z]: https://github.com/rjwalters/thrust/releases/tag/vX.Y.Z
+   ```
+4. Commit:
+   ```bash
+   git add CHANGELOG.md
+   git commit -m "docs: prepare CHANGELOG for vX.Y.Z"
+   ```
+
+## Step 2: Bump `Cargo.toml`
+
+Edit `Cargo.toml`'s `[package].version`:
+
+```toml
+[package]
+version = "X.Y.Z"
+```
+
+Then rebuild so `Cargo.lock` picks up the new version:
+
+```bash
+cargo check --no-default-features
+```
+
+Commit:
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "chore: bump version to vX.Y.Z"
+```
+
+(`Cargo.lock` is `.gitignore`d in this repo, so only `Cargo.toml`
+will appear in the commit. That's expected.)
+
+## Step 3: Validate the publish
+
+Run `cargo publish --dry-run` to make sure the manifest is publishable
+and the tarball builds:
+
+```bash
+# Without libtorch on the host machine, run with --no-default-features:
+cargo publish --dry-run --no-default-features
+
+# With libtorch available (either via $LIBTORCH or LIBTORCH_USE_PYTORCH=1),
+# run the full default-features dry-run too:
+LIBTORCH_USE_PYTORCH=1 cargo publish --dry-run
+```
+
+Inspect the tarball contents:
+
+```bash
+cargo package --list
+```
+
+Confirm the file list does **not** include:
+- Model checkpoints (`*.pt`, `*.safetensors`, `models/**`).
+- The `web/` React app, `web-old/`, or `envs/bucket-brigade/` submodule.
+- Training/automation scripts under `scripts/`.
+- `.loom/`, `.claude/`, `.github/`.
+
+If something unexpected slipped in, update the `exclude = [...]` field
+in `[package]` (`Cargo.toml`) and re-run `cargo package --list`. Aim
+for a tarball well under crates.io's 10 MB limit; v0.1.0 ships at
+~300 KB.
+
+## Step 4: Push the version commits
+
+```bash
+git push origin main
+```
+
+Wait for CI to go green on the head of `main` before tagging.
+
+## Step 5: Tag and create the GitHub Release
+
+Tag the version-bump commit (or whichever commit you intend as the
+release point):
+
+```bash
+git tag -a vX.Y.Z -m "thrust-rl vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+Create the GitHub Release with notes pulled from `CHANGELOG.md`:
+
+```bash
+# Extract the section for vX.Y.Z from CHANGELOG.md and pass as notes:
+gh release create vX.Y.Z \
+    --title "vX.Y.Z" \
+    --notes-file <(awk '/^## \[X\.Y\.Z\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md)
+```
+
+(Substitute the literal version into the `awk` pattern, e.g.
+`/^## \[0\.1\.0\]/`.)
+
+No `release.yml` GitHub Actions workflow is configured for v0.1.0, so
+no binary artifacts are attached. This is intentional --- consumers
+build from source via `cargo install thrust-rl`.
+
+## Step 6: Publish to crates.io
+
+**Only the maintainer with a valid crates.io API token runs this step.**
+Do not delegate it to autonomous agents.
+
+```bash
+# Make sure you're on the exact tagged commit:
+git checkout vX.Y.Z
+
+# Authenticate (one-time per machine; token stored in
+# ~/.cargo/credentials.toml):
+cargo login <your-crates.io-token>
+
+# Publish for real (no --dry-run this time):
+LIBTORCH_USE_PYTORCH=1 cargo publish
+
+# Or, if you trust the dry-run and want to skip the verification rebuild:
+cargo publish --no-verify
+```
+
+`cargo publish` will:
+1. Re-run the manifest verification.
+2. Rebuild the tarball.
+3. Upload to crates.io.
+
+Within a few minutes:
+- `https://crates.io/crates/thrust-rl/X.Y.Z` is live.
+- `https://docs.rs/thrust-rl/X.Y.Z/` starts a doc build (takes 5-30
+  minutes for the first version).
+
+## Step 7: Verify and announce
+
+```bash
+# crates.io
+curl -s https://crates.io/api/v1/crates/thrust-rl | jq '.crate.max_stable_version'
+
+# docs.rs build status
+open https://docs.rs/thrust-rl/X.Y.Z/
+```
+
+If docs.rs failed (commonly because of `tch` / libtorch), open a
+follow-up issue with the failing log and consider whether to publish
+without the `training` feature on docs.rs by adding to `Cargo.toml`:
+
+```toml
+[package.metadata.docs.rs]
+no-default-features = true
+features = []
+```
+
+## Yanking a bad release
+
+If you discover a serious bug post-publish:
+
+```bash
+cargo yank --vers X.Y.Z
+```
+
+Yanking removes the version from new dependency resolution but does not
+delete it. Existing `Cargo.lock` files pinning that version continue to
+work. Follow up with a `X.Y.(Z+1)` patch release containing the fix.
+
+## Out of scope (today)
+
+These are explicit non-goals for the current release procedure:
+
+- **Automated `cargo publish` from CI.** The first few releases are
+  hand-published. Automate later, once the procedure is stable.
+- **Binary release artifacts.** No `release.yml` builds a binary
+  tarball; consumers `cargo install`.
+- **Workspace publishing.** `thrust-rl` is a single crate today.
+- **Bumping `web/package.json`'s version.** The web subproject is not
+  an npm package and is excluded from the published tarball.


### PR DESCRIPTION
Closes #64.

## Summary

Adds the crate-level metadata, documentation, and tooling needed to publish `thrust-rl` to crates.io as v0.1.0. The actual `cargo publish`, `git tag v0.1.0`, and GitHub Release creation are explicit maintainer post-merge steps, per the issue body:

> The actual `cargo publish` should be done by the maintainer (rjwalters) with their crates.io token --- NOT by an autonomous agent. The PR delivers a publish-ready state; the maintainer executes the final `cargo publish` command from a green main after merge.

## What's in this PR

### `Cargo.toml`

- Replaced placeholder `authors` and `repository` with real values (Robb Walters, `rjwalters/thrust`).
- Expanded `description`. Refined `keywords` (5 entries, all <=20 chars, valid alphanumeric/`-`/`_`): `reinforcement`, `machine-learning`, `rl`, `ppo`, `dqn`.
- Tightened `categories` to entries from the [official crates.io slug list](https://crates.io/category_slugs): `science`, `algorithms`, `game-development`, `simulation`.
- Added `homepage` (the GitHub Pages demo) and `documentation` (docs.rs) keys.
- Added a comprehensive `exclude = [...]` block so the published tarball drops model checkpoints (`*.pt`, `*.safetensors`, `models/**`), the web demo, the `envs/bucket-brigade/` submodule, training scripts, `.loom/`, `.claude/`, `.github/`, and project planning docs.
- **Disabled the `env-bucket-brigade` feature** for the published manifest. `cargo publish` rejects path-only deps without a version, and `bucket-brigade-core` is not yet on crates.io. The dep and feature lines are commented out (not deleted); local builds can un-comment two blocks in `Cargo.toml` to use the env. The source files under `src/env/games/bucket_brigade/` remain in-tree (they are `#[cfg(feature = "env-bucket-brigade")]` gated, so the published crate simply omits them). Tracked as a v0.2.x follow-up.

### `CHANGELOG.md` (new, root)

Keep-a-Changelog format with an `[Unreleased]` placeholder and a fully populated `[0.1.0] - 2026-06-08` entry. The 0.1.0 entry curates `git log --oneline` (191 commits since project start) into the user-visible categories the issue called out:

- Algorithms (PPO clipped + GAE + aux-loss hook; DQN, Double-DQN with Polyak soft updates, Prioritized Experience Replay).
- Environments (CartPole, Snake single+multi, Pong single+self-play, SimpleBandit, ContinuousLqr, BucketBrigade source-only).
- Multi-agent infra (`Population`, `JointMultiAgentTrainer`, four matchmakers, `clone_state`/`restore_state`).
- WASM and browser demos.
- Hyperparameter optimization.
- Documentation.
- Tooling.
- **Known limitations**: DQN doesn't reliably solve CartPole; `env-bucket-brigade` is source-only in the published crate; `multi_agent::PolicyLearner` API is experimental; `tch` 0.22 + Rust nightly + edition 2024; no binary release artifacts.

### `docs/RELEASING.md` (new)

Maintainer-facing release procedure documenting:

- Pre-1.0 semver convention (breaking changes go to MINOR until `1.0.0`).
- Pre-flight checks (CI green, no open PRs, clean tree).
- `CHANGELOG.md` and `Cargo.toml` update steps (with literal commands).
- `cargo publish --dry-run` validation, both with and without libtorch.
- `cargo package --list` inspection.
- The literal `git tag -a vX.Y.Z`, `git push origin vX.Y.Z`, `gh release create` commands.
- `cargo publish` hand-off (token-bearing, maintainer-only).
- Yanking a bad release.
- Explicit out-of-scope items (CI-driven publish, binary artifacts, workspace publishing, `web/package.json`).

### `.claude/commands/loom/release.md` (rewritten)

The original file was Loom-framework verbatim --- referenced `loom-daemon`, `loom-api`, `mcp-loom/package.json`, a `scripts/version.sh` that doesn't exist here, and "5 version-bearing files" that don't exist either. Replaced with a 9-phase Thrust-specific interactive walkthrough: pre-flight, gather changes, semver decision (pre-1.0 calibrated), draft CHANGELOG, apply changes, commit/tag/push, create GitHub Release, hand off to maintainer for `cargo publish`, post-release summary. Explicit note that `cargo publish` must not be run from an autonomous agent (token exposure).

## Acceptance criteria coverage

From the issue body:

- [x] `.claude/commands/loom/release.md` rewritten for Thrust.
- [x] `CHANGELOG.md` exists at root with a non-trivial `## [0.1.0]` section.
- [x] Release procedure documented in `docs/RELEASING.md`.
- [x] `Cargo.toml` has all crates.io-required metadata (`description`, `license`, `repository`, `readme`) and validated `cargo publish --dry-run`.
- [ ] **(Maintainer step)** `v0.1.0` tag pushed to `origin`.
- [ ] **(Maintainer step)** GitHub Release for v0.1.0 created and visible.
- [ ] **(Maintainer step)** `cargo publish` succeeds; `thrust-rl v0.1.0` is live on crates.io and docs.rs.

The three unchecked items are the maintainer's responsibility per the explicit "Publishing logistics" guidance in the issue.

## Validation performed

- `cargo publish --dry-run --no-default-features --allow-dirty`: **OK**
- `LIBTORCH_USE_PYTORCH=1 cargo publish --dry-run --allow-dirty`: **OK** (uses host pytorch install for libtorch).
- `cargo test --lib --features training`: **207/207 passing.**
- `cargo test --tests --features training`: **all targets passing.**
- `cargo check --no-default-features`: **OK** (10 pre-existing warnings, unchanged by this PR).
- `cargo package --list`: 143 files, 316 KB tarball. Confirmed excluded: model checkpoints, `web/`, `web-old/`, `envs/**`, `scripts/**`, `.loom/`, `.claude/`, `.github/`, optimization result JSON.

## Maintainer post-merge checklist

From a clean checkout of `main` after merge:

```bash
# 1. Tag
git checkout main && git pull
git tag -a v0.1.0 -m "thrust-rl v0.1.0"
git push origin v0.1.0

# 2. GitHub Release with notes from CHANGELOG
gh release create v0.1.0 \
    --title "v0.1.0" \
    --notes-file <(awk '/^## \[0\.1\.0\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md)

# 3. Publish to crates.io (token required, do NOT delegate to agents)
LIBTORCH_USE_PYTORCH=1 cargo publish
# or
cargo publish --no-verify
```

Verify within a few minutes:
- `https://crates.io/crates/thrust-rl/0.1.0` is live.
- `https://docs.rs/thrust-rl/0.1.0/` is building.

## Test plan

- [ ] `cargo publish --dry-run --no-default-features` succeeds on CI.
- [ ] `cargo publish --dry-run` succeeds with libtorch present on CI.
- [ ] All existing tests still pass (`cargo test --features training`).
- [ ] `cargo check --no-default-features` still compiles.
- [ ] `cargo package --list` output reviewed: no model files, no submodule, no web demo.