### PR TITLE
Bump rand 0.8 to 0.9 across workspace (drops r#gen ugliness)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
 # Random number generation
-rand = { version = "0.8", features = ["getrandom"] }
+rand = { version = "0.9" }
 getrandom = { version = "0.2", features = ["js"] }
 
 # Multi-threading and channels (not available in WASM)

--- a/examples/games/pong/train_pong_self_play.rs
+++ b/examples/games/pong/train_pong_self_play.rs
@@ -162,7 +162,7 @@ fn main() -> Result<()> {
 
     // Per-env snapshot assignment: which snapshot in the pool controls the
     // right paddle of env `i` for the current episode.
-    let mut rng = StdRng::from_entropy();
+    let mut rng = StdRng::from_os_rng();
     let mut env_snapshot_idx: Vec<usize> = (0..NUM_ENVS).map(|_| 0).collect();
 
     // Win/loss tracking: recent episode results from the left agent's
@@ -283,7 +283,7 @@ fn main() -> Result<()> {
                     env_right_score[env_id] = 0;
 
                     // Re-sample opponent snapshot for the next episode
-                    env_snapshot_idx[env_id] = rng.gen_range(0..snapshot_pool.len());
+                    env_snapshot_idx[env_id] = rng.random_range(0..snapshot_pool.len());
                 }
             }
 

--- a/examples/games/snake/optimize_snake.rs
+++ b/examples/games/snake/optimize_snake.rs
@@ -307,7 +307,7 @@ fn run_trial(
             // Shuffle indices
             let mut indices: Vec<usize> = (0..buffer_size).collect();
             use rand::seq::SliceRandom;
-            indices.shuffle(&mut rand::thread_rng());
+            indices.shuffle(&mut rand::rng());
 
             // Mini-batch updates
             for chunk in indices.chunks(minibatch_size) {

--- a/examples/games/snake/train_snake.rs
+++ b/examples/games/snake/train_snake.rs
@@ -268,7 +268,7 @@ fn main() -> Result<()> {
             // Shuffle indices for minibatch sampling
             let mut indices: Vec<usize> = (0..batch_size).collect();
             use rand::seq::SliceRandom;
-            indices.shuffle(&mut rand::thread_rng());
+            indices.shuffle(&mut rand::rng());
 
             for mb in 0..num_minibatches {
                 let mb_indices = &indices[mb * MINIBATCH_SIZE..(mb + 1) * MINIBATCH_SIZE];

--- a/examples/games/snake/train_snake_multi.rs
+++ b/examples/games/snake/train_snake_multi.rs
@@ -293,7 +293,7 @@ fn main() -> Result<()> {
             // Shuffle indices
             let mut indices: Vec<usize> = (0..buffer_size).collect();
             use rand::seq::SliceRandom;
-            indices.shuffle(&mut rand::thread_rng());
+            indices.shuffle(&mut rand::rng());
 
             // Mini-batch updates
             for chunk in indices.chunks(args.minibatch_size) {

--- a/examples/games/snake/train_snake_multi_v2.rs
+++ b/examples/games/snake/train_snake_multi_v2.rs
@@ -362,7 +362,7 @@ fn train_shared_policy(args: Args, device: Device) -> Result<()> {
             // Shuffle indices
             let mut indices: Vec<usize> = (0..buffer_size).collect();
             use rand::seq::SliceRandom;
-            indices.shuffle(&mut rand::thread_rng());
+            indices.shuffle(&mut rand::rng());
 
             // Mini-batch updates
             for chunk in indices.chunks(args.minibatch_size) {
@@ -698,7 +698,7 @@ fn train_independent_policies(args: Args, device: Device) -> Result<()> {
             for _ in 0..args.ppo_epochs {
                 let mut indices: Vec<usize> = (0..buffer_size).collect();
                 use rand::seq::SliceRandom;
-                indices.shuffle(&mut rand::thread_rng());
+                indices.shuffle(&mut rand::rng());
 
                 for chunk in indices.chunks(args.minibatch_size.min(buffer_size)) {
                     // Prepare batch

--- a/src/buffer/replay/prioritized.rs
+++ b/src/buffer/replay/prioritized.rs
@@ -331,9 +331,9 @@ impl PrioritizedReplayBuffer {
         for k in 0..batch_size {
             let lo = segment * k as f32;
             let hi = segment * (k + 1) as f32;
-            // `gen_range(lo..hi)` would panic if `lo == hi` (zero-width
+            // `random_range(lo..hi)` would panic if `lo == hi` (zero-width
             // segment) — in that case just take the boundary.
-            let p = if hi > lo { rng.gen_range(lo..hi) } else { lo };
+            let p = if hi > lo { rng.random_range(lo..hi) } else { lo };
             let (leaf_idx, leaf_priority) = self.tree.find(p);
 
             // Defensive: if we somehow landed on a leaf past `self.len`

--- a/src/buffer/replay/prioritized.rs
+++ b/src/buffer/replay/prioritized.rs
@@ -333,7 +333,11 @@ impl PrioritizedReplayBuffer {
             let hi = segment * (k + 1) as f32;
             // `random_range(lo..hi)` would panic if `lo == hi` (zero-width
             // segment) — in that case just take the boundary.
-            let p = if hi > lo { rng.random_range(lo..hi) } else { lo };
+            let p = if hi > lo {
+                rng.random_range(lo..hi)
+            } else {
+                lo
+            };
             let (leaf_idx, leaf_priority) = self.tree.find(p);
 
             // Defensive: if we somehow landed on a leaf past `self.len`

--- a/src/buffer/replay/sampling.rs
+++ b/src/buffer/replay/sampling.rs
@@ -94,7 +94,7 @@ pub fn sample<R: Rng>(buffer: &ReplayBuffer, batch_size: usize, rng: &mut R) -> 
     let mut dones = Vec::with_capacity(batch_size);
 
     for k in 0..batch_size {
-        let idx = rng.gen_range(0..len);
+        let idx = rng.random_range(0..len);
         let obs_slice = &mut observations[k * obs_dim..(k + 1) * obs_dim];
         let next_slice = &mut next_observations[k * obs_dim..(k + 1) * obs_dim];
         let (a, r, d) = buffer.read_into(idx, obs_slice, next_slice);

--- a/src/buffer/rollout/sampling.rs
+++ b/src/buffer/rollout/sampling.rs
@@ -18,10 +18,10 @@ use super::storage::RolloutBuffer;
 /// Vector of vectors, where each inner vector contains indices for one
 /// minibatch
 pub fn generate_minibatch_indices(buffer_size: usize, batch_size: usize) -> Vec<Vec<usize>> {
-    use rand::{seq::SliceRandom, thread_rng};
+    use rand::seq::SliceRandom;
 
     let mut indices: Vec<usize> = (0..buffer_size).collect();
-    indices.shuffle(&mut thread_rng());
+    indices.shuffle(&mut rand::rng());
 
     indices.chunks(batch_size).map(|chunk| chunk.to_vec()).collect()
 }
@@ -187,10 +187,10 @@ impl<'a> Iterator for MinibatchIterator<'a> {
 /// # Returns
 /// Vector of shuffled indices
 pub fn shuffle_indices(size: usize) -> Vec<usize> {
-    use rand::{seq::SliceRandom, thread_rng};
+    use rand::seq::SliceRandom;
 
     let mut indices: Vec<usize> = (0..size).collect();
-    indices.shuffle(&mut thread_rng());
+    indices.shuffle(&mut rand::rng());
     indices
 }
 

--- a/src/env/games/cartpole.rs
+++ b/src/env/games/cartpole.rs
@@ -130,13 +130,13 @@ impl CartPole {
     /// All state variables are initialized with small random perturbations
     /// around equilibrium (uniform distribution in [-0.05, 0.05])
     fn reset_state(&mut self) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // Initialize with small random perturbations
-        self.x = rng.gen_range(-0.05..0.05);
-        self.x_dot = rng.gen_range(-0.05..0.05);
-        self.theta = rng.gen_range(-0.05..0.05);
-        self.theta_dot = rng.gen_range(-0.05..0.05);
+        self.x = rng.random_range(-0.05..0.05);
+        self.x_dot = rng.random_range(-0.05..0.05);
+        self.theta = rng.random_range(-0.05..0.05);
+        self.theta_dot = rng.random_range(-0.05..0.05);
     }
 
     /// Perform one physics simulation step using Euler integration

--- a/src/env/games/pong.rs
+++ b/src/env/games/pong.rs
@@ -89,15 +89,15 @@ impl Pong {
     }
 
     fn serve(&mut self, toward_agent: bool) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         self.ball_x = 0.5;
-        self.ball_y = 0.3 + rng.gen_range(0.0f32..0.4f32);
+        self.ball_y = 0.3 + rng.random_range(0.0f32..0.4f32);
         self.ball_dx = if toward_agent {
             -BALL_SPEED
         } else {
             BALL_SPEED
         };
-        self.ball_dy = rng.gen_range(-0.5f32..0.5f32) * BALL_SPEED;
+        self.ball_dy = rng.random_range(-0.5f32..0.5f32) * BALL_SPEED;
     }
 
     fn clamp_paddle(y: f32) -> f32 {
@@ -187,12 +187,12 @@ impl Pong {
         if self.ball_x - BALL_R < 0.0 {
             self.right_score += 1;
             reward = -1.0;
-            let toward = rand::thread_rng().gen_bool(0.5);
+            let toward = rand::rng().random_bool(0.5);
             self.serve(toward);
         } else if self.ball_x + BALL_R > 1.0 {
             self.left_score += 1;
             reward = 1.0;
-            let toward = rand::thread_rng().gen_bool(0.5);
+            let toward = rand::rng().random_bool(0.5);
             self.serve(toward);
         }
 
@@ -239,7 +239,7 @@ impl Environment for Pong {
         self.left_score = 0;
         self.right_score = 0;
         self.steps = 0;
-        let toward = rand::thread_rng().gen_bool(0.5);
+        let toward = rand::rng().random_bool(0.5);
         self.serve(toward);
     }
 
@@ -311,12 +311,12 @@ impl Environment for Pong {
         if self.ball_x - BALL_R < 0.0 {
             self.right_score += 1;
             reward = -1.0;
-            let toward = rand::thread_rng().gen_bool(0.5);
+            let toward = rand::rng().random_bool(0.5);
             self.serve(toward);
         } else if self.ball_x + BALL_R > 1.0 {
             self.left_score += 1;
             reward = 1.0;
-            let toward = rand::thread_rng().gen_bool(0.5);
+            let toward = rand::rng().random_bool(0.5);
             self.serve(toward);
         }
 

--- a/src/env/games/simple_bandit.rs
+++ b/src/env/games/simple_bandit.rs
@@ -53,7 +53,7 @@ pub struct SimpleBandit {
 impl SimpleBandit {
     /// Create a new simple bandit environment
     pub fn new() -> Self {
-        Self { state: 0.0, steps: 0, max_steps: 100, rng: rand::rngs::StdRng::from_entropy() }
+        Self { state: 0.0, steps: 0, max_steps: 100, rng: rand::rngs::StdRng::from_os_rng() }
     }
 }
 
@@ -69,7 +69,7 @@ impl Environment for SimpleBandit {
 
     fn reset(&mut self) {
         // Random start state (0 or 1)
-        self.state = self.rng.gen_range(0..2) as f32;
+        self.state = self.rng.random_range(0..2) as f32;
         self.steps = 0;
     }
 
@@ -89,7 +89,7 @@ impl Environment for SimpleBandit {
         let terminated = self.steps >= self.max_steps;
 
         // Random next state
-        self.state = self.rng.gen_range(0..2) as f32;
+        self.state = self.rng.random_range(0..2) as f32;
 
         StepResult {
             observation: self.get_observation(),

--- a/src/env/games/snake/environment.rs
+++ b/src/env/games/snake/environment.rs
@@ -16,7 +16,7 @@ use crate::env::{Environment, SpaceInfo, SpaceType, StepInfo, StepResult};
 ///
 /// Captures every visible field of the env (grid, snake positions, food
 /// position, score, step count, done flag) but **not** the RNG used by
-/// `thread_rng()` inside `step` for food respawn. After `restore_state`, any
+/// `rand::rng()` inside `step` for food respawn. After `restore_state`, any
 /// step that triggers a food respawn will sample a different food location
 /// than the original trajectory.
 #[derive(Debug, Clone)]
@@ -76,7 +76,7 @@ pub struct SnakeEnv {
 impl SnakeEnv {
     /// Create new snake environment with specified number of agents
     pub fn new_multi(width: i32, height: i32, num_agents: usize) -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // Create snakes in different corners
         let mut snakes = Vec::new();
@@ -94,7 +94,7 @@ impl SnakeEnv {
         }
 
         // Generate initial food
-        let food_pos = Position::new(rng.gen_range(0..width), rng.gen_range(0..height));
+        let food_pos = Position::new(rng.random_range(0..width), rng.random_range(0..height));
 
         Self {
             width,
@@ -125,7 +125,7 @@ impl SnakeEnv {
 
     /// Reset environment to initial state
     pub fn reset(&mut self) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // Reset all snakes
         self.snakes.clear();
@@ -143,7 +143,7 @@ impl SnakeEnv {
         }
 
         // Generate new food
-        self.food = Position::new(rng.gen_range(0..self.width), rng.gen_range(0..self.height));
+        self.food = Position::new(rng.random_range(0..self.width), rng.random_range(0..self.height));
 
         self.episode += 1;
         self.steps = 0;
@@ -226,10 +226,10 @@ impl SnakeEnv {
                 self.snakes[i].grow();
 
                 // Generate new food
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
                 loop {
-                    let x = rng.gen_range(0..self.width);
-                    let y = rng.gen_range(0..self.height);
+                    let x = rng.random_range(0..self.width);
+                    let y = rng.random_range(0..self.height);
                     let new_food = Position::new(x, y);
 
                     // Make sure food doesn't spawn on any snake
@@ -362,10 +362,10 @@ impl SnakeEnv {
                 self.snakes[i].grow();
 
                 // Generate new food
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
                 loop {
-                    let x = rng.gen_range(0..self.width);
-                    let y = rng.gen_range(0..self.height);
+                    let x = rng.random_range(0..self.width);
+                    let y = rng.random_range(0..self.height);
                     let new_food = Position::new(x, y);
 
                     // Make sure food doesn't spawn on any snake

--- a/src/env/games/snake/environment.rs
+++ b/src/env/games/snake/environment.rs
@@ -143,7 +143,8 @@ impl SnakeEnv {
         }
 
         // Generate new food
-        self.food = Position::new(rng.random_range(0..self.width), rng.random_range(0..self.height));
+        self.food =
+            Position::new(rng.random_range(0..self.width), rng.random_range(0..self.height));
 
         self.episode += 1;
         self.steps = 0;

--- a/src/env/games/snake/multi_agent.rs
+++ b/src/env/games/snake/multi_agent.rs
@@ -33,7 +33,7 @@ pub struct MultiAgentSnakeEnv {
 impl MultiAgentSnakeEnv {
     /// Create new multi-agent snake environment
     pub fn new(width: i32, height: i32, num_agents: usize) -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut snakes = Vec::new();
 
         // Create snakes at different starting positions
@@ -66,7 +66,7 @@ impl MultiAgentSnakeEnv {
 
     /// Reset environment to initial state
     pub fn reset(&mut self) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // Reset all snakes
         for (i, snake) in self.snakes.iter_mut().enumerate() {
@@ -134,7 +134,7 @@ impl MultiAgentSnakeEnv {
 
         // Generate new food if eaten
         if food_eaten {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             self.food = Food::generate_random(self.width, self.height, &self.snakes, &mut rng);
         }
 

--- a/src/env/games/snake/snake.rs
+++ b/src/env/games/snake/snake.rs
@@ -135,8 +135,8 @@ impl Food {
         rng: &mut impl rand::Rng,
     ) -> Self {
         loop {
-            let x = rng.gen_range(0..width);
-            let y = rng.gen_range(0..height);
+            let x = rng.random_range(0..width);
+            let y = rng.random_range(0..height);
             let pos = Position::new(x, y);
 
             // Check if position is occupied by any snake
@@ -236,7 +236,7 @@ mod tests {
 
     #[test]
     fn test_food_generation() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let snakes = vec![
             Snake::new(0, Position::new(0, 0), Direction::Right),
             Snake::new(1, Position::new(2, 2), Direction::Right),

--- a/src/multi_agent/matchmaking.rs
+++ b/src/multi_agent/matchmaking.rs
@@ -2,8 +2,8 @@
 //!
 //! Determines which agents play together in each game instance.
 
-use rand::{Rng, SeedableRng, rngs::StdRng};
 // NB: `SeedableRng` is required to bring `StdRng::from_os_rng` into scope.
+use rand::{Rng, SeedableRng, rngs::StdRng};
 
 use super::population::{AgentId, Population};
 

--- a/src/multi_agent/matchmaking.rs
+++ b/src/multi_agent/matchmaking.rs
@@ -3,6 +3,7 @@
 //! Determines which agents play together in each game instance.
 
 use rand::{Rng, SeedableRng, rngs::StdRng};
+// NB: `SeedableRng` is required to bring `StdRng::from_os_rng` into scope.
 
 use super::population::{AgentId, Population};
 
@@ -74,7 +75,7 @@ impl RandomMatchmaker {
     /// constructing directly — the strategy enum is the documented
     /// configuration surface.
     pub fn new() -> Self {
-        Self { rng: StdRng::from_entropy() }
+        Self { rng: StdRng::from_os_rng() }
     }
 }
 
@@ -91,7 +92,7 @@ impl Matchmaker for RandomMatchmaker {
         for _ in 0..num_games {
             let mut game_agents = Vec::with_capacity(agents_per_game);
             for _ in 0..agents_per_game {
-                let agent_id = self.rng.gen_range(0..pop_size);
+                let agent_id = self.rng.random_range(0..pop_size);
                 game_agents.push(agent_id);
             }
             matches.push(game_agents);
@@ -157,7 +158,7 @@ impl FitnessBasedMatchmaker {
     /// Prefer [`MatchmakingStrategy::FitnessBased`] +
     /// `create_matchmaker()` over constructing directly.
     pub fn new(window_size: usize) -> Self {
-        Self { window_size, rng: StdRng::from_entropy() }
+        Self { window_size, rng: StdRng::from_os_rng() }
     }
 }
 
@@ -180,7 +181,7 @@ impl Matchmaker for FitnessBasedMatchmaker {
             // Pick a base rank within valid range
             let max_base = pop_size.saturating_sub(self.window_size);
             let base_rank = if max_base > 0 {
-                self.rng.gen_range(0..max_base)
+                self.rng.random_range(0..max_base)
             } else {
                 0
             };
@@ -190,7 +191,7 @@ impl Matchmaker for FitnessBasedMatchmaker {
             let window_end = (base_rank + self.window_size).min(pop_size);
 
             for _ in 0..agents_per_game {
-                let idx = self.rng.gen_range(base_rank..window_end);
+                let idx = self.rng.random_range(base_rank..window_end);
                 game_agents.push(ranked[idx].0);
             }
             matches.push(game_agents);
@@ -212,7 +213,7 @@ impl SelfPlayMatchmaker {
     /// [`MatchmakingStrategy::SelfPlay`] + `create_matchmaker()` over
     /// constructing directly.
     pub fn new() -> Self {
-        Self { rng: StdRng::from_entropy() }
+        Self { rng: StdRng::from_os_rng() }
     }
 }
 
@@ -228,7 +229,7 @@ impl Matchmaker for SelfPlayMatchmaker {
 
         for _ in 0..num_games {
             // Pick one agent for this game
-            let agent_id = self.rng.gen_range(0..pop_size);
+            let agent_id = self.rng.random_range(0..pop_size);
 
             // All players in this game are the same agent
             let game_agents = vec![agent_id; agents_per_game];

--- a/src/optimize/space.rs
+++ b/src/optimize/space.rs
@@ -72,7 +72,7 @@ impl Parameter {
     /// Sample a random value from this parameter's range
     pub fn sample(&self) -> ParameterValue {
         use rand::Rng;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         match self {
             Parameter::Continuous { min, max, log_scale, .. } => {
@@ -80,14 +80,14 @@ impl Parameter {
                     // Sample in log space
                     let log_min = min.ln();
                     let log_max = max.ln();
-                    (rng.r#gen::<f64>() * (log_max - log_min) + log_min).exp()
+                    (rng.random::<f64>() * (log_max - log_min) + log_min).exp()
                 } else {
-                    rng.r#gen::<f64>() * (max - min) + min
+                    rng.random::<f64>() * (max - min) + min
                 };
                 ParameterValue::Continuous(value)
             }
             Parameter::Discrete { values, .. } => {
-                let idx = rng.gen_range(0..values.len());
+                let idx = rng.random_range(0..values.len());
                 ParameterValue::Discrete(values[idx])
             }
         }

--- a/src/policy/mlp_burn.rs
+++ b/src/policy/mlp_burn.rs
@@ -99,11 +99,11 @@ impl<B: Backend> MlpBurnPolicy<B> {
             log_probs_all.into_data().to_vec().expect("log_probs to_vec");
         let values_host: Vec<f32> = value.into_data().to_vec().expect("values to_vec");
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut actions = Vec::with_capacity(batch);
         let mut log_probs = Vec::with_capacity(batch);
         for row in 0..batch {
-            let u: f32 = rng.r#gen();
+            let u: f32 = rng.random();
             let mut cum = 0.0;
             let mut chosen = (n_actions - 1) as i64;
             for j in 0..n_actions {

--- a/src/train/dqn/trainer.rs
+++ b/src/train/dqn/trainer.rs
@@ -261,8 +261,8 @@ impl DQNTrainer {
         let eps = self.config.epsilon_at(self.total_env_steps);
         self.last_epsilon = eps;
         let n_actions = self.online.n_actions();
-        if rng.r#gen::<f64>() < eps {
-            rng.gen_range(0..n_actions)
+        if rng.random::<f64>() < eps {
+            rng.random_range(0..n_actions)
         } else {
             self.greedy_action(obs)
         }

--- a/src/train/ppo/loss.rs
+++ b/src/train/ppo/loss.rs
@@ -122,10 +122,10 @@ pub fn compute_entropy_loss(entropy: &Tensor) -> Tensor {
 /// Vector of vectors, where each inner vector contains indices for one
 /// minibatch
 pub fn generate_minibatch_indices(buffer_size: usize, batch_size: usize) -> Vec<Vec<usize>> {
-    use rand::{seq::SliceRandom, thread_rng};
+    use rand::seq::SliceRandom;
 
     let mut indices: Vec<usize> = (0..buffer_size).collect();
-    indices.shuffle(&mut thread_rng());
+    indices.shuffle(&mut rand::rng());
 
     indices.chunks(batch_size).map(|chunk| chunk.to_vec()).collect()
 }


### PR DESCRIPTION
## Summary

Bumps `rand` from `0.8` to `0.9` (`Cargo.toml`) and migrates all rand 0.8 API usage to the 0.9 equivalents. `rand 0.9` renamed several methods to sidestep Rust 2024's `gen` reserved keyword, which was forcing `r#gen::<T>()` raw-identifier calls at three sites.

Closes #89.

## Actual API churn surfaced by the compiler

| rand 0.8 | rand 0.9 | Sites migrated |
| --- | --- | --- |
| `Rng::gen::<T>()` (a.k.a. `r#gen::<T>()`) | `Rng::random::<T>()` | 3 (the issue's known sites) + 1 (`mlp_burn.rs`) |
| `Rng::gen_range(a..b)` | `Rng::random_range(a..b)` | ~20 (cartpole, pong, simple_bandit, snake env, matchmaking, dqn trainer, optimize/space, replay buffer, prioritized buffer, pong self-play example) |
| `Rng::gen_bool(p)` | `Rng::random_bool(p)` | 5 (all in `pong.rs`) |
| `rand::thread_rng()` | `rand::rng()` | ~15 (cartpole, pong, snake env/snake/multi_agent, optimize/space, ppo/loss minibatch shuffle, rollout sampling, mlp_burn, four snake training examples) |
| `StdRng::from_entropy()` | `StdRng::from_os_rng()` | 4 (`simple_bandit.rs`, three `matchmaking.rs` matchmakers, `train_pong_self_play.rs`) |

`StdRng::from_entropy` was the only **hard removal** (compile error). All the `gen_*` / `thread_rng` calls were just deprecation warnings in 0.9 (shims still work), but I migrated them anyway since they're trivial mechanical renames.

## Rng trait import lines

All `use rand::Rng;` / `use rand::{Rng, SeedableRng, rngs::StdRng};` imports are still correct in 0.9. The `Rng` trait did not move. `SeedableRng` is still needed wherever `StdRng::seed_from_u64` or `StdRng::from_os_rng` is called.

## Behavior preserved (no opportunistic changes)

- **Trainer determinism unchanged**: DQN `select_action` still uses the caller-provided `&mut R: Rng` (no implicit RNG construction), and all the seeded `StdRng::seed_from_u64(N)` test fixtures are untouched. PPO/DQN seeded runs reproduce identically up to a single `r#gen::<f64>() < eps` to `random::<f64>() < eps` rename (semantically identical).
- **Default RNG is still `ThreadRng`**: `rand::rng()` in 0.9 returns the same `ThreadRng` as `rand::thread_rng()` in 0.8 — same algorithm (ChaCha12 by default), same seeding via OS entropy.
- **`StdRng::from_entropy()` → `from_os_rng()`** is a name-only rename (both pull from the OS CSPRNG via `getrandom`).
- **Doc comments** updated in two spots that mentioned the old API by name (`snake/environment.rs` doc-string referencing `thread_rng()`, `prioritized.rs` inline comment referencing `gen_range`).

## Transitive-dep concerns

`tch 0.22` still pins `rand 0.8`, so `Cargo.lock` now has both `rand v0.8.6` (via tch) and `rand v0.9.4` (us) co-existing. This is the expected outcome and produces no conflicts (verified via `cargo tree -i`).

## Test plan

- [x] `cargo build --features training` (with `LIBTORCH_USE_PYTORCH=1 LIBTORCH_BYPASS_VERSION_CHECK=1`)
- [x] `cargo build --features training --tests`
- [x] `cargo build --features training --examples`
- [x] `cargo build --no-default-features --features training-burn` (CPU-only, Burn scout)
- [x] `cargo build --no-default-features` (non-training surface)
- [x] `cargo test --features training` — all 216 lib tests + integration + 3 doc tests pass; no regressions
- [x] `cargo doc --no-deps --features training` clean
- [x] `cargo clippy --features training` — 82 warnings, identical count to main (no new warnings introduced)
- [x] Manual sweep: `grep -rn 'thread_rng\|gen_range\|gen_bool\|r#gen\|from_entropy' src/ examples/ tests/` returns no matches