### PR TITLE
Burn migration phase 2a: add Burn variants to buffer tensor surface

### DIFF
--- a/src/buffer/replay.rs
+++ b/src/buffer/replay.rs
@@ -50,7 +50,11 @@
 //! ```
 
 pub use prioritized::{PrioritizedBatch, PrioritizedReplayBuffer};
+#[cfg(feature = "training-burn")]
+pub use prioritized::PrioritizedBurnTensors;
 pub use sampling::{ReplayBatch, sample};
+#[cfg(feature = "training-burn")]
+pub use sampling::ReplayBurnTensors;
 pub use storage::ReplayBuffer;
 pub use sum_tree::SumTree;
 

--- a/src/buffer/replay.rs
+++ b/src/buffer/replay.rs
@@ -49,12 +49,12 @@
 //! }
 //! ```
 
-pub use prioritized::{PrioritizedBatch, PrioritizedReplayBuffer};
 #[cfg(feature = "training-burn")]
 pub use prioritized::PrioritizedBurnTensors;
-pub use sampling::{ReplayBatch, sample};
+pub use prioritized::{PrioritizedBatch, PrioritizedReplayBuffer};
 #[cfg(feature = "training-burn")]
 pub use sampling::ReplayBurnTensors;
+pub use sampling::{ReplayBatch, sample};
 pub use storage::ReplayBuffer;
 pub use sum_tree::SumTree;
 

--- a/src/buffer/replay/prioritized.rs
+++ b/src/buffer/replay/prioritized.rs
@@ -55,7 +55,11 @@
 //! - Schaul et al., *Prioritized Experience Replay* ([ICLR 2016](https://arxiv.org/abs/1511.05952)).
 
 use rand::Rng;
+#[cfg(feature = "training")]
 use tch::{Device, Tensor};
+
+#[cfg(feature = "training-burn")]
+use burn::tensor::{Int, Tensor as BurnTensor, TensorData, backend::Backend};
 
 use super::sum_tree::SumTree;
 
@@ -108,6 +112,7 @@ impl PrioritizedBatch {
     /// - `next_obs`: `[batch, obs_dim]`, `Kind::Float`
     /// - `dones`: `[batch]`, `Kind::Float` (0.0 or 1.0)
     /// - `is_weights`: `[batch]`, `Kind::Float`
+    #[cfg(feature = "training")]
     pub fn to_tensors(&self, device: Device) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor) {
         let batch = self.len() as i64;
         let obs_dim = self.obs_dim as i64;
@@ -126,6 +131,87 @@ impl PrioritizedBatch {
 
         (obs, actions, rewards, next_obs, dones, is_weights)
     }
+
+    /// Stack the batch into Burn tensors on `device`.
+    ///
+    /// Parallel to [`Self::to_tensors`] but emits a named
+    /// [`PrioritizedBurnTensors`] struct so the DQN trainer can grab
+    /// fields by name. Includes the importance-sampling weights that the
+    /// uniform [`super::ReplayBatch`] does not carry.
+    ///
+    /// Shapes (all on `device`):
+    /// - `observations`: `[batch, obs_dim]`, `f32`
+    /// - `actions`: `[batch]`, `i64`
+    /// - `rewards`: `[batch]`, `f32`
+    /// - `next_observations`: `[batch, obs_dim]`, `f32`
+    /// - `dones`: `[batch]`, `f32` (0.0 / 1.0)
+    /// - `is_weights`: `[batch]`, `f32`
+    ///
+    /// Note: `indices` is *not* a tensor — leaf-index round-trips back
+    /// into [`PrioritizedReplayBuffer::update_priorities`] as a host
+    /// `&[usize]`, so it stays on `self`.
+    #[cfg(feature = "training-burn")]
+    pub fn to_burn_tensors<B: Backend>(&self, device: &B::Device) -> PrioritizedBurnTensors<B> {
+        let batch = self.len();
+        let obs_dim = self.obs_dim;
+
+        // Direct rank-2 construction (vs. rank-1 + reshape) to keep the
+        // empty-batch case panic-free; the reshape path trips an internal
+        // shape assertion in cubecl-zspace when both dims are zero.
+        let observations = BurnTensor::<B, 2>::from_data(
+            TensorData::new(self.observations.clone(), [batch, obs_dim]),
+            device,
+        );
+        let next_observations = BurnTensor::<B, 2>::from_data(
+            TensorData::new(self.next_observations.clone(), [batch, obs_dim]),
+            device,
+        );
+        let actions = BurnTensor::<B, 1, Int>::from_data(
+            TensorData::new(self.actions.clone(), [batch]),
+            device,
+        );
+        let rewards =
+            BurnTensor::<B, 1>::from_data(TensorData::new(self.rewards.clone(), [batch]), device);
+        let dones_f: Vec<f32> = self.dones.iter().map(|&d| if d { 1.0 } else { 0.0 }).collect();
+        let dones = BurnTensor::<B, 1>::from_data(TensorData::new(dones_f, [batch]), device);
+        let is_weights = BurnTensor::<B, 1>::from_data(
+            TensorData::new(self.is_weights.clone(), [batch]),
+            device,
+        );
+
+        PrioritizedBurnTensors {
+            observations,
+            actions,
+            rewards,
+            next_observations,
+            dones,
+            is_weights,
+        }
+    }
+}
+
+/// Bundle of Burn tensors produced by [`PrioritizedBatch::to_burn_tensors`].
+///
+/// Adds the per-sample importance-sampling weights on top of the
+/// `ReplayBurnTensors` field set. The trainer multiplies the per-row
+/// TD-error magnitude by `is_weights` before reducing to a scalar loss
+/// — this is the bias correction described in Schaul et al. §3.4.
+#[cfg(feature = "training-burn")]
+#[derive(Debug)]
+pub struct PrioritizedBurnTensors<B: Backend> {
+    /// Observations, shape `[batch, obs_dim]`, dtype `f32`.
+    pub observations: BurnTensor<B, 2>,
+    /// Discrete actions, shape `[batch]`, dtype `i64`.
+    pub actions: BurnTensor<B, 1, Int>,
+    /// Rewards, shape `[batch]`, dtype `f32`.
+    pub rewards: BurnTensor<B, 1>,
+    /// Bootstrap-state observations, shape `[batch, obs_dim]`, dtype `f32`.
+    pub next_observations: BurnTensor<B, 2>,
+    /// Episode-terminal mask (0.0 or 1.0), shape `[batch]`, dtype `f32`.
+    pub dones: BurnTensor<B, 1>,
+    /// Importance-sampling weights, shape `[batch]`, dtype `f32`,
+    /// normalized so the max element is `1.0`.
+    pub is_weights: BurnTensor<B, 1>,
 }
 
 /// Fixed-capacity prioritized replay buffer.
@@ -620,6 +706,7 @@ mod tests {
         assert!((batch.is_weights[0] - 1.0).abs() < 1e-6);
     }
 
+    #[cfg(feature = "training")]
     #[test]
     fn test_to_tensors_shapes() {
         let mut buf = PrioritizedReplayBuffer::new(8, 4, 0.6, 1e-6);
@@ -635,6 +722,71 @@ mod tests {
         assert_eq!(rewards.size(), vec![3]);
         assert_eq!(dones.size(), vec![3]);
         assert_eq!(is_weights.size(), vec![3]);
+    }
+
+    #[cfg(feature = "training-burn")]
+    mod burn_tests {
+        use burn::backend::NdArray;
+
+        use super::*;
+
+        type B = NdArray<f32>;
+
+        #[test]
+        fn test_to_burn_tensors_shapes_and_roundtrip() {
+            let mut buf = PrioritizedReplayBuffer::new(8, 4, 0.6, 1e-6);
+            for i in 0..6 {
+                buf.push(&[i as f32; 4], (i % 2) as i64, i as f32, &[i as f32 + 1.0; 4], i == 5);
+            }
+            let mut rng = StdRng::seed_from_u64(1);
+            let batch = buf.sample(3, 0.4, &mut rng);
+            let device = crate::utils::cuda::default_burn_device::<B>();
+            let t = batch.to_burn_tensors::<B>(&device);
+
+            assert_eq!(t.observations.dims(), [3, 4]);
+            assert_eq!(t.next_observations.dims(), [3, 4]);
+            assert_eq!(t.actions.dims(), [3]);
+            assert_eq!(t.rewards.dims(), [3]);
+            assert_eq!(t.dones.dims(), [3]);
+            assert_eq!(t.is_weights.dims(), [3]);
+
+            let obs_flat: Vec<f32> = t.observations.into_data().to_vec().unwrap();
+            assert_eq!(obs_flat, batch.observations);
+            let next_flat: Vec<f32> = t.next_observations.into_data().to_vec().unwrap();
+            assert_eq!(next_flat, batch.next_observations);
+            let acts: Vec<i64> = t.actions.into_data().to_vec().unwrap();
+            assert_eq!(acts, batch.actions);
+            let rews: Vec<f32> = t.rewards.into_data().to_vec().unwrap();
+            assert_eq!(rews, batch.rewards);
+            let isw: Vec<f32> = t.is_weights.into_data().to_vec().unwrap();
+            assert_eq!(isw, batch.is_weights);
+            let dones_f: Vec<f32> = t.dones.into_data().to_vec().unwrap();
+            let expected_dones: Vec<f32> =
+                batch.dones.iter().map(|&d| if d { 1.0 } else { 0.0 }).collect();
+            assert_eq!(dones_f, expected_dones);
+        }
+
+        #[test]
+        fn test_to_burn_tensors_empty_batch_does_not_panic() {
+            let batch = PrioritizedBatch {
+                observations: vec![],
+                actions: vec![],
+                rewards: vec![],
+                next_observations: vec![],
+                dones: vec![],
+                is_weights: vec![],
+                indices: vec![],
+                obs_dim: 4,
+            };
+            let device = crate::utils::cuda::default_burn_device::<B>();
+            let t = batch.to_burn_tensors::<B>(&device);
+            assert_eq!(t.observations.dims(), [0, 4]);
+            assert_eq!(t.next_observations.dims(), [0, 4]);
+            assert_eq!(t.actions.dims(), [0]);
+            assert_eq!(t.rewards.dims(), [0]);
+            assert_eq!(t.dones.dims(), [0]);
+            assert_eq!(t.is_weights.dims(), [0]);
+        }
     }
 
     #[test]

--- a/src/buffer/replay/prioritized.rs
+++ b/src/buffer/replay/prioritized.rs
@@ -54,12 +54,11 @@
 //!
 //! - Schaul et al., *Prioritized Experience Replay* ([ICLR 2016](https://arxiv.org/abs/1511.05952)).
 
+#[cfg(feature = "training-burn")]
+use burn::tensor::{Int, Tensor as BurnTensor, TensorData, backend::Backend};
 use rand::Rng;
 #[cfg(feature = "training")]
 use tch::{Device, Tensor};
-
-#[cfg(feature = "training-burn")]
-use burn::tensor::{Int, Tensor as BurnTensor, TensorData, backend::Backend};
 
 use super::sum_tree::SumTree;
 

--- a/src/buffer/replay/sampling.rs
+++ b/src/buffer/replay/sampling.rs
@@ -5,9 +5,19 @@
 //! transitions into flat CPU-side vectors. `ReplayBatch::to_tensors`
 //! then stacks those vectors into `tch::Tensor`s on the requested
 //! device so the trainer can run a single Q-network forward pass.
+//!
+//! For the in-flight Burn migration (#65), `ReplayBatch::to_burn_tensors`
+//! produces the equivalent bundle as Burn tensors. The two methods are
+//! parallel surfaces, gated by `feature = "training"` and
+//! `feature = "training-burn"` respectively; nothing in the storage
+//! layout itself depends on the choice of tensor backend.
 
 use rand::Rng;
+#[cfg(feature = "training")]
 use tch::{Device, Tensor};
+
+#[cfg(feature = "training-burn")]
+use burn::tensor::{Int, Tensor as BurnTensor, TensorData, backend::Backend};
 
 use super::storage::ReplayBuffer;
 
@@ -52,6 +62,7 @@ impl ReplayBatch {
     /// - `next_obs`: `[batch, obs_dim]`, `Kind::Float`
     /// - `dones`: `[batch]`, `Kind::Float` (0.0 or 1.0 — Kind::Float is what
     ///   the TD-target formula `(1 - done)` needs).
+    #[cfg(feature = "training")]
     pub fn to_tensors(&self, device: Device) -> (Tensor, Tensor, Tensor, Tensor, Tensor) {
         let batch = self.len() as i64;
         let obs_dim = self.obs_dim as i64;
@@ -69,6 +80,71 @@ impl ReplayBatch {
 
         (obs, actions, rewards, next_obs, dones)
     }
+
+    /// Stack the batch into Burn tensors on `device`.
+    ///
+    /// Parallel to [`Self::to_tensors`] but emits a named
+    /// [`ReplayBurnTensors`] struct so trainers can pattern-match named
+    /// fields rather than positional tuple elements. Mirrors the
+    /// `RolloutTchTensors` convention introduced in #86.
+    ///
+    /// Shapes (all on `device`):
+    /// - `observations`: `[batch, obs_dim]`, `f32`
+    /// - `actions`: `[batch]`, `i64` (Burn `Int` kind)
+    /// - `rewards`: `[batch]`, `f32`
+    /// - `next_observations`: `[batch, obs_dim]`, `f32`
+    /// - `dones`: `[batch]`, `f32` (0.0 / 1.0 — same convention as the
+    ///   tch path so the `(1 - done)` TD-target formula carries over).
+    #[cfg(feature = "training-burn")]
+    pub fn to_burn_tensors<B: Backend>(&self, device: &B::Device) -> ReplayBurnTensors<B> {
+        let batch = self.len();
+        let obs_dim = self.obs_dim;
+
+        // Direct rank-2 construction (vs. rank-1 + reshape) to keep the
+        // empty-batch case panic-free; the reshape path trips an internal
+        // shape assertion in cubecl-zspace when both dims are zero.
+        let observations = BurnTensor::<B, 2>::from_data(
+            TensorData::new(self.observations.clone(), [batch, obs_dim]),
+            device,
+        );
+        let next_observations = BurnTensor::<B, 2>::from_data(
+            TensorData::new(self.next_observations.clone(), [batch, obs_dim]),
+            device,
+        );
+        let actions = BurnTensor::<B, 1, Int>::from_data(
+            TensorData::new(self.actions.clone(), [batch]),
+            device,
+        );
+        let rewards =
+            BurnTensor::<B, 1>::from_data(TensorData::new(self.rewards.clone(), [batch]), device);
+        let dones_f: Vec<f32> = self.dones.iter().map(|&d| if d { 1.0 } else { 0.0 }).collect();
+        let dones = BurnTensor::<B, 1>::from_data(TensorData::new(dones_f, [batch]), device);
+
+        ReplayBurnTensors { observations, actions, rewards, next_observations, dones }
+    }
+}
+
+/// Bundle of Burn tensors produced by [`ReplayBatch::to_burn_tensors`].
+///
+/// Fields are in the order DQN trainers consume them: state and action
+/// first, then the reward signal, then the bootstrap state and terminal
+/// mask used to build the TD target. Parallel to the tch path's positional
+/// 5-tuple but named so callers can grab fields by name (which keeps
+/// downstream patches that add fields source-compatible).
+#[cfg(feature = "training-burn")]
+#[derive(Debug)]
+pub struct ReplayBurnTensors<B: Backend> {
+    /// Observations, shape `[batch, obs_dim]`, dtype `f32`.
+    pub observations: BurnTensor<B, 2>,
+    /// Discrete actions, shape `[batch]`, dtype `i64`.
+    pub actions: BurnTensor<B, 1, Int>,
+    /// Rewards, shape `[batch]`, dtype `f32`.
+    pub rewards: BurnTensor<B, 1>,
+    /// Bootstrap-state observations, shape `[batch, obs_dim]`, dtype `f32`.
+    pub next_observations: BurnTensor<B, 2>,
+    /// Episode-terminal mask (0.0 or 1.0), shape `[batch]`, dtype `f32`.
+    /// Kept as `f32` so the TD-target formula `(1 - done)` works directly.
+    pub dones: BurnTensor<B, 1>,
 }
 
 /// Sample `batch_size` transitions uniformly with replacement from the
@@ -109,6 +185,7 @@ pub fn sample<R: Rng>(buffer: &ReplayBuffer, batch_size: usize, rng: &mut R) -> 
 #[cfg(test)]
 mod tests {
     use rand::{SeedableRng, rngs::StdRng};
+    #[cfg(feature = "training")]
     use tch::Kind;
 
     use super::*;
@@ -153,6 +230,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "training")]
     #[test]
     fn test_to_tensors_shapes() {
         let mut buf = ReplayBuffer::new(8, 4);
@@ -171,6 +249,73 @@ mod tests {
         assert_eq!(rewards.kind(), Kind::Float);
         // dones tensor is float-valued so it can be used in (1 - done)
         assert_eq!(dones.kind(), Kind::Float);
+    }
+
+    #[cfg(feature = "training-burn")]
+    mod burn_tests {
+        use burn::backend::NdArray;
+
+        use super::*;
+
+        type B = NdArray<f32>;
+
+        #[test]
+        fn test_to_burn_tensors_shapes_and_roundtrip() {
+            let mut buf = ReplayBuffer::new(8, 4);
+            for i in 0..6 {
+                buf.push(&[i as f32; 4], (i % 2) as i64, i as f32, &[i as f32 + 1.0; 4], i == 5);
+            }
+            let mut rng = StdRng::seed_from_u64(1);
+            let batch = sample(&buf, 3, &mut rng);
+            let device = crate::utils::cuda::default_burn_device::<B>();
+            let t = batch.to_burn_tensors::<B>(&device);
+
+            // Shapes.
+            assert_eq!(t.observations.dims(), [3, 4]);
+            assert_eq!(t.next_observations.dims(), [3, 4]);
+            assert_eq!(t.actions.dims(), [3]);
+            assert_eq!(t.rewards.dims(), [3]);
+            assert_eq!(t.dones.dims(), [3]);
+
+            // Round-trip: copying out the host data should match the
+            // CPU-side `Vec`s the batch was built from. Observations are
+            // reshaped to `[3, 4]` but the underlying buffer order is the
+            // same row-major flatten.
+            let obs_flat: Vec<f32> = t.observations.into_data().to_vec().unwrap();
+            assert_eq!(obs_flat, batch.observations);
+            let next_flat: Vec<f32> = t.next_observations.into_data().to_vec().unwrap();
+            assert_eq!(next_flat, batch.next_observations);
+            let acts: Vec<i64> = t.actions.into_data().to_vec().unwrap();
+            assert_eq!(acts, batch.actions);
+            let rews: Vec<f32> = t.rewards.into_data().to_vec().unwrap();
+            assert_eq!(rews, batch.rewards);
+            let dones_f: Vec<f32> = t.dones.into_data().to_vec().unwrap();
+            let expected_dones: Vec<f32> =
+                batch.dones.iter().map(|&d| if d { 1.0 } else { 0.0 }).collect();
+            assert_eq!(dones_f, expected_dones);
+        }
+
+        #[test]
+        fn test_to_burn_tensors_empty_batch_does_not_panic() {
+            // A 0-row batch must produce well-formed zero-element tensors.
+            // The buffer-side `sample` API doesn't accept batch_size == 0,
+            // so build the batch by hand to exercise the edge case.
+            let batch = ReplayBatch {
+                observations: vec![],
+                actions: vec![],
+                rewards: vec![],
+                next_observations: vec![],
+                dones: vec![],
+                obs_dim: 4,
+            };
+            let device = crate::utils::cuda::default_burn_device::<B>();
+            let t = batch.to_burn_tensors::<B>(&device);
+            assert_eq!(t.observations.dims(), [0, 4]);
+            assert_eq!(t.next_observations.dims(), [0, 4]);
+            assert_eq!(t.actions.dims(), [0]);
+            assert_eq!(t.rewards.dims(), [0]);
+            assert_eq!(t.dones.dims(), [0]);
+        }
     }
 
     #[test]

--- a/src/buffer/replay/sampling.rs
+++ b/src/buffer/replay/sampling.rs
@@ -12,12 +12,11 @@
 //! `feature = "training-burn"` respectively; nothing in the storage
 //! layout itself depends on the choice of tensor backend.
 
+#[cfg(feature = "training-burn")]
+use burn::tensor::{Int, Tensor as BurnTensor, TensorData, backend::Backend};
 use rand::Rng;
 #[cfg(feature = "training")]
 use tch::{Device, Tensor};
-
-#[cfg(feature = "training-burn")]
-use burn::tensor::{Int, Tensor as BurnTensor, TensorData, backend::Backend};
 
 use super::storage::ReplayBuffer;
 
@@ -93,8 +92,8 @@ impl ReplayBatch {
     /// - `actions`: `[batch]`, `i64` (Burn `Int` kind)
     /// - `rewards`: `[batch]`, `f32`
     /// - `next_observations`: `[batch, obs_dim]`, `f32`
-    /// - `dones`: `[batch]`, `f32` (0.0 / 1.0 — same convention as the
-    ///   tch path so the `(1 - done)` TD-target formula carries over).
+    /// - `dones`: `[batch]`, `f32` (0.0 / 1.0 — same convention as the tch path
+    ///   so the `(1 - done)` TD-target formula carries over).
     #[cfg(feature = "training-burn")]
     pub fn to_burn_tensors<B: Backend>(&self, device: &B::Device) -> ReplayBurnTensors<B> {
         let batch = self.len();

--- a/src/buffer/rollout.rs
+++ b/src/buffer/rollout.rs
@@ -23,7 +23,11 @@ pub use sampling::{
     Minibatch, MinibatchIterator, generate_minibatch_indices, sample_minibatch, shuffle_indices,
     train_val_split,
 };
-pub use storage::{RolloutBatch, RolloutBuffer, RolloutTchTensors};
+pub use storage::{RolloutBatch, RolloutBuffer};
+#[cfg(feature = "training-burn")]
+pub use storage::RolloutBurnTensors;
+#[cfg(feature = "training")]
+pub use storage::RolloutTchTensors;
 
 // Submodules
 mod gae;

--- a/src/buffer/rollout.rs
+++ b/src/buffer/rollout.rs
@@ -23,11 +23,11 @@ pub use sampling::{
     Minibatch, MinibatchIterator, generate_minibatch_indices, sample_minibatch, shuffle_indices,
     train_val_split,
 };
-pub use storage::{RolloutBatch, RolloutBuffer};
 #[cfg(feature = "training-burn")]
 pub use storage::RolloutBurnTensors;
 #[cfg(feature = "training")]
 pub use storage::RolloutTchTensors;
+pub use storage::{RolloutBatch, RolloutBuffer};
 
 // Submodules
 mod gae;

--- a/src/buffer/rollout/storage.rs
+++ b/src/buffer/rollout/storage.rs
@@ -2,6 +2,16 @@
 //!
 //! This module handles the core storage functionality for rollout buffers,
 //! including data insertion, retrieval, and buffer management.
+//!
+//! The host-side storage layout (`Vec<f32>` / `Vec<i64>`) is deliberately
+//! backend-agnostic. The two tensor-emitting surfaces —
+//! [`RolloutBatch::to_tch_tensors`] (tch path) and
+//! [`RolloutBatch::to_burn_tensors`] (Burn path, #65) — are gated behind
+//! disjoint features so that `--features training-burn` does not drag in
+//! tch and vice versa.
+
+#[cfg(feature = "training-burn")]
+use burn::tensor::{Int, Tensor as BurnTensor, TensorData, backend::Backend};
 
 /// Rollout buffer for storing trajectories
 ///
@@ -365,11 +375,11 @@ impl RolloutBatch {
     /// the dimensions reported by [`Self::obs_shape`].
     ///
     /// # Notes
-    /// - This helper is intentionally tch-only; the planned Burn migration will
-    ///   add a sibling `to_burn_tensors` method.
     /// - For empty batches the observation tensor is still shaped `[0, 0]` to
     ///   match the existing inline behavior, which simply produced a
     ///   zero-element tensor.
+    /// - The Burn-backend sibling is [`Self::to_burn_tensors`].
+    #[cfg(feature = "training")]
     pub fn to_tch_tensors(&self, device: tch::Device) -> RolloutTchTensors {
         let (batch_size, obs_dim) = self.obs_shape();
 
@@ -384,6 +394,62 @@ impl RolloutBatch {
 
         RolloutTchTensors { observations, actions, old_log_probs, old_values, advantages, returns }
     }
+
+    /// Construct the full set of training tensors as Burn tensors on
+    /// `device`.
+    ///
+    /// Parallel to [`Self::to_tch_tensors`] but emits a named
+    /// [`RolloutBurnTensors`] bundle (Burn migration epic #65, phase 2a).
+    /// The host-side fields of `RolloutBatch` are unchanged; only the
+    /// tensor type at the boundary is different.
+    ///
+    /// Shapes (all on `device`):
+    /// - `observations`: `[batch, obs_dim]`, `f32`
+    /// - `actions`: `[batch]`, `i64` (Burn `Int` kind)
+    /// - `old_log_probs`: `[batch]`, `f32`
+    /// - `old_values`: `[batch]`, `f32`
+    /// - `advantages`: `[batch]`, `f32`
+    /// - `returns`: `[batch]`, `f32`
+    ///
+    /// Empty batches still produce well-formed `[0, obs_dim]` /
+    /// `[0]` tensors. The `obs_dim` is derived from
+    /// [`Self::obs_shape`] (which returns `0` for an empty batch), so
+    /// the observation tensor for the empty case is shaped `[0, 0]`.
+    #[cfg(feature = "training-burn")]
+    pub fn to_burn_tensors<B: Backend>(&self, device: &B::Device) -> RolloutBurnTensors<B> {
+        let (batch_size, obs_dim) = self.obs_shape();
+
+        // Construct the rank-2 observation tensor directly rather than
+        // building a rank-1 tensor and reshaping. The reshape path hits a
+        // panic deep in cubecl-zspace when both dims are zero (empty
+        // batch), and direct rank-2 construction sidesteps that edge case.
+        let observations = BurnTensor::<B, 2>::from_data(
+            TensorData::new(self.observations.clone(), [batch_size, obs_dim]),
+            device,
+        );
+        let actions = BurnTensor::<B, 1, Int>::from_data(
+            TensorData::new(self.actions.clone(), [batch_size]),
+            device,
+        );
+        let old_log_probs = BurnTensor::<B, 1>::from_data(
+            TensorData::new(self.old_log_probs.clone(), [batch_size]),
+            device,
+        );
+        let old_values = BurnTensor::<B, 1>::from_data(
+            TensorData::new(self.old_values.clone(), [batch_size]),
+            device,
+        );
+        let advantages = BurnTensor::<B, 1>::from_data(
+            TensorData::new(self.advantages.clone(), [batch_size]),
+            device,
+        );
+        let returns = BurnTensor::<B, 1>::from_data(
+            TensorData::new(self.returns.clone(), [batch_size]),
+            device,
+        );
+
+        RolloutBurnTensors { observations, actions, old_log_probs, old_values, advantages, returns }
+    }
 }
 
 /// Bundle of tch tensors produced by [`RolloutBatch::to_tch_tensors`].
@@ -392,6 +458,7 @@ impl RolloutBatch {
 /// inputs first (observations, actions), then the old policy outputs
 /// (log-probs and values used for the importance ratio and value clip),
 /// then the GAE outputs (advantages and returns).
+#[cfg(feature = "training")]
 #[derive(Debug)]
 pub struct RolloutTchTensors {
     /// Observations, shape `[batch_size, obs_dim]`, dtype `f32`.
@@ -414,6 +481,40 @@ pub struct RolloutTchTensors {
     /// Value-function targets (advantages + values), shape
     /// `[batch_size]`, dtype `f32`.
     pub returns: tch::Tensor,
+}
+
+/// Bundle of Burn tensors produced by [`RolloutBatch::to_burn_tensors`].
+///
+/// Mirrors [`RolloutTchTensors`] field-for-field — the only difference is
+/// the tensor type. Generic over the backend `B` so the same trainer
+/// surface works for CPU (`NdArray`), GPU (`Wgpu`, `Cuda`), and
+/// `Autodiff<_>` wrappers. The const-rank parameters (`Tensor<B, 2>` for
+/// observations, `Tensor<B, 1>` for the scalar-per-row fields) are
+/// concrete here so trainer code does not need turbofish at every call
+/// site (friction point #3 from the phase-1 scout report).
+#[cfg(feature = "training-burn")]
+#[derive(Debug)]
+pub struct RolloutBurnTensors<B: Backend> {
+    /// Observations, shape `[batch_size, obs_dim]`, dtype `f32`.
+    pub observations: BurnTensor<B, 2>,
+
+    /// Discrete actions, shape `[batch_size]`, dtype `i64`.
+    pub actions: BurnTensor<B, 1, Int>,
+
+    /// Behavior-policy log-probabilities, shape `[batch_size]`,
+    /// dtype `f32`.
+    pub old_log_probs: BurnTensor<B, 1>,
+
+    /// Behavior-policy value estimates `V(s_t)`, shape `[batch_size]`,
+    /// dtype `f32`.
+    pub old_values: BurnTensor<B, 1>,
+
+    /// GAE advantages, shape `[batch_size]`, dtype `f32`.
+    pub advantages: BurnTensor<B, 1>,
+
+    /// Value-function targets (advantages + values), shape
+    /// `[batch_size]`, dtype `f32`.
+    pub returns: BurnTensor<B, 1>,
 }
 
 #[cfg(test)]
@@ -517,6 +618,7 @@ mod tests {
         let _ = RolloutBatch::from_buffer_partial(&buffer, 5);
     }
 
+    #[cfg(feature = "training")]
     #[test]
     fn test_to_tch_tensors_matches_inline_construction() {
         // The helper must produce tensors byte-for-byte equivalent to the
@@ -562,6 +664,7 @@ mod tests {
         assert_eq!(ret, batch.returns);
     }
 
+    #[cfg(feature = "training")]
     #[test]
     fn test_to_tch_tensors_empty_batch() {
         // Empty batches must still produce well-formed (zero-element)
@@ -585,6 +688,80 @@ mod tests {
         assert_eq!(t.old_values.size(), vec![0]);
         assert_eq!(t.advantages.size(), vec![0]);
         assert_eq!(t.returns.size(), vec![0]);
+    }
+
+    #[cfg(feature = "training-burn")]
+    mod burn_tests {
+        use burn::backend::NdArray;
+
+        use super::*;
+
+        type B = NdArray<f32>;
+
+        #[test]
+        fn test_to_burn_tensors_matches_inline_construction() {
+            // Mirrors the tch round-trip test: shapes + element-wise equality
+            // against the source `Vec`s the batch was built from.
+            let batch = RolloutBatch {
+                observations: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+                actions: vec![0, 1, 0],
+                old_log_probs: vec![-0.1, -0.2, -0.3],
+                old_values: vec![0.5, 0.7, 0.9],
+                advantages: vec![0.1, -0.2, 0.3],
+                returns: vec![0.6, 0.5, 1.2],
+            };
+
+            let device = crate::utils::cuda::default_burn_device::<B>();
+            let t = batch.to_burn_tensors::<B>(&device);
+
+            // Shapes.
+            assert_eq!(t.observations.dims(), [3, 2]);
+            assert_eq!(t.actions.dims(), [3]);
+            assert_eq!(t.old_log_probs.dims(), [3]);
+            assert_eq!(t.old_values.dims(), [3]);
+            assert_eq!(t.advantages.dims(), [3]);
+            assert_eq!(t.returns.dims(), [3]);
+
+            // Round-trip values. Observations are row-major flatten, so
+            // copying the `[3, 2]` tensor back to a `Vec<f32>` must equal
+            // the original 1-D buffer.
+            let obs_flat: Vec<f32> = t.observations.into_data().to_vec().unwrap();
+            assert_eq!(obs_flat, batch.observations);
+            let acts: Vec<i64> = t.actions.into_data().to_vec().unwrap();
+            assert_eq!(acts, batch.actions);
+            let lp: Vec<f32> = t.old_log_probs.into_data().to_vec().unwrap();
+            assert_eq!(lp, batch.old_log_probs);
+            let v: Vec<f32> = t.old_values.into_data().to_vec().unwrap();
+            assert_eq!(v, batch.old_values);
+            let adv: Vec<f32> = t.advantages.into_data().to_vec().unwrap();
+            assert_eq!(adv, batch.advantages);
+            let ret: Vec<f32> = t.returns.into_data().to_vec().unwrap();
+            assert_eq!(ret, batch.returns);
+        }
+
+        #[test]
+        fn test_to_burn_tensors_empty_batch() {
+            // Empty batch → `[0, 0]` observation tensor and `[0]`
+            // scalar-per-row tensors, matching the tch path's edge case.
+            let batch = RolloutBatch {
+                observations: vec![],
+                actions: vec![],
+                old_log_probs: vec![],
+                old_values: vec![],
+                advantages: vec![],
+                returns: vec![],
+            };
+
+            let device = crate::utils::cuda::default_burn_device::<B>();
+            let t = batch.to_burn_tensors::<B>(&device);
+
+            assert_eq!(t.observations.dims(), [0, 0]);
+            assert_eq!(t.actions.dims(), [0]);
+            assert_eq!(t.old_log_probs.dims(), [0]);
+            assert_eq!(t.old_values.dims(), [0]);
+            assert_eq!(t.advantages.dims(), [0]);
+            assert_eq!(t.returns.dims(), [0]);
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,14 @@ pub mod env;
 pub mod policy;
 
 /// Experience buffers and replay management (requires training feature)
-#[cfg(feature = "training")]
+///
+/// Gated on either backend (tch `training` or burn `training-burn`) —
+/// the storage layer is plain `Vec<f32>`/`Vec<i64>` regardless of which
+/// tensor framework the trainer ultimately uses. The Burn migration
+/// (#65) keeps the two tensor-emitting surfaces in this module behind
+/// disjoint cfgs so that `--features training-burn` can lean on the
+/// existing buffers without dragging in tch.
+#[cfg(any(feature = "training", feature = "training-burn"))]
 pub mod buffer;
 
 /// Training algorithms (PPO, etc.) (requires training feature)

--- a/src/utils/cuda.rs
+++ b/src/utils/cuda.rs
@@ -89,3 +89,55 @@ pub fn ensure_cuda_if_expected(device: Device) {
 #[cfg(not(feature = "training"))]
 #[allow(dead_code)]
 pub fn ensure_cuda_if_expected(_device: &()) {}
+
+/// Backend-generic default device helper for the Burn path.
+///
+/// Burn's device type is associated with the backend (`B::Device`); each
+/// backend implements `Default` for it, so for CPU (`NdArray`) this returns
+/// the singleton CPU device, for `Wgpu` the default GPU adapter, and so on.
+/// Trainer code that wants to stay backend-agnostic should call this
+/// instead of constructing a device manually.
+///
+/// Parallels the tch-path convention of using
+/// [`tch::Device::cuda_if_available`] (or `Device::Cpu`); a unified helper
+/// across both backends is deferred to phase 6 of the Burn migration
+/// (#65).
+///
+/// # Example
+/// ```rust,no_run
+/// # #[cfg(feature = "training-burn")]
+/// # {
+/// use burn::backend::NdArray;
+/// use thrust_rl::utils::cuda::default_burn_device;
+///
+/// let device = default_burn_device::<NdArray<f32>>();
+/// # let _ = device;
+/// # }
+/// ```
+#[cfg(feature = "training-burn")]
+pub fn default_burn_device<B: burn::tensor::backend::Backend>()
+-> <B as burn::tensor::backend::BackendTypes>::Device {
+    <<B as burn::tensor::backend::BackendTypes>::Device as Default>::default()
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "training-burn")]
+    #[test]
+    fn test_default_burn_device_ndarray_smoke() {
+        // Sanity-check: the helper compiles, returns a device, and the
+        // returned device can actually allocate a tensor (i.e. it isn't
+        // some uninitialized placeholder).
+        use burn::{
+            backend::NdArray,
+            tensor::{Tensor, TensorData},
+        };
+
+        type B = NdArray<f32>;
+        let device = super::default_burn_device::<B>();
+        let t: Tensor<B, 1> = Tensor::from_data(TensorData::new(vec![1.0_f32, 2.0, 3.0], [3]), &device);
+        assert_eq!(t.dims(), [3]);
+        let data: Vec<f32> = t.into_data().to_vec().unwrap();
+        assert_eq!(data, vec![1.0, 2.0, 3.0]);
+    }
+}

--- a/src/utils/cuda.rs
+++ b/src/utils/cuda.rs
@@ -135,7 +135,8 @@ mod tests {
 
         type B = NdArray<f32>;
         let device = super::default_burn_device::<B>();
-        let t: Tensor<B, 1> = Tensor::from_data(TensorData::new(vec![1.0_f32, 2.0, 3.0], [3]), &device);
+        let t: Tensor<B, 1> =
+            Tensor::from_data(TensorData::new(vec![1.0_f32, 2.0, 3.0], [3]), &device);
         assert_eq!(t.dims(), [3]);
         let data: Vec<f32> = t.into_data().to_vec().unwrap();
         assert_eq!(data, vec![1.0, 2.0, 3.0]);


### PR DESCRIPTION
Closes #79

## Summary

Phase 2a of the Burn migration epic (#65). Adds parallel Burn-backed
tensor-emitting methods alongside the existing tch ones on the three
batch types the trainers consume, plus a backend-generic device helper.

Trainer structs, optimizer fields, and policy networks are deliberately
out of scope — those are phase 2b, phase 3 (#80), and phase 4. Phase 3's
algorithm port can integrate against the named-struct surface introduced
here without further changes.

## Changes

**New Burn surfaces** (gated `feature = "training-burn"`):

- `ReplayBatch::to_burn_tensors<B>(device) -> ReplayBurnTensors<B>`
- `PrioritizedBatch::to_burn_tensors<B>(device) -> PrioritizedBurnTensors<B>`
- `RolloutBatch::to_burn_tensors<B>(device) -> RolloutBurnTensors<B>`
- `utils::cuda::default_burn_device<B>() -> B::Device`

**cfg gating** (per phase 1 scout friction #4):

- Widened the `pub mod buffer` gate in `src/lib.rs` to
  `any(feature = "training", feature = "training-burn")`. Storage is
  plain `Vec<f32>` / `Vec<i64>` so the inner data structures are
  backend-agnostic; the tensor-emitting methods remain disjointly gated.
- Existing `to_tensors` / `to_tch_tensors` methods are now explicitly
  gated `feature = "training"`.
- `RolloutTchTensors` re-export is feature-gated; `RolloutBurnTensors`,
  `ReplayBurnTensors`, and `PrioritizedBurnTensors` are exported behind
  the `training-burn` gate.

**Implementation note:** observation tensors are constructed directly as
rank-2 (`TensorData::new(vec, [batch, obs_dim])`) rather than rank-1 +
`reshape([batch, obs_dim])`. The reshape path hits an internal shape
assertion in `cubecl-zspace` when both dims are zero (empty batch);
direct rank-2 construction sidesteps that edge case.

## Definition of done

- [x] `cargo build --features training` succeeds.
- [x] `cargo build --no-default-features --features training-burn` succeeds.
- [x] `cargo build --features training,training-burn` succeeds.
- [x] `cargo test --features training --lib` — 216 passed, 0 failed.
- [x] `cargo test --no-default-features --features training-burn --lib` — 121 passed.
- [x] `cargo test --features training,training-burn --lib buffer::` — 60 passed.
- [x] Round-trip + empty-batch tests on `NdArray<f32>` for each batch type.
- [x] `default_burn_device<B>()` smoke test against `NdArray`.
- [x] No `tch::nn::Optimizer` field touched.

## LOC

Total diff is **545 insertions / 4 deletions across 7 files**, slightly
above the 400 LOC ceiling in the issue. The overage is almost entirely
in test bodies and doc-comments — the production code itself stays
mechanical and additive. Flagging here for reviewer awareness rather
than chasing the soft target by trimming the test coverage the DoD
explicitly asks for.

## Test plan

- [x] cargo build --features training
- [x] cargo build --no-default-features --features training-burn
- [x] cargo build --features training,training-burn
- [x] cargo test --features training --lib
- [x] cargo test --no-default-features --features training-burn --lib
- [x] cargo build --no-default-features --features training-burn --example train_simple_bandit_burn

🤖 Generated with [Claude Code](https://claude.com/claude-code)