### PR TITLE
Burn migration phase 3: PPO + DQN loss/update compile under both backends (closes #80)

### DIFF
--- a/src/multi_agent/learner.rs
+++ b/src/multi_agent/learner.rs
@@ -228,11 +228,11 @@ impl PolicyLearner {
     /// `obs_dim`. The last-inserted experience snapshot (used for
     /// the GAE bootstrap) is updated.
     fn ingest_experience(&mut self, exp: Experience) -> Result<()> {
-        // Tensors may live on GPU; move to CPU before extracting to Vec.
-        let obs_cpu = exp.observation.to_device(tch::Device::Cpu);
-        let obs_vec: Vec<f32> = Vec::<f32>::try_from(&obs_cpu).map_err(|e| {
-            anyhow::anyhow!("Failed to convert observation tensor to Vec<f32>: {e}")
-        })?;
+        // Phase 3 (#80) of the Burn migration moves message-protocol
+        // observations from `tch::Tensor` to `Vec<f32>` host buffers;
+        // see the module-level note in `multi_agent::messages`. No
+        // host↔tch conversion is needed here anymore.
+        let obs_vec = exp.observation;
 
         if obs_vec.len() != self.config.obs_dim {
             return Err(anyhow::anyhow!(
@@ -242,10 +242,7 @@ impl PolicyLearner {
             ));
         }
 
-        let next_obs_cpu = exp.next_observation.to_device(tch::Device::Cpu);
-        let next_obs_vec: Vec<f32> = Vec::<f32>::try_from(&next_obs_cpu).map_err(|e| {
-            anyhow::anyhow!("Failed to convert next_observation tensor to Vec<f32>: {e}")
-        })?;
+        let next_obs_vec = exp.next_observation;
 
         // Single-env learner: env_id is always 0. If/when multi-env per
         // learner support is added, this should be threaded through.
@@ -461,8 +458,6 @@ impl From<LearnerConfig> for crate::train::ppo::PPOConfig {
 
 #[cfg(test)]
 mod tests {
-    use tch::Kind;
-
     use super::*;
 
     #[test]
@@ -525,11 +520,12 @@ mod tests {
                 .expect("learner construction should succeed");
 
         // Push a small batch of experiences with the last one terminal.
+        // Observations are `Vec<f32>` host buffers (phase 3 of the
+        // Burn migration, #80).
         let n_exp = 6;
         for i in 0..n_exp {
-            let obs = Tensor::ones([obs_dim as i64], (Kind::Float, tch::Device::Cpu));
-            let next_obs =
-                Tensor::ones([obs_dim as i64], (Kind::Float, tch::Device::Cpu)) * (i as f64 + 1.0);
+            let obs: Vec<f32> = vec![1.0; obs_dim];
+            let next_obs: Vec<f32> = vec![(i as f32) + 1.0; obs_dim];
             let terminated = i == n_exp - 1;
             let exp = Experience::new(
                 0,
@@ -633,8 +629,8 @@ mod tests {
         let n_exp = 10usize;
         let sentinel_log_prob: f32 = -0.69;
         for i in 0..n_exp {
-            let obs = Tensor::ones([obs_dim as i64], (Kind::Float, tch::Device::Cpu));
-            let next_obs = Tensor::ones([obs_dim as i64], (Kind::Float, tch::Device::Cpu));
+            let obs: Vec<f32> = vec![1.0; obs_dim];
+            let next_obs: Vec<f32> = vec![1.0; obs_dim];
             let terminated = i == n_exp - 1;
             let exp = Experience::new(
                 0,

--- a/src/multi_agent/messages.rs
+++ b/src/multi_agent/messages.rs
@@ -3,19 +3,41 @@
 //! Defines the message formats for communication between:
 //! - GameSimulator → PolicyLearner: Experience data
 //! - PolicyLearner → GameSimulator: Policy updates
-
-use tch::Tensor;
+//!
+//! # Backend-agnostic storage (phase 3 of the Burn migration, #80)
+//!
+//! Prior to phase 3 the `Experience` struct stored `tch::Tensor`
+//! observations directly. That tied every channel-shaped message to
+//! the tch backend even though the multi_agent simulator/learner do
+//! not need autograd on these tensors — they always immediately
+//! convert to `Vec<f32>` host data before pushing into the replay
+//! buffer.
+//!
+//! Phase 3 inlines that conversion: `Experience::observation` /
+//! `next_observation` are now `Vec<f32>` host primitives. The
+//! tch-using simulator builds them with `Vec::<f32>::try_from(&tensor)`
+//! at the boundary (was: send the tensor, receive-and-convert on the
+//! other side); the receiver consumes them directly. This:
+//!
+//! 1. Makes `messages.rs` backend-agnostic (no `tch::Tensor` fields).
+//! 2. Removes a redundant host→tch→host round-trip on every message.
+//! 3. Sets up phase 4 to swap `MlpPolicy` for `MlpBurnPolicy` in the
+//!    simulator without touching the message protocol.
 
 use super::population::AgentId;
 
-/// Experience tuple sent from simulator to learner
-#[derive(Debug)]
+/// Experience tuple sent from simulator to learner.
+///
+/// Observations are stored as `Vec<f32>` host primitives so the
+/// message protocol is backend-agnostic; see the module-level note
+/// for the rationale.
+#[derive(Debug, Clone)]
 pub struct Experience {
     /// Agent that generated this experience
     pub agent_id: AgentId,
 
-    /// Observation tensor `[obs_dim]`
-    pub observation: Tensor,
+    /// Observation, flattened to `[obs_dim]` f32. Backend-neutral.
+    pub observation: Vec<f32>,
 
     /// Action taken
     pub action: i64,
@@ -23,8 +45,8 @@ pub struct Experience {
     /// Reward received
     pub reward: f32,
 
-    /// Next observation tensor `[obs_dim]`
-    pub next_observation: Tensor,
+    /// Next observation, flattened to `[obs_dim]` f32.
+    pub next_observation: Vec<f32>,
 
     /// Whether episode terminated
     pub terminated: bool,
@@ -40,13 +62,18 @@ pub struct Experience {
 }
 
 impl Experience {
-    /// Create a new experience tuple
+    /// Create a new experience tuple.
+    ///
+    /// Observations are `Vec<f32>` host buffers; callers using tch
+    /// should convert at the boundary with
+    /// `Vec::<f32>::try_from(&tensor)`.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         agent_id: AgentId,
-        observation: Tensor,
+        observation: Vec<f32>,
         action: i64,
         reward: f32,
-        next_observation: Tensor,
+        next_observation: Vec<f32>,
         terminated: bool,
         truncated: bool,
         value: f32,
@@ -158,17 +185,15 @@ pub enum ControlMessage {
 
 #[cfg(test)]
 mod tests {
-    use tch::Kind;
-
     use super::*;
+
+    fn obs(seed: usize) -> Vec<f32> {
+        (0..4).map(|i| (seed + i) as f32 * 0.1).collect()
+    }
 
     #[test]
     fn test_experience_creation() {
-        let obs = Tensor::randn([4], (Kind::Float, tch::Device::Cpu));
-        let next_obs = Tensor::randn([4], (Kind::Float, tch::Device::Cpu));
-
-        let exp = Experience::new(0, obs, 1, 1.0, next_obs, false, false, 0.5, -0.69);
-
+        let exp = Experience::new(0, obs(0), 1, 1.0, obs(1), false, false, 0.5, -0.69);
         assert_eq!(exp.agent_id, 0);
         assert_eq!(exp.action, 1);
         assert_eq!(exp.reward, 1.0);
@@ -177,33 +202,9 @@ mod tests {
 
     #[test]
     fn test_experience_done() {
-        let obs = Tensor::randn([4], (Kind::Float, tch::Device::Cpu));
-        let next_obs = Tensor::randn([4], (Kind::Float, tch::Device::Cpu));
-
-        let exp_term = Experience::new(
-            0,
-            obs.shallow_clone(),
-            1,
-            1.0,
-            next_obs.shallow_clone(),
-            true,
-            false,
-            0.5,
-            -0.69,
-        );
-        let exp_trunc = Experience::new(
-            0,
-            obs.shallow_clone(),
-            1,
-            1.0,
-            next_obs.shallow_clone(),
-            false,
-            true,
-            0.5,
-            -0.69,
-        );
-        let exp_both = Experience::new(0, obs, 1, 1.0, next_obs, true, true, 0.5, -0.69);
-
+        let exp_term = Experience::new(0, obs(0), 1, 1.0, obs(1), true, false, 0.5, -0.69);
+        let exp_trunc = Experience::new(0, obs(0), 1, 1.0, obs(1), false, true, 0.5, -0.69);
+        let exp_both = Experience::new(0, obs(0), 1, 1.0, obs(1), true, true, 0.5, -0.69);
         assert!(exp_term.is_done());
         assert!(exp_trunc.is_done());
         assert!(exp_both.is_done());

--- a/src/multi_agent/messages.rs
+++ b/src/multi_agent/messages.rs
@@ -21,8 +21,8 @@
 //!
 //! 1. Makes `messages.rs` backend-agnostic (no `tch::Tensor` fields).
 //! 2. Removes a redundant host→tch→host round-trip on every message.
-//! 3. Sets up phase 4 to swap `MlpPolicy` for `MlpBurnPolicy` in the
-//!    simulator without touching the message protocol.
+//! 3. Sets up phase 4 to swap `MlpPolicy` for `MlpBurnPolicy` in the simulator
+//!    without touching the message protocol.
 
 use super::population::AgentId;
 

--- a/src/multi_agent/simulator.rs
+++ b/src/multi_agent/simulator.rs
@@ -178,17 +178,20 @@ where
                 let actions_md: Vec<Vec<i64>> = actions.iter().map(|&a| vec![a]).collect();
                 let result = env.step_multi(&actions_md);
 
-                // Send experiences to learners
+                // Send experiences to learners. Observations cross the
+                // channel as `Vec<f32>` host buffers (phase 3 of the
+                // Burn migration, #80) — backend-agnostic message
+                // protocol, no tensor round-trip on the wire.
                 for (i, &agent_id) in agent_ids.iter().enumerate() {
-                    let obs_tensor = Self::obs_to_tensor(&observations[i], device)?;
-                    let next_obs_tensor = Self::obs_to_tensor(&result.observations[i], device)?;
+                    let obs_vec = observations[i].clone();
+                    let next_obs_vec = result.observations[i].clone();
 
                     let exp = Experience::new(
                         agent_id,
-                        obs_tensor,
+                        obs_vec,
                         actions[i],
                         result.rewards[i],
-                        next_obs_tensor,
+                        next_obs_vec,
                         result.terminated[i],
                         result.truncated[i],
                         values[i],

--- a/src/train/dqn.rs
+++ b/src/train/dqn.rs
@@ -46,13 +46,20 @@
 //!   ([ICLR 2016](https://arxiv.org/abs/1509.02971)).
 //! - [OpenAI Spinning Up: DQN](https://spinningup.openai.com/en/latest/algorithms/dqn.html)
 
+// `DQNConfig` is backend-agnostic. Tensor-typed loss helpers and the
+// `DQNTrainer` are tch-only; the parallel Burn-backend module lives at
+// [`crate::train::dqn_burn`].
 pub use config::DQNConfig;
+#[cfg(feature = "training")]
 pub use loss::{
     compute_dqn_loss, compute_dqn_loss_double, compute_loss, compute_td_target,
     compute_td_target_double, gather_action_q,
 };
+#[cfg(feature = "training")]
 pub use trainer::{DQNStepStats, DQNTrainer};
 
 mod config;
+#[cfg(feature = "training")]
 mod loss;
+#[cfg(feature = "training")]
 mod trainer;

--- a/src/train/dqn_burn.rs
+++ b/src/train/dqn_burn.rs
@@ -10,8 +10,8 @@
 //!   math.
 //! - [`crate::train::dqn_burn::trainer`] — `DQNTrainerBurn<B, Q, O>` that owns
 //!   the online Q-network module (Burn's optimizer-consumes-module ownership
-//!   model) and exposes a `train_step` that runs Smooth-L1 loss /
-//!   gradient-step logic.
+//!   model) and exposes a `train_step` that runs Smooth-L1 loss / gradient-step
+//!   logic.
 //!
 //! # Why a separate module
 //!

--- a/src/train/dqn_burn.rs
+++ b/src/train/dqn_burn.rs
@@ -1,0 +1,30 @@
+//! Burn-backend DQN module (phase 3 of the Burn migration, #80).
+//!
+//! Sibling to [`crate::train::dqn`] (tch path). The two modules expose
+//! deliberately parallel APIs so phase 5 (#82) can collapse them into
+//! one when the tch path is dropped.
+//!
+//! # Contents
+//!
+//! - [`loss`] — backend-generic DQN / Double-DQN loss math.
+//! - [`trainer`] — `DQNTrainerBurn<B, Q, O>` that owns the online
+//!   Q-network module (Burn's optimizer-consumes-module ownership
+//!   model) and exposes a `train_step` that runs Smooth-L1 loss /
+//!   gradient-step logic.
+//!
+//! # Why a separate module
+//!
+//! Same reasoning as `crate::train::ppo_burn`: the pre-phase-3
+//! `train/dqn` module is gated on `feature = "training"` and pulls
+//! tch in at the top of every file. The parallel-sibling pattern keeps
+//! both backends cleanly separated; phase 5 collapses them when the
+//! tch path is dropped.
+
+pub mod loss;
+pub mod trainer;
+
+pub use loss::{
+    compute_dqn_loss, compute_dqn_loss_double, compute_loss, compute_td_target,
+    compute_td_target_double, gather_action_q, huber_per_sample,
+};
+pub use trainer::{DQNStepStatsBurn, DQNTrainerBurn};

--- a/src/train/dqn_burn.rs
+++ b/src/train/dqn_burn.rs
@@ -6,10 +6,12 @@
 //!
 //! # Contents
 //!
-//! - [`loss`] — backend-generic DQN / Double-DQN loss math.
-//! - [`trainer`] — `DQNTrainerBurn<B, Q, O>` that owns the online Q-network
-//!   module (Burn's optimizer-consumes-module ownership model) and exposes a
-//!   `train_step` that runs Smooth-L1 loss / gradient-step logic.
+//! - [`crate::train::dqn_burn::loss`] — backend-generic DQN / Double-DQN loss
+//!   math.
+//! - [`crate::train::dqn_burn::trainer`] — `DQNTrainerBurn<B, Q, O>` that owns
+//!   the online Q-network module (Burn's optimizer-consumes-module ownership
+//!   model) and exposes a `train_step` that runs Smooth-L1 loss /
+//!   gradient-step logic.
 //!
 //! # Why a separate module
 //!

--- a/src/train/dqn_burn.rs
+++ b/src/train/dqn_burn.rs
@@ -7,10 +7,9 @@
 //! # Contents
 //!
 //! - [`loss`] — backend-generic DQN / Double-DQN loss math.
-//! - [`trainer`] — `DQNTrainerBurn<B, Q, O>` that owns the online
-//!   Q-network module (Burn's optimizer-consumes-module ownership
-//!   model) and exposes a `train_step` that runs Smooth-L1 loss /
-//!   gradient-step logic.
+//! - [`trainer`] — `DQNTrainerBurn<B, Q, O>` that owns the online Q-network
+//!   module (Burn's optimizer-consumes-module ownership model) and exposes a
+//!   `train_step` that runs Smooth-L1 loss / gradient-step logic.
 //!
 //! # Why a separate module
 //!

--- a/src/train/dqn_burn/loss.rs
+++ b/src/train/dqn_burn/loss.rs
@@ -146,13 +146,8 @@ pub fn compute_dqn_loss_double<B: Backend>(
     gamma: f64,
 ) -> Tensor<B, 1> {
     let q_taken = gather_action_q(q_online_all, actions);
-    let target = compute_td_target_double(
-        rewards,
-        dones,
-        next_q_online_all,
-        next_q_target_all,
-        gamma,
-    );
+    let target =
+        compute_td_target_double(rewards, dones, next_q_online_all, next_q_target_all, gamma);
     compute_loss(q_taken, target)
 }
 
@@ -216,8 +211,7 @@ mod tests {
         let q_online_next = tensor2d(&[0.5, 2.0, 1.0, 0.5], 2, 2);
         let q_target_next = tensor2d(&[10.0, 3.0, 7.0, 4.0], 2, 2);
 
-        let target =
-            compute_td_target_double(rewards, dones, q_online_next, q_target_next, 0.9);
+        let target = compute_td_target_double(rewards, dones, q_online_next, q_target_next, 0.9);
         let vals = read_vec(target);
         assert!((vals[0] - 3.7).abs() < 1e-4, "double-Q target sample 0 = {}", vals[0]);
         assert!((vals[1] - 0.5).abs() < 1e-4, "double-Q target sample 1 = {}", vals[1]);
@@ -257,7 +251,8 @@ mod tests {
 
     #[test]
     fn test_compute_dqn_loss_runs_end_to_end() {
-        let q_online = tensor2d(&[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2], 4, 3);
+        let q_online =
+            tensor2d(&[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2], 4, 3);
         let actions = actions1d(&[0, 1, 2, 1]);
         let rewards = tensor1d(&[1.0, 0.0, -1.0, 0.5]);
         let dones = tensor1d(&[0.0, 1.0, 0.0, 0.0]);

--- a/src/train/dqn_burn/loss.rs
+++ b/src/train/dqn_burn/loss.rs
@@ -1,0 +1,271 @@
+//! Burn-backend DQN loss math (phase 3 of the Burn migration, #80).
+//!
+//! Mirrors `crate::train::dqn::loss` (tch path) op-for-op. The two
+//! sit side-by-side under their respective feature flags so the
+//! existing tch trainer is not disturbed and the Burn-side trainer
+//! [`crate::train::dqn_burn::trainer`] has a backend-agnostic surface
+//! to call.
+//!
+//! # Numerical parity
+//!
+//! On identical inputs the Burn and tch implementations must agree to
+//! `1e-4` absolute tolerance (DoD on issue #80). The
+//! `crate::train::parity_tests` module enforces this when both
+//! `training` and `training-burn` features are enabled.
+//!
+//! # tch::no_grad ↔ Burn detach
+//!
+//! tch's `tch::no_grad(|| ...)` is a thread-local autograd suppression
+//! scope. Burn uses tape-based autograd (`Autodiff<Backend>`); the
+//! analogous operation is to wrap a non-autodiff "inner backend" tensor
+//! in the autodiff wrapper *after* the bootstrap computation, which the
+//! Burn ecosystem expresses through `Tensor::detach()` (the boundary
+//! between grad-bearing and grad-free tensors).
+//!
+//! The TD-target computation in [`compute_td_target`] /
+//! [`compute_td_target_double`] returns a fully detached tensor — its
+//! gradient (if any) is discarded inside the function. Callers therefore
+//! see the same "the target does not flow gradients" semantics as the
+//! tch path, without needing a `no_grad` scope at the call site.
+
+use burn::tensor::{Int, Tensor, backend::Backend};
+
+/// Compute the vanilla DQN TD target.
+///
+/// ```text
+/// y = r + γ · (1 − done) · max_aʹ Q_target(sʹ, aʹ)
+/// ```
+///
+/// Returns a `[batch]` tensor that is **detached** from the autograd
+/// graph (gradients do not flow back through `next_q_target`).
+pub fn compute_td_target<B: Backend>(
+    rewards: Tensor<B, 1>,
+    dones: Tensor<B, 1>,
+    next_q_target: Tensor<B, 2>,
+    gamma: f64,
+) -> Tensor<B, 1> {
+    // max_aʹ Q_target(sʹ, aʹ) — Burn returns a [batch, 1] tensor; squeeze.
+    let next_max: Tensor<B, 1> = next_q_target.max_dim(1).squeeze_dim(1);
+    let one = Tensor::<B, 1>::ones_like(&dones);
+    let not_done = one - dones;
+    let target = rewards + (not_done * next_max).mul_scalar(gamma as f32);
+    target.detach()
+}
+
+/// Compute the Double-DQN TD target.
+///
+/// ```text
+/// a* = argmax_aʹ Q_online(sʹ, aʹ)
+/// y  = r + γ · (1 − done) · Q_target(sʹ, a*)
+/// ```
+///
+/// Action selection uses the *online* network and action evaluation
+/// uses the *target* network. Returns a detached `[batch]` tensor.
+pub fn compute_td_target_double<B: Backend>(
+    rewards: Tensor<B, 1>,
+    dones: Tensor<B, 1>,
+    next_q_online: Tensor<B, 2>,
+    next_q_target: Tensor<B, 2>,
+    gamma: f64,
+) -> Tensor<B, 1> {
+    // Choose the action with the online net, evaluate with the target net.
+    let a_star: Tensor<B, 2, Int> = next_q_online.argmax(1); // [batch, 1]
+    // `gather` over the action axis returns [batch, 1]; squeeze.
+    let next_q: Tensor<B, 1> = next_q_target.gather(1, a_star).squeeze_dim(1);
+    let one = Tensor::<B, 1>::ones_like(&dones);
+    let not_done = one - dones;
+    let target = rewards + (not_done * next_q).mul_scalar(gamma as f32);
+    target.detach()
+}
+
+/// Gather the Q-value of the action that was actually taken.
+///
+/// `[batch, n_actions]` x `[batch]` → `[batch]`.
+pub fn gather_action_q<B: Backend>(
+    q_online_all: Tensor<B, 2>,
+    actions: Tensor<B, 1, Int>,
+) -> Tensor<B, 1> {
+    let actions_2d: Tensor<B, 2, Int> = actions.unsqueeze_dim(1); // [batch, 1]
+    q_online_all.gather(1, actions_2d).squeeze_dim(1)
+}
+
+/// Smooth-L1 (Huber) loss between Q(s, a) and the TD target.
+///
+/// Burn 0.21 ships `nn::loss::HuberLoss` but its API binds the delta
+/// at config time; we instead express the math directly so the
+/// function signature mirrors the tch path's `compute_loss` exactly.
+///
+/// For a delta of 1.0 (standard DQN):
+/// - If `|x| <= 1`: loss = 0.5 * x²
+/// - If `|x| > 1`:  loss = |x| - 0.5
+///
+/// Returns the mean across the batch as a scalar tensor.
+pub fn compute_loss<B: Backend>(
+    q_online_taken: Tensor<B, 1>,
+    td_target: Tensor<B, 1>,
+) -> Tensor<B, 1> {
+    huber_per_sample(q_online_taken - td_target, 1.0).mean()
+}
+
+/// Per-sample Smooth-L1 (Huber) loss with explicit delta. Useful for
+/// the prioritized-replay path which needs per-sample weights before
+/// reduction.
+pub fn huber_per_sample<B: Backend>(diff: Tensor<B, 1>, delta: f64) -> Tensor<B, 1> {
+    let delta_f = delta as f32;
+    let abs_diff = diff.clone().abs();
+    let quadratic = abs_diff.clone().clamp(0.0, delta);
+    let linear = abs_diff - quadratic.clone();
+    // 0.5 * quadratic² + delta * linear  (continuous & differentiable
+    // at |x| = delta).
+    quadratic.clone().mul(quadratic).mul_scalar(0.5_f32) + linear.mul_scalar(delta_f)
+}
+
+/// One-shot convenience wrapper: full vanilla-DQN loss.
+pub fn compute_dqn_loss<B: Backend>(
+    q_online_all: Tensor<B, 2>,
+    actions: Tensor<B, 1, Int>,
+    rewards: Tensor<B, 1>,
+    next_q_target_all: Tensor<B, 2>,
+    dones: Tensor<B, 1>,
+    gamma: f64,
+) -> Tensor<B, 1> {
+    let q_taken = gather_action_q(q_online_all, actions);
+    let target = compute_td_target(rewards, dones, next_q_target_all, gamma);
+    compute_loss(q_taken, target)
+}
+
+/// One-shot convenience wrapper: full Double-DQN loss.
+#[allow(clippy::too_many_arguments)]
+pub fn compute_dqn_loss_double<B: Backend>(
+    q_online_all: Tensor<B, 2>,
+    next_q_online_all: Tensor<B, 2>,
+    actions: Tensor<B, 1, Int>,
+    rewards: Tensor<B, 1>,
+    next_q_target_all: Tensor<B, 2>,
+    dones: Tensor<B, 1>,
+    gamma: f64,
+) -> Tensor<B, 1> {
+    let q_taken = gather_action_q(q_online_all, actions);
+    let target = compute_td_target_double(
+        rewards,
+        dones,
+        next_q_online_all,
+        next_q_target_all,
+        gamma,
+    );
+    compute_loss(q_taken, target)
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::{
+        backend::{Autodiff, NdArray},
+        tensor::{Int, Tensor, TensorData},
+    };
+
+    use super::*;
+
+    type B = Autodiff<NdArray<f32>>;
+
+    fn tensor1d(data: &[f32]) -> Tensor<B, 1> {
+        let device = Default::default();
+        Tensor::<B, 1>::from_data(TensorData::new(data.to_vec(), [data.len()]), &device)
+    }
+
+    fn tensor2d(data: &[f32], rows: usize, cols: usize) -> Tensor<B, 2> {
+        let device = Default::default();
+        Tensor::<B, 2>::from_data(TensorData::new(data.to_vec(), [rows, cols]), &device)
+    }
+
+    fn actions1d(data: &[i64]) -> Tensor<B, 1, Int> {
+        let device = Default::default();
+        Tensor::<B, 1, Int>::from_data(TensorData::new(data.to_vec(), [data.len()]), &device)
+    }
+
+    fn read_vec(t: Tensor<B, 1>) -> Vec<f32> {
+        t.into_data().to_vec().unwrap()
+    }
+
+    #[test]
+    fn test_td_target_terminal_drops_bootstrap() {
+        let rewards = tensor1d(&[1.0, 2.0]);
+        let dones = tensor1d(&[0.0, 1.0]);
+        let next_q = tensor2d(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
+        let target = compute_td_target(rewards, dones, next_q, 0.9);
+        let vals = read_vec(target);
+        // Sample 0: 1.0 + 0.9*3.0 = 3.7
+        // Sample 1: done → 2.0
+        assert!((vals[0] - 3.7).abs() < 1e-4);
+        assert!((vals[1] - 2.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_gather_action_q_burn() {
+        let q = tensor2d(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let actions = actions1d(&[0, 1, 0]);
+        let gathered = gather_action_q(q, actions);
+        let vals = read_vec(gathered);
+        assert_eq!(vals, vec![1.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn test_double_dqn_target_hand_computed() {
+        // Same setup as the tch test.
+        let rewards = tensor1d(&[1.0, 0.5]);
+        let dones = tensor1d(&[0.0, 1.0]);
+        let q_online_next = tensor2d(&[0.5, 2.0, 1.0, 0.5], 2, 2);
+        let q_target_next = tensor2d(&[10.0, 3.0, 7.0, 4.0], 2, 2);
+
+        let target =
+            compute_td_target_double(rewards, dones, q_online_next, q_target_next, 0.9);
+        let vals = read_vec(target);
+        assert!((vals[0] - 3.7).abs() < 1e-4, "double-Q target sample 0 = {}", vals[0]);
+        assert!((vals[1] - 0.5).abs() < 1e-4, "double-Q target sample 1 = {}", vals[1]);
+    }
+
+    #[test]
+    fn test_huber_per_sample_quadratic_branch() {
+        // Small residuals: 0.5 * x² applies.
+        let diff = tensor1d(&[0.1, -0.2, 0.5]);
+        let loss = huber_per_sample(diff, 1.0);
+        let vals = read_vec(loss);
+        // Expected: 0.005, 0.02, 0.125
+        assert!((vals[0] - 0.005).abs() < 1e-4);
+        assert!((vals[1] - 0.02).abs() < 1e-4);
+        assert!((vals[2] - 0.125).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_huber_per_sample_linear_branch() {
+        // Large residuals: |x| - 0.5 applies.
+        let diff = tensor1d(&[2.0, -3.0]);
+        let loss = huber_per_sample(diff, 1.0);
+        let vals = read_vec(loss);
+        // |x| - 0.5: 1.5, 2.5
+        assert!((vals[0] - 1.5).abs() < 1e-4, "got {}", vals[0]);
+        assert!((vals[1] - 2.5).abs() < 1e-4, "got {}", vals[1]);
+    }
+
+    #[test]
+    fn test_compute_loss_finite_on_zero_residual() {
+        let q = tensor1d(&[1.0, 2.0, 3.0]);
+        let target = tensor1d(&[1.0, 2.0, 3.0]);
+        let loss = compute_loss(q, target);
+        let v = loss.into_scalar();
+        assert!((v - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_dqn_loss_runs_end_to_end() {
+        let q_online = tensor2d(&[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2], 4, 3);
+        let actions = actions1d(&[0, 1, 2, 1]);
+        let rewards = tensor1d(&[1.0, 0.0, -1.0, 0.5]);
+        let dones = tensor1d(&[0.0, 1.0, 0.0, 0.0]);
+        let next_q_target =
+            tensor2d(&[0.5, 0.1, 0.0, 0.2, 0.3, 0.4, 1.0, 0.5, 0.7, 0.2, 0.8, 0.6], 4, 3);
+        let loss = compute_dqn_loss(q_online, actions, rewards, next_q_target, dones, 0.99);
+        let v = loss.into_scalar();
+        assert!(v.is_finite());
+        assert!(v >= 0.0);
+    }
+}

--- a/src/train/dqn_burn/trainer.rs
+++ b/src/train/dqn_burn/trainer.rs
@@ -9,35 +9,33 @@
 //!
 //! The Burn trainer:
 //!
-//! - Owns an online Q-network module `Q` and a target Q-network module
-//!   of the same type. The trainer is generic over `Q: AutodiffModule<B>
+//! - Owns an online Q-network module `Q` and a target Q-network module of the
+//!   same type. The trainer is generic over `Q: AutodiffModule<B>
 //!   + Clone` so the actual network shape (CartPole MLP, Snake CNN,
 //!   etc.) ships in phase 4.
-//! - Provides ε-greedy action selection through a caller-supplied
-//!   `greedy_fn` (the network's forward + argmax). The trainer owns
-//!   the ε schedule and the env-step counter — the same as the tch
-//!   trainer's `select_action` API.
+//! - Provides ε-greedy action selection through a caller-supplied `greedy_fn`
+//!   (the network's forward + argmax). The trainer owns the ε schedule and the
+//!   env-step counter — the same as the tch trainer's `select_action` API.
 //! - Performs the Smooth-L1 / Double-DQN training step inside
-//!   [`DQNTrainerBurn::train_step`]. Caller-supplied closures hand off
-//!   the forward pass — exactly the shape the tch trainer uses when
-//!   `train_step` is called against an external loss closure.
-//! - Pushes transitions into a [`crate::buffer::replay::ReplayBuffer`]
-//!   and samples minibatches the same way as the tch trainer.
+//!   [`DQNTrainerBurn::train_step`]. Caller-supplied closures hand off the
+//!   forward pass — exactly the shape the tch trainer uses when `train_step` is
+//!   called against an external loss closure.
+//! - Pushes transitions into a [`crate::buffer::replay::ReplayBuffer`] and
+//!   samples minibatches the same way as the tch trainer.
 //! - Soft / Polyak target updates are folded into
-//!   [`DQNTrainerBurn::soft_update_target`], which the caller invokes
-//!   with the `tau` from config.
+//!   [`DQNTrainerBurn::soft_update_target`], which the caller invokes with the
+//!   `tau` from config.
 //!
 //! # NOT in scope for phase 3
 //!
-//! - Prioritized replay is intentionally **not** ported in this phase
-//!   — it would inflate the LOC delta past the 800-line budget called
-//!   out on issue #80. The hooks are still there
-//!   (`huber_per_sample` is exposed on the loss module) and phase 4
-//!   / 5 can add the IS-weighted path.
-//! - Hard / interval-based target sync is implemented as `clone()`
-//!   of the online module into the target slot when the env-step
-//!   counter hits the interval; the soft path uses Burn's module-tree
-//!   mutation through the trainer-provided `soft_blend_fn`.
+//! - Prioritized replay is intentionally **not** ported in this phase — it
+//!   would inflate the LOC delta past the 800-line budget called out on issue
+//!   #80. The hooks are still there (`huber_per_sample` is exposed on the loss
+//!   module) and phase 4 / 5 can add the IS-weighted path.
+//! - Hard / interval-based target sync is implemented as `clone()` of the
+//!   online module into the target slot when the env-step counter hits the
+//!   interval; the soft path uses Burn's module-tree mutation through the
+//!   trainer-provided `soft_blend_fn`.
 //!
 //! The acceptance test for phase 3 is that `train_cartpole_dqn` can be
 //! ported to this trainer with no algorithmic divergence; the
@@ -85,8 +83,8 @@ pub struct DQNStepStatsBurn {
 ///
 /// Generic over:
 /// - `B: AutodiffBackend`,
-/// - `Q: AutodiffModule<B> + Clone` — the Q-network module type
-///   (single backbone + action-dim head; ports in phase 4),
+/// - `Q: AutodiffModule<B> + Clone` — the Q-network module type (single
+///   backbone + action-dim head; ports in phase 4),
 /// - `O: Optimizer<Q, B>` — the Burn optimizer.
 pub struct DQNTrainerBurn<B, Q, O>
 where
@@ -241,13 +239,12 @@ where
     /// Two modes:
     /// 1. **Hard sync** (default): clones online → target every
     ///    `target_update_interval` env steps.
-    /// 2. **Soft / Polyak** (`config.soft_update_tau = Some(τ)`):
-    ///    the caller-supplied `blend_fn` is invoked every step. The
-    ///    caller is responsible for implementing the per-parameter
-    ///    blend `θ_target ← τ · θ_online + (1 − τ) · θ_target`. Burn
-    ///    0.21 does not expose a uniform `map_params` API, so the
-    ///    blend is parameterized over the concrete module type by the
-    ///    caller.
+    /// 2. **Soft / Polyak** (`config.soft_update_tau = Some(τ)`): the
+    ///    caller-supplied `blend_fn` is invoked every step. The caller is
+    ///    responsible for implementing the per-parameter blend `θ_target ← τ ·
+    ///    θ_online + (1 − τ) · θ_target`. Burn 0.21 does not expose a uniform
+    ///    `map_params` API, so the blend is parameterized over the concrete
+    ///    module type by the caller.
     pub fn maybe_sync_target<F>(&mut self, blend_fn: F) -> bool
     where
         F: FnOnce(&Q, Q, f64) -> Q,
@@ -276,13 +273,12 @@ where
     /// Double-DQN TD target.
     ///
     /// Caller supplies two closures:
-    /// - `forward_fn(&Q, obs)` — forward pass returning the
-    ///   `[batch, n_actions]` Q-values, with grad bearing iff the
-    ///   module is the online network.
-    /// - `forward_target_fn(&Q, obs)` — forward pass returning the
-    ///   `[batch, n_actions]` target-net Q-values. The trainer takes
-    ///   care of detaching these for the TD target — caller doesn't
-    ///   need to manage `no_grad`.
+    /// - `forward_fn(&Q, obs)` — forward pass returning the `[batch,
+    ///   n_actions]` Q-values, with grad bearing iff the module is the online
+    ///   network.
+    /// - `forward_target_fn(&Q, obs)` — forward pass returning the `[batch,
+    ///   n_actions]` target-net Q-values. The trainer takes care of detaching
+    ///   these for the TD target — caller doesn't need to manage `no_grad`.
     ///
     /// Returns `Ok(None)` if the buffer doesn't yet hold
     /// `min_buffer_size` transitions.
@@ -384,8 +380,7 @@ where
         let q_online_all = forward_fn(&online, t.observations);
         let q_taken = gather_action_q(q_online_all.clone(), t.actions);
         let next_q_target_all = forward_target_fn(&self.target, t.next_observations);
-        let td_target =
-            compute_td_target(t.rewards, t.dones, next_q_target_all, self.config.gamma);
+        let td_target = compute_td_target(t.rewards, t.dones, next_q_target_all, self.config.gamma);
 
         let td_loss = compute_loss(q_taken.clone(), td_target);
         let td_loss_val: f64 = td_loss.clone().into_scalar().to_f64();
@@ -421,9 +416,7 @@ mod tests {
     use rand::SeedableRng;
 
     use super::*;
-    use crate::{
-        policy::mlp_burn::MlpBurnPolicy, train::optimizer::BurnOptimizer,
-    };
+    use crate::{policy::mlp_burn::MlpBurnPolicy, train::optimizer::BurnOptimizer};
 
     type B = Autodiff<NdArray<f32>>;
 
@@ -445,8 +438,7 @@ mod tests {
         let online = MlpBurnPolicy::<B>::new(4, 2, 16, &device);
         let inner_opt = AdamConfig::new().init();
         let burn_opt = BurnOptimizer::new(inner_opt, small_config().learning_rate);
-        let trainer =
-            DQNTrainerBurn::new(small_config(), online, burn_opt, 4, 2, device).unwrap();
+        let trainer = DQNTrainerBurn::new(small_config(), online, burn_opt, 4, 2, device).unwrap();
         assert_eq!(trainer.total_env_steps(), 0);
         assert_eq!(trainer.buffer_len(), 0);
     }
@@ -492,9 +484,7 @@ mod tests {
             let (logits, _) = q.forward(o);
             logits
         };
-        let stats = trainer
-            .train_step(&mut rng, forward_fn, forward_fn)
-            .unwrap();
+        let stats = trainer.train_step(&mut rng, forward_fn, forward_fn).unwrap();
         assert!(stats.is_some());
         let s = stats.unwrap();
         assert!(s.td_loss.is_finite());

--- a/src/train/dqn_burn/trainer.rs
+++ b/src/train/dqn_burn/trainer.rs
@@ -10,9 +10,8 @@
 //! The Burn trainer:
 //!
 //! - Owns an online Q-network module `Q` and a target Q-network module of the
-//!   same type. The trainer is generic over `Q: AutodiffModule<B>
-//!   + Clone` so the actual network shape (CartPole MLP, Snake CNN,
-//!   etc.) ships in phase 4.
+//!   same type. The trainer is generic over `Q: AutodiffModule<B> + Clone` so
+//!   the actual network shape (CartPole MLP, Snake CNN, etc.) ships in phase 4.
 //! - Provides ε-greedy action selection through a caller-supplied `greedy_fn`
 //!   (the network's forward + argmax). The trainer owns the ε schedule and the
 //!   env-step counter — the same as the tch trainer's `select_action` API.
@@ -23,8 +22,8 @@
 //! - Pushes transitions into a [`crate::buffer::replay::ReplayBuffer`] and
 //!   samples minibatches the same way as the tch trainer.
 //! - Soft / Polyak target updates are folded into
-//!   [`DQNTrainerBurn::soft_update_target`], which the caller invokes with the
-//!   `tau` from config.
+//!   [`DQNTrainerBurn::maybe_sync_target`], which the caller invokes with a
+//!   blend closure that applies the `tau` from config.
 //!
 //! # NOT in scope for phase 3
 //!

--- a/src/train/dqn_burn/trainer.rs
+++ b/src/train/dqn_burn/trainer.rs
@@ -1,0 +1,502 @@
+//! Burn-backend DQN trainer (phase 3 of the Burn migration, #80).
+//!
+//! Sibling to [`crate::train::dqn::DQNTrainer`] (tch path). Implements
+//! the same Double-DQN target / Smooth-L1 loss / gradient-step recipe
+//! but holds the Q-network as a Burn module that flows through the
+//! optimizer on every step.
+//!
+//! # Scope (phase 3)
+//!
+//! The Burn trainer:
+//!
+//! - Owns an online Q-network module `Q` and a target Q-network module
+//!   of the same type. The trainer is generic over `Q: AutodiffModule<B>
+//!   + Clone` so the actual network shape (CartPole MLP, Snake CNN,
+//!   etc.) ships in phase 4.
+//! - Provides ε-greedy action selection through a caller-supplied
+//!   `greedy_fn` (the network's forward + argmax). The trainer owns
+//!   the ε schedule and the env-step counter — the same as the tch
+//!   trainer's `select_action` API.
+//! - Performs the Smooth-L1 / Double-DQN training step inside
+//!   [`DQNTrainerBurn::train_step`]. Caller-supplied closures hand off
+//!   the forward pass — exactly the shape the tch trainer uses when
+//!   `train_step` is called against an external loss closure.
+//! - Pushes transitions into a [`crate::buffer::replay::ReplayBuffer`]
+//!   and samples minibatches the same way as the tch trainer.
+//! - Soft / Polyak target updates are folded into
+//!   [`DQNTrainerBurn::soft_update_target`], which the caller invokes
+//!   with the `tau` from config.
+//!
+//! # NOT in scope for phase 3
+//!
+//! - Prioritized replay is intentionally **not** ported in this phase
+//!   — it would inflate the LOC delta past the 800-line budget called
+//!   out on issue #80. The hooks are still there
+//!   (`huber_per_sample` is exposed on the loss module) and phase 4
+//!   / 5 can add the IS-weighted path.
+//! - Hard / interval-based target sync is implemented as `clone()`
+//!   of the online module into the target slot when the env-step
+//!   counter hits the interval; the soft path uses Burn's module-tree
+//!   mutation through the trainer-provided `soft_blend_fn`.
+//!
+//! The acceptance test for phase 3 is that `train_cartpole_dqn` can be
+//! ported to this trainer with no algorithmic divergence; the
+//! prioritized-replay diagnostics live with `crate::train::dqn` until
+//! phase 5 drops them.
+
+use anyhow::{Result, anyhow};
+use burn::{
+    module::AutodiffModule,
+    optim::{GradientsParams, Optimizer},
+    prelude::ToElement,
+    tensor::{Tensor, backend::AutodiffBackend},
+};
+use rand::Rng;
+
+use super::loss::{compute_loss, compute_td_target, compute_td_target_double, gather_action_q};
+use crate::{
+    buffer::replay::{ReplayBuffer, sample},
+    train::{
+        dqn::DQNConfig,
+        optimizer::{BackendOptimizer, BurnOptimizer},
+    },
+};
+
+/// Per-step training statistics for the Burn DQN trainer.
+///
+/// Mirrors `crate::train::dqn::DQNStepStats` (tch path) field-for-field
+/// where the fields make sense for the Burn / non-prioritized path.
+/// Prioritized-replay fields (`beta`, `mean_abs_td_error`) are dropped
+/// because the Burn trainer does not yet implement prioritized replay
+/// (see module doc).
+#[derive(Debug, Clone, Copy)]
+pub struct DQNStepStatsBurn {
+    /// Mean Smooth-L1 (Huber) loss across the minibatch.
+    pub td_loss: f64,
+    /// Mean of `Q(s, a)` across the minibatch.
+    pub mean_q: f64,
+    /// ε used to draw the most recent action.
+    pub epsilon: f64,
+    /// Replay buffer fill level at the time of this update.
+    pub buffer_len: usize,
+}
+
+/// Burn-backend DQN trainer.
+///
+/// Generic over:
+/// - `B: AutodiffBackend`,
+/// - `Q: AutodiffModule<B> + Clone` — the Q-network module type
+///   (single backbone + action-dim head; ports in phase 4),
+/// - `O: Optimizer<Q, B>` — the Burn optimizer.
+pub struct DQNTrainerBurn<B, Q, O>
+where
+    B: AutodiffBackend,
+    Q: AutodiffModule<B> + Clone,
+    O: Optimizer<Q, B>,
+{
+    config: DQNConfig,
+    n_actions: i64,
+    online: Option<Q>,
+    target: Q,
+    optimizer: BurnOptimizer<B, Q, O>,
+    buffer: ReplayBuffer,
+    device: B::Device,
+    total_env_steps: usize,
+    total_train_steps: usize,
+    total_episodes: usize,
+    last_epsilon: f64,
+}
+
+impl<B, Q, O> DQNTrainerBurn<B, Q, O>
+where
+    B: AutodiffBackend,
+    Q: AutodiffModule<B> + Clone,
+    O: Optimizer<Q, B>,
+{
+    /// Build a new Burn DQN trainer.
+    ///
+    /// The caller supplies the online network already initialized; the
+    /// trainer clones it once to seed the target network so the two
+    /// start byte-equal (matching the tch trainer's
+    /// `target.copy_params_from(&online)` semantics).
+    pub fn new(
+        config: DQNConfig,
+        online: Q,
+        optimizer: BurnOptimizer<B, Q, O>,
+        obs_dim: usize,
+        n_actions: i64,
+        device: B::Device,
+    ) -> Result<Self> {
+        config.validate()?;
+        if config.prioritized_replay {
+            return Err(anyhow!(
+                "DQNTrainerBurn does not yet implement prioritized replay (phase 3 \
+                 scope on issue #80). Use the tch DQNTrainer or wait for phase 5."
+            ));
+        }
+        let target = online.clone();
+        let buffer = ReplayBuffer::new(config.buffer_capacity, obs_dim);
+        let last_epsilon = config.epsilon_start;
+        Ok(Self {
+            config,
+            n_actions,
+            online: Some(online),
+            target,
+            optimizer,
+            buffer,
+            device,
+            total_env_steps: 0,
+            total_train_steps: 0,
+            total_episodes: 0,
+            last_epsilon,
+        })
+    }
+
+    /// Number of discrete actions in this trainer's action space.
+    pub fn n_actions(&self) -> i64 {
+        self.n_actions
+    }
+
+    /// Borrow the configuration.
+    pub fn config(&self) -> &DQNConfig {
+        &self.config
+    }
+
+    /// Borrow the online network. Panics if mid-step.
+    pub fn online(&self) -> &Q {
+        self.online.as_ref().expect("online network is None mid-step")
+    }
+
+    /// Borrow the target network.
+    pub fn target(&self) -> &Q {
+        &self.target
+    }
+
+    /// Borrow the replay buffer.
+    pub fn buffer(&self) -> &ReplayBuffer {
+        &self.buffer
+    }
+
+    /// Mutably borrow the replay buffer.
+    pub fn buffer_mut(&mut self) -> &mut ReplayBuffer {
+        &mut self.buffer
+    }
+
+    /// Number of transitions currently in the buffer.
+    pub fn buffer_len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Caller invokes this once per environment step.
+    pub fn increment_env_step(&mut self) {
+        self.total_env_steps += 1;
+    }
+
+    /// Caller invokes this when an episode terminates / truncates.
+    pub fn increment_episodes(&mut self, n: usize) {
+        self.total_episodes += n;
+    }
+
+    /// Current env-step counter.
+    pub fn total_env_steps(&self) -> usize {
+        self.total_env_steps
+    }
+
+    /// Number of completed gradient updates.
+    pub fn total_train_steps(&self) -> usize {
+        self.total_train_steps
+    }
+
+    /// Number of completed episodes.
+    pub fn total_episodes(&self) -> usize {
+        self.total_episodes
+    }
+
+    /// ε used to draw the most recent action.
+    pub fn last_epsilon(&self) -> f64 {
+        self.last_epsilon
+    }
+
+    /// ε-greedy action selection.
+    ///
+    /// Computes the current ε using the config's
+    /// [`DQNConfig::epsilon_at`] schedule, then either picks a uniform
+    /// random action with probability ε or invokes `greedy_fn` for the
+    /// argmax-Q action.
+    pub fn select_action<R: Rng, F>(&mut self, obs: &[f32], rng: &mut R, greedy_fn: F) -> i64
+    where
+        F: FnOnce(&Q, &[f32]) -> i64,
+    {
+        let eps = self.config.epsilon_at(self.total_env_steps);
+        self.last_epsilon = eps;
+        if rng.random::<f64>() < eps {
+            rng.random_range(0..self.n_actions)
+        } else {
+            greedy_fn(self.online(), obs)
+        }
+    }
+
+    /// Sync the target network from the online network.
+    ///
+    /// Two modes:
+    /// 1. **Hard sync** (default): clones online → target every
+    ///    `target_update_interval` env steps.
+    /// 2. **Soft / Polyak** (`config.soft_update_tau = Some(τ)`):
+    ///    the caller-supplied `blend_fn` is invoked every step. The
+    ///    caller is responsible for implementing the per-parameter
+    ///    blend `θ_target ← τ · θ_online + (1 − τ) · θ_target`. Burn
+    ///    0.21 does not expose a uniform `map_params` API, so the
+    ///    blend is parameterized over the concrete module type by the
+    ///    caller.
+    pub fn maybe_sync_target<F>(&mut self, blend_fn: F) -> bool
+    where
+        F: FnOnce(&Q, Q, f64) -> Q,
+    {
+        match self.config.soft_update_tau {
+            Some(tau) => {
+                let online = self.online().clone();
+                let target = std::mem::replace(&mut self.target, online.clone());
+                self.target = blend_fn(&online, target, tau);
+                true
+            }
+            None => {
+                if self.total_env_steps > 0
+                    && self.total_env_steps % self.config.target_update_interval == 0
+                {
+                    self.target = self.online().clone();
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    /// Sample a minibatch and run one gradient step against the
+    /// Double-DQN TD target.
+    ///
+    /// Caller supplies two closures:
+    /// - `forward_fn(&Q, obs)` — forward pass returning the
+    ///   `[batch, n_actions]` Q-values, with grad bearing iff the
+    ///   module is the online network.
+    /// - `forward_target_fn(&Q, obs)` — forward pass returning the
+    ///   `[batch, n_actions]` target-net Q-values. The trainer takes
+    ///   care of detaching these for the TD target — caller doesn't
+    ///   need to manage `no_grad`.
+    ///
+    /// Returns `Ok(None)` if the buffer doesn't yet hold
+    /// `min_buffer_size` transitions.
+    pub fn train_step<R: Rng, FOnline, FTarget>(
+        &mut self,
+        rng: &mut R,
+        forward_fn: FOnline,
+        forward_target_fn: FTarget,
+    ) -> Result<Option<DQNStepStatsBurn>>
+    where
+        FOnline: Fn(&Q, Tensor<B, 2>) -> Tensor<B, 2>,
+        FTarget: Fn(&Q, Tensor<B, 2>) -> Tensor<B, 2>,
+    {
+        if !self.buffer.is_ready(self.config.min_buffer_size) {
+            return Ok(None);
+        }
+
+        let batch = sample(&self.buffer, self.config.batch_size, rng);
+        let buffer_len = self.buffer.len();
+
+        // Lift the replay batch into Burn tensors via the buffer's
+        // built-in `to_burn_tensors` helper (phase 2a, #79).
+        let t = batch.to_burn_tensors::<B>(&self.device);
+
+        let online = self
+            .online
+            .take()
+            .ok_or_else(|| anyhow!("online network is None; concurrent train_step calls?"))?;
+
+        let q_online_all = forward_fn(&online, t.observations);
+        let q_taken = gather_action_q(q_online_all.clone(), t.actions);
+
+        // Target / Double-DQN target — both forward passes use the
+        // online + target networks but the resulting target tensor is
+        // detached inside `compute_td_target_double`, so no gradient
+        // flows through them.
+        let next_q_online_all = forward_fn(&online, t.next_observations.clone());
+        let next_q_target_all = forward_target_fn(&self.target, t.next_observations);
+        let td_target = compute_td_target_double(
+            t.rewards,
+            t.dones,
+            next_q_online_all,
+            next_q_target_all,
+            self.config.gamma,
+        );
+
+        let td_loss = compute_loss(q_taken.clone(), td_target);
+        let td_loss_val: f64 = td_loss.clone().into_scalar().to_f64();
+        let mean_q_val: f64 = q_taken.mean().into_scalar().to_f64();
+
+        if !td_loss_val.is_finite() {
+            return Err(anyhow!("Non-finite TD loss: {}", td_loss_val));
+        }
+
+        // Burn optimizer step.
+        let grads = td_loss.backward();
+        let grads = GradientsParams::from_grads(grads, &online);
+        let lr = self.optimizer.learning_rate();
+        let online = self.optimizer.inner_mut().step(lr, online, grads);
+        self.online = Some(online);
+
+        self.total_train_steps += 1;
+
+        Ok(Some(DQNStepStatsBurn {
+            td_loss: td_loss_val,
+            mean_q: mean_q_val,
+            epsilon: self.last_epsilon,
+            buffer_len,
+        }))
+    }
+
+    /// Vanilla-DQN train step (uses [`compute_td_target`] instead of
+    /// the Double-DQN target). Exposed for completeness; the default
+    /// `train_step` uses Double-DQN to match the tch trainer's default.
+    pub fn train_step_vanilla<R: Rng, FOnline, FTarget>(
+        &mut self,
+        rng: &mut R,
+        forward_fn: FOnline,
+        forward_target_fn: FTarget,
+    ) -> Result<Option<DQNStepStatsBurn>>
+    where
+        FOnline: Fn(&Q, Tensor<B, 2>) -> Tensor<B, 2>,
+        FTarget: Fn(&Q, Tensor<B, 2>) -> Tensor<B, 2>,
+    {
+        if !self.buffer.is_ready(self.config.min_buffer_size) {
+            return Ok(None);
+        }
+
+        let batch = sample(&self.buffer, self.config.batch_size, rng);
+        let buffer_len = self.buffer.len();
+
+        let t = batch.to_burn_tensors::<B>(&self.device);
+
+        let online = self
+            .online
+            .take()
+            .ok_or_else(|| anyhow!("online network is None; concurrent train_step calls?"))?;
+
+        let q_online_all = forward_fn(&online, t.observations);
+        let q_taken = gather_action_q(q_online_all.clone(), t.actions);
+        let next_q_target_all = forward_target_fn(&self.target, t.next_observations);
+        let td_target =
+            compute_td_target(t.rewards, t.dones, next_q_target_all, self.config.gamma);
+
+        let td_loss = compute_loss(q_taken.clone(), td_target);
+        let td_loss_val: f64 = td_loss.clone().into_scalar().to_f64();
+        let mean_q_val: f64 = q_taken.mean().into_scalar().to_f64();
+
+        if !td_loss_val.is_finite() {
+            return Err(anyhow!("Non-finite TD loss: {}", td_loss_val));
+        }
+
+        let grads = td_loss.backward();
+        let grads = GradientsParams::from_grads(grads, &online);
+        let lr = self.optimizer.learning_rate();
+        let online = self.optimizer.inner_mut().step(lr, online, grads);
+        self.online = Some(online);
+
+        self.total_train_steps += 1;
+
+        Ok(Some(DQNStepStatsBurn {
+            td_loss: td_loss_val,
+            mean_q: mean_q_val,
+            epsilon: self.last_epsilon,
+            buffer_len,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::{
+        backend::{Autodiff, NdArray},
+        optim::AdamConfig,
+    };
+    use rand::SeedableRng;
+
+    use super::*;
+    use crate::{
+        policy::mlp_burn::MlpBurnPolicy, train::optimizer::BurnOptimizer,
+    };
+
+    type B = Autodiff<NdArray<f32>>;
+
+    fn small_config() -> DQNConfig {
+        DQNConfig::new()
+            .buffer_capacity(128)
+            .min_buffer_size(8)
+            .batch_size(8)
+            .target_update_interval(4)
+            .epsilon_decay_steps(100)
+    }
+
+    /// Smoke test: a Burn DQN trainer constructs without error using
+    /// `MlpBurnPolicy` as a Q-network stand-in (phase 4 ports the
+    /// proper `QNetworkBurn`).
+    #[test]
+    fn dqn_trainer_burn_constructs() {
+        let device = Default::default();
+        let online = MlpBurnPolicy::<B>::new(4, 2, 16, &device);
+        let inner_opt = AdamConfig::new().init();
+        let burn_opt = BurnOptimizer::new(inner_opt, small_config().learning_rate);
+        let trainer =
+            DQNTrainerBurn::new(small_config(), online, burn_opt, 4, 2, device).unwrap();
+        assert_eq!(trainer.total_env_steps(), 0);
+        assert_eq!(trainer.buffer_len(), 0);
+    }
+
+    /// Prioritized replay is intentionally not yet supported on the
+    /// Burn path.
+    #[test]
+    fn dqn_trainer_burn_rejects_prioritized_config() {
+        let device = Default::default();
+        let online = MlpBurnPolicy::<B>::new(4, 2, 16, &device);
+        let inner_opt = AdamConfig::new().init();
+        let burn_opt = BurnOptimizer::new(inner_opt, 1e-3);
+        let cfg = small_config().prioritized_replay(true);
+        assert!(DQNTrainerBurn::new(cfg, online, burn_opt, 4, 2, device).is_err());
+    }
+
+    /// End-to-end: pushing transitions and calling `train_step` runs
+    /// the Smooth-L1 / Double-DQN gradient step without panicking.
+    /// Uses `MlpBurnPolicy` as a Q-network stand-in — its `forward`
+    /// returns `(logits, value)`; we use the logits as the Q-values.
+    #[test]
+    fn dqn_trainer_burn_train_step_runs() {
+        let device = Default::default();
+        let online = MlpBurnPolicy::<B>::new(4, 2, 16, &device);
+        let inner_opt = AdamConfig::new().init();
+        let burn_opt = BurnOptimizer::new(inner_opt, 1e-3);
+        let mut trainer =
+            DQNTrainerBurn::new(small_config(), online, burn_opt, 4, 2, device).unwrap();
+
+        // Push enough transitions to clear min_buffer_size.
+        for i in 0..32 {
+            let phase = (i as f32) * 0.1;
+            let obs = [phase.sin(), phase.cos(), phase * 0.5, phase * -0.3];
+            let next_obs = [(phase + 0.1).sin(), (phase + 0.1).cos(), phase * 0.5, phase * -0.3];
+            let action = (i % 2) as i64;
+            let reward = if action == 0 { 1.0 } else { -1.0 };
+            let done = i % 8 == 7;
+            trainer.buffer_mut().push(&obs, action, reward, &next_obs, done);
+        }
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(7);
+        let forward_fn = |q: &MlpBurnPolicy<B>, o: Tensor<B, 2>| -> Tensor<B, 2> {
+            let (logits, _) = q.forward(o);
+            logits
+        };
+        let stats = trainer
+            .train_step(&mut rng, forward_fn, forward_fn)
+            .unwrap();
+        assert!(stats.is_some());
+        let s = stats.unwrap();
+        assert!(s.td_loss.is_finite());
+    }
+}

--- a/src/train/mod.rs
+++ b/src/train/mod.rs
@@ -10,13 +10,34 @@
 /// write-up.
 pub mod optimizer;
 
-#[cfg(feature = "training")]
+#[cfg(any(feature = "training", feature = "training-burn"))]
 pub mod dqn;
-#[cfg(feature = "training")]
+#[cfg(any(feature = "training", feature = "training-burn"))]
 pub mod ppo;
+
+/// Burn-backend PPO module (phase 3 of #65). Sibling to the tch
+/// [`ppo`] module; both implement the same algorithm but use different
+/// tensor backends. Collapses into a single module in phase 5 (#82).
+#[cfg(feature = "training-burn")]
+pub mod ppo_burn;
+
+/// Burn-backend DQN module (phase 3 of #65). Sibling to the tch
+/// [`dqn`] module.
+#[cfg(feature = "training-burn")]
+pub mod dqn_burn;
+
+/// Numerical-parity tests between the tch and Burn loss
+/// implementations. Active only when **both** backends are compiled
+/// in. See the module-level doc on
+/// [`crate::train::ppo_burn::loss`] / [`crate::train::dqn_burn::loss`]
+/// for the 1e-4 tolerance contract.
+#[cfg(all(feature = "training", feature = "training-burn", test))]
+mod parity_tests;
 
 #[cfg(feature = "training")]
 pub use dqn::{DQNConfig, DQNStepStats, DQNTrainer};
+#[cfg(feature = "training-burn")]
+pub use dqn_burn::{DQNStepStatsBurn, DQNTrainerBurn};
 // The optimizer abstraction is available regardless of which backend
 // feature is selected. The tch impl (`TchOptimizer`) and Burn impl
 // (`BurnOptimizer`) are individually feature-gated inside the module.
@@ -30,3 +51,5 @@ pub use ppo::{
     AggregatedStats, PPOConfig, PPOTrainer, TrainingStats, compute_gae, compute_policy_loss,
     compute_value_loss, generate_minibatch_indices,
 };
+#[cfg(feature = "training-burn")]
+pub use ppo_burn::PPOTrainerBurn;

--- a/src/train/parity_tests.rs
+++ b/src/train/parity_tests.rs
@@ -8,14 +8,14 @@
 //!
 //! # What is and isn't compared
 //!
-//! - **In scope**: scalar values returned by the loss functions
-//!   (`policy_loss`, `value_loss`, `entropy_loss`, `td_target`,
-//!   `td_loss`). These are computed from synthetic inputs that exist
-//!   on both backends and have known numerical answers.
+//! - **In scope**: scalar values returned by the loss functions (`policy_loss`,
+//!   `value_loss`, `entropy_loss`, `td_target`, `td_loss`). These are computed
+//!   from synthetic inputs that exist on both backends and have known numerical
+//!   answers.
 //! - **Out of scope**: gradients. Burn and tch use different autograd
-//!   implementations and their derivatives may differ in the last bit
-//!   even when the forward pass matches; gradient-level parity is
-//!   tested at the trainer-integration level in phases 4/5.
+//!   implementations and their derivatives may differ in the last bit even when
+//!   the forward pass matches; gradient-level parity is tested at the
+//!   trainer-integration level in phases 4/5.
 
 use burn::{
     backend::{Autodiff, NdArray},

--- a/src/train/parity_tests.rs
+++ b/src/train/parity_tests.rs
@@ -1,0 +1,260 @@
+//! Numerical-parity tests between the tch and Burn loss
+//! implementations (phase 3 of the Burn migration, #80).
+//!
+//! These tests run only when both `training` (tch) and `training-burn`
+//! (Burn) features are compiled in. They enforce the DoD contract on
+//! issue #80: identical inputs to the two backend implementations of
+//! the PPO and DQN loss math must agree to **1e-4 absolute tolerance**.
+//!
+//! # What is and isn't compared
+//!
+//! - **In scope**: scalar values returned by the loss functions
+//!   (`policy_loss`, `value_loss`, `entropy_loss`, `td_target`,
+//!   `td_loss`). These are computed from synthetic inputs that exist
+//!   on both backends and have known numerical answers.
+//! - **Out of scope**: gradients. Burn and tch use different autograd
+//!   implementations and their derivatives may differ in the last bit
+//!   even when the forward pass matches; gradient-level parity is
+//!   tested at the trainer-integration level in phases 4/5.
+
+use burn::{
+    backend::{Autodiff, NdArray},
+    tensor::{Int, Tensor as BurnTensor, TensorData},
+};
+use tch::Tensor as TchTensor;
+
+use crate::train::{dqn_burn::loss as dqn_loss_burn, ppo_burn::loss as ppo_loss_burn};
+
+type B = Autodiff<NdArray<f32>>;
+
+const PARITY_TOL: f64 = 1e-4;
+
+fn tch1(data: &[f32]) -> TchTensor {
+    TchTensor::from_slice(data)
+}
+
+fn tch2(data: &[f32], rows: usize, cols: usize) -> TchTensor {
+    TchTensor::from_slice(data).reshape([rows as i64, cols as i64])
+}
+
+fn burn1(data: &[f32]) -> BurnTensor<B, 1> {
+    let device = Default::default();
+    BurnTensor::<B, 1>::from_data(TensorData::new(data.to_vec(), [data.len()]), &device)
+}
+
+fn burn2(data: &[f32], rows: usize, cols: usize) -> BurnTensor<B, 2> {
+    let device = Default::default();
+    BurnTensor::<B, 2>::from_data(TensorData::new(data.to_vec(), [rows, cols]), &device)
+}
+
+fn burn_actions(data: &[i64]) -> BurnTensor<B, 1, Int> {
+    let device = Default::default();
+    BurnTensor::<B, 1, Int>::from_data(TensorData::new(data.to_vec(), [data.len()]), &device)
+}
+
+#[test]
+fn parity_ppo_policy_loss() {
+    let log_probs_f = [0.0_f32, 0.5, -0.5];
+    let old_log_probs_f = [0.0_f32, 0.0, 0.0];
+    let advantages_f = [1.0_f32, -1.0, 0.5];
+    let clip_range = 0.2;
+
+    let (loss_tch, clip_tch, kl_tch) = crate::train::ppo::compute_policy_loss(
+        &tch1(&log_probs_f),
+        &tch1(&old_log_probs_f),
+        &tch1(&advantages_f),
+        clip_range,
+    );
+    let loss_tch_val = f64::try_from(&loss_tch).unwrap();
+
+    let (loss_burn, clip_burn, kl_burn) = ppo_loss_burn::compute_policy_loss(
+        burn1(&log_probs_f),
+        burn1(&old_log_probs_f),
+        burn1(&advantages_f),
+        clip_range,
+    );
+    let loss_burn_val = ppo_loss_burn::scalar_f64(loss_burn);
+
+    assert!(
+        (loss_tch_val - loss_burn_val).abs() < PARITY_TOL,
+        "policy_loss mismatch: tch={loss_tch_val} burn={loss_burn_val}"
+    );
+    assert!(
+        (clip_tch - clip_burn).abs() < PARITY_TOL,
+        "clip_fraction mismatch: tch={clip_tch} burn={clip_burn}"
+    );
+    assert!(
+        (kl_tch - kl_burn).abs() < PARITY_TOL,
+        "approx_kl mismatch: tch={kl_tch} burn={kl_burn}"
+    );
+}
+
+#[test]
+fn parity_ppo_value_loss_with_clip() {
+    let values_f = [5.0_f32, 5.0, 5.0];
+    let old_values_f = [0.0_f32, 0.0, 0.0];
+    let returns_f = [0.0_f32, 0.0, 0.0];
+    let clip_range_vf = 0.2;
+
+    let (loss_tch, ev_tch) = crate::train::ppo::compute_value_loss(
+        &tch1(&values_f),
+        &tch1(&old_values_f),
+        &tch1(&returns_f),
+        clip_range_vf,
+    );
+    let loss_tch_val = f64::try_from(&loss_tch).unwrap();
+
+    let (loss_burn, ev_burn) = ppo_loss_burn::compute_value_loss(
+        burn1(&values_f),
+        burn1(&old_values_f),
+        burn1(&returns_f),
+        clip_range_vf,
+    );
+    let loss_burn_val = ppo_loss_burn::scalar_f64(loss_burn);
+
+    assert!(
+        (loss_tch_val - loss_burn_val).abs() < PARITY_TOL,
+        "value_loss mismatch: tch={loss_tch_val} burn={loss_burn_val}"
+    );
+    assert!(
+        (ev_tch - ev_burn).abs() < PARITY_TOL,
+        "explained_var mismatch: tch={ev_tch} burn={ev_burn}"
+    );
+}
+
+#[test]
+fn parity_ppo_value_loss_infinite_clip() {
+    let values_f = [1.0_f32, 2.0, 0.5];
+    let old_values_f = [1.0_f32, 1.5, 0.8];
+    let returns_f = [1.2_f32, 2.1, 0.6];
+    let clip_range_vf = f64::INFINITY;
+
+    let (loss_tch, _) = crate::train::ppo::compute_value_loss(
+        &tch1(&values_f),
+        &tch1(&old_values_f),
+        &tch1(&returns_f),
+        clip_range_vf,
+    );
+    let loss_tch_val = f64::try_from(&loss_tch).unwrap();
+
+    let (loss_burn, _) = ppo_loss_burn::compute_value_loss(
+        burn1(&values_f),
+        burn1(&old_values_f),
+        burn1(&returns_f),
+        clip_range_vf,
+    );
+    let loss_burn_val = ppo_loss_burn::scalar_f64(loss_burn);
+
+    assert!(
+        (loss_tch_val - loss_burn_val).abs() < PARITY_TOL,
+        "infinite-clip value_loss mismatch: tch={loss_tch_val} burn={loss_burn_val}"
+    );
+}
+
+#[test]
+fn parity_ppo_entropy_loss() {
+    let entropy_f = [0.5_f32, 1.0, 0.1];
+    let loss_tch = crate::train::ppo::compute_entropy_loss(&tch1(&entropy_f));
+    let loss_tch_val = f64::try_from(&loss_tch).unwrap();
+
+    let loss_burn = ppo_loss_burn::compute_entropy_loss(burn1(&entropy_f));
+    let loss_burn_val = ppo_loss_burn::scalar_f64(loss_burn);
+
+    assert!(
+        (loss_tch_val - loss_burn_val).abs() < PARITY_TOL,
+        "entropy_loss mismatch: tch={loss_tch_val} burn={loss_burn_val}"
+    );
+}
+
+#[test]
+fn parity_dqn_td_target() {
+    let rewards_f = [1.0_f32, 2.0];
+    let dones_f = [0.0_f32, 1.0];
+    let next_q_f = [1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0];
+
+    let target_tch = crate::train::dqn::compute_td_target(
+        &tch1(&rewards_f),
+        &tch1(&dones_f),
+        &tch2(&next_q_f, 2, 3),
+        0.9,
+    );
+    let tch_vec: Vec<f32> = Vec::try_from(target_tch).unwrap();
+
+    let target_burn = dqn_loss_burn::compute_td_target(
+        burn1(&rewards_f),
+        burn1(&dones_f),
+        burn2(&next_q_f, 2, 3),
+        0.9,
+    );
+    let burn_vec: Vec<f32> = target_burn.into_data().to_vec().unwrap();
+
+    assert_eq!(tch_vec.len(), burn_vec.len());
+    for (t, b) in tch_vec.iter().zip(burn_vec.iter()) {
+        assert!((*t as f64 - *b as f64).abs() < PARITY_TOL, "td_target {} vs {}", t, b);
+    }
+}
+
+#[test]
+fn parity_dqn_td_target_double() {
+    let rewards_f = [1.0_f32, 0.5];
+    let dones_f = [0.0_f32, 1.0];
+    let q_online_f = [0.5_f32, 2.0, 1.0, 0.5];
+    let q_target_f = [10.0_f32, 3.0, 7.0, 4.0];
+
+    let target_tch = crate::train::dqn::compute_td_target_double(
+        &tch1(&rewards_f),
+        &tch1(&dones_f),
+        &tch2(&q_online_f, 2, 2),
+        &tch2(&q_target_f, 2, 2),
+        0.9,
+    );
+    let tch_vec: Vec<f32> = Vec::try_from(target_tch).unwrap();
+
+    let target_burn = dqn_loss_burn::compute_td_target_double(
+        burn1(&rewards_f),
+        burn1(&dones_f),
+        burn2(&q_online_f, 2, 2),
+        burn2(&q_target_f, 2, 2),
+        0.9,
+    );
+    let burn_vec: Vec<f32> = target_burn.into_data().to_vec().unwrap();
+
+    for (t, b) in tch_vec.iter().zip(burn_vec.iter()) {
+        assert!((*t as f64 - *b as f64).abs() < PARITY_TOL, "double td_target {} vs {}", t, b);
+    }
+}
+
+#[test]
+fn parity_dqn_gather_action_q() {
+    let q_f = [1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let actions_f = [0_i64, 1, 0];
+
+    // tch path: actions tensor.
+    let actions_tch = TchTensor::from_slice(&actions_f);
+    let gathered_tch = crate::train::dqn::gather_action_q(&tch2(&q_f, 3, 2), &actions_tch);
+    let tch_vec: Vec<f32> = Vec::try_from(gathered_tch).unwrap();
+
+    let gathered_burn = dqn_loss_burn::gather_action_q(burn2(&q_f, 3, 2), burn_actions(&actions_f));
+    let burn_vec: Vec<f32> = gathered_burn.into_data().to_vec().unwrap();
+
+    for (t, b) in tch_vec.iter().zip(burn_vec.iter()) {
+        assert!((*t as f64 - *b as f64).abs() < PARITY_TOL, "gather_action_q {} vs {}", t, b);
+    }
+}
+
+#[test]
+fn parity_dqn_compute_loss() {
+    let q_f = [1.0_f32, 2.0, 3.0];
+    let target_f = [1.1_f32, 1.5, 4.0];
+
+    let loss_tch = crate::train::dqn::compute_loss(&tch1(&q_f), &tch1(&target_f));
+    let loss_tch_val: f64 = f64::try_from(&loss_tch).unwrap();
+
+    let loss_burn = dqn_loss_burn::compute_loss(burn1(&q_f), burn1(&target_f));
+    let loss_burn_val: f64 = loss_burn.into_scalar() as f64;
+
+    assert!(
+        (loss_tch_val - loss_burn_val).abs() < PARITY_TOL,
+        "dqn compute_loss mismatch: tch={loss_tch_val} burn={loss_burn_val}"
+    );
+}

--- a/src/train/ppo.rs
+++ b/src/train/ppo.rs
@@ -28,9 +28,9 @@
 // tch-specific bits (`compute_gae`, `compute_policy_loss`,
 // `compute_value_loss`, `PPOTrainer`) stay gated on `training`.
 pub use config::PPOConfig;
+pub use loss::generate_minibatch_indices;
 #[cfg(feature = "training")]
 pub use loss::{compute_entropy_loss, compute_gae, compute_policy_loss, compute_value_loss};
-pub use loss::generate_minibatch_indices;
 pub use stats::{AggregatedStats, TrainingStats};
 #[cfg(feature = "training")]
 pub use trainer::PPOTrainer;

--- a/src/train/ppo.rs
+++ b/src/train/ppo.rs
@@ -21,14 +21,23 @@
 //! - [Proximal Policy Optimization Algorithms](https://arxiv.org/abs/1707.06347)
 //! - [OpenAI Spinning Up: PPO](https://spinningup.openai.com/en/latest/algorithms/ppo.html)
 
-// Re-export main components
+// Re-export main components. `PPOConfig`, `TrainingStats`,
+// `AggregatedStats`, and `generate_minibatch_indices` are
+// backend-agnostic (they do not touch `tch::Tensor`) and are
+// available under either `training` (tch) or `training-burn`. The
+// tch-specific bits (`compute_gae`, `compute_policy_loss`,
+// `compute_value_loss`, `PPOTrainer`) stay gated on `training`.
 pub use config::PPOConfig;
-pub use loss::{compute_gae, compute_policy_loss, compute_value_loss, generate_minibatch_indices};
+#[cfg(feature = "training")]
+pub use loss::{compute_entropy_loss, compute_gae, compute_policy_loss, compute_value_loss};
+pub use loss::generate_minibatch_indices;
 pub use stats::{AggregatedStats, TrainingStats};
+#[cfg(feature = "training")]
 pub use trainer::PPOTrainer;
 
 // Submodules
 mod config;
 mod loss;
 mod stats;
+#[cfg(feature = "training")]
 mod trainer;

--- a/src/train/ppo/loss.rs
+++ b/src/train/ppo/loss.rs
@@ -2,7 +2,19 @@
 //!
 //! This module contains the core loss computation functions used
 //! in PPO training including policy loss, value loss, and entropy loss.
+//!
+//! # Backend gating
+//!
+//! All tensor-typed helpers in this file (`compute_policy_loss`,
+//! `compute_value_loss`, `compute_entropy_loss`, `compute_gae`) are
+//! tch-backend specific and gated on `feature = "training"`. The
+//! backend-agnostic helpers (`generate_minibatch_indices`) sit outside
+//! the gate so the Burn-side trainer
+//! ([`crate::train::ppo_burn::trainer::PPOTrainerBurn`]) can share
+//! them. See [`crate::train::ppo_burn::loss`] for the Burn-backend
+//! parallels.
 
+#[cfg(feature = "training")]
 use tch::{Kind, Tensor};
 
 /// Compute PPO policy loss with clipping
@@ -14,6 +26,7 @@ use tch::{Kind, Tensor};
 /// * `old_log_probs` - Log probabilities of actions under old policy
 /// * `advantages` - Computed advantages
 /// * `clip_range` - PPO clipping parameter (epsilon)
+#[cfg(feature = "training")]
 pub fn compute_policy_loss(
     log_probs: &Tensor,
     old_log_probs: &Tensor,
@@ -68,6 +81,7 @@ pub fn compute_policy_loss(
 /// * `returns` - Computed returns (targets)
 /// * `clip_range_vf` - Value function clipping parameter (use `f64::INFINITY`
 ///   to disable clipping)
+#[cfg(feature = "training")]
 pub fn compute_value_loss(
     values: &Tensor,
     old_values: &Tensor,
@@ -105,6 +119,7 @@ pub fn compute_value_loss(
 ///
 /// # Arguments
 /// * `entropy` - Entropy tensor from policy distribution
+#[cfg(feature = "training")]
 pub fn compute_entropy_loss(entropy: &Tensor) -> Tensor {
     -entropy.mean(Kind::Float)
 }
@@ -142,6 +157,7 @@ pub fn generate_minibatch_indices(buffer_size: usize, batch_size: usize) -> Vec<
 ///
 /// # Returns
 /// (advantages, returns) tensors
+#[cfg(feature = "training")]
 pub fn compute_gae(
     rewards: &Tensor,
     values: &Tensor,
@@ -182,6 +198,7 @@ pub fn compute_gae(
 }
 
 /// Compute GAE for a single environment
+#[cfg(feature = "training")]
 fn compute_gae_single_env(
     rewards: &Tensor,
     values: &Tensor,
@@ -227,7 +244,7 @@ fn compute_gae_single_env(
     (Tensor::from_slice(&advantages), Tensor::from_slice(&returns))
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "training"))]
 mod tests {
     use tch::Tensor;
 

--- a/src/train/ppo_burn.rs
+++ b/src/train/ppo_burn.rs
@@ -7,10 +7,10 @@
 //! # Contents
 //!
 //! - [`loss`] — backend-generic PPO loss math (policy/value/entropy).
-//! - [`trainer`] — `PPOTrainerBurn<B, P, O>` that owns the policy
-//!   module (Burn's optimizer-consumes-module ownership model) and
-//!   exposes a `train_step` that runs the same surrogate-loss /
-//!   gradient-step / KL-early-stop logic as the tch trainer.
+//! - [`trainer`] — `PPOTrainerBurn<B, P, O>` that owns the policy module
+//!   (Burn's optimizer-consumes-module ownership model) and exposes a
+//!   `train_step` that runs the same surrogate-loss / gradient-step /
+//!   KL-early-stop logic as the tch trainer.
 //!
 //! # Numerical parity
 //!
@@ -26,9 +26,8 @@
 //! and pulls in tch types at the top of every file. Putting the Burn
 //! port under `train/ppo` would mean either:
 //!
-//! 1. Loosening the feature gate on the whole tch module, which forces
-//!    every tch-gated file to also be valid under `training-burn` alone;
-//!    or
+//! 1. Loosening the feature gate on the whole tch module, which forces every
+//!    tch-gated file to also be valid under `training-burn` alone; or
 //! 2. Pervasive cfg-attr scaffolding inside each file.
 //!
 //! Both are noisy; the parallel-sibling pattern (`ppo` for tch,

--- a/src/train/ppo_burn.rs
+++ b/src/train/ppo_burn.rs
@@ -1,0 +1,44 @@
+//! Burn-backend PPO module (phase 3 of the Burn migration, #80).
+//!
+//! Sibling to [`crate::train::ppo`] (tch path). The two modules expose
+//! deliberately parallel APIs so phase 5 (#82) can collapse them into
+//! one when the tch path is dropped.
+//!
+//! # Contents
+//!
+//! - [`loss`] — backend-generic PPO loss math (policy/value/entropy).
+//! - [`trainer`] — `PPOTrainerBurn<B, P, O>` that owns the policy
+//!   module (Burn's optimizer-consumes-module ownership model) and
+//!   exposes a `train_step` that runs the same surrogate-loss /
+//!   gradient-step / KL-early-stop logic as the tch trainer.
+//!
+//! # Numerical parity
+//!
+//! Identical inputs to the tch PPO loss surface must produce the same
+//! scalar values to **1e-4 absolute tolerance** (DoD on issue #80).
+//! That is enforced by the integration parity tests in
+//! [`crate::train::parity_tests`] (active only when both `training` and
+//! `training-burn` features are enabled).
+//!
+//! # Why a separate module
+//!
+//! The pre-phase-3 `train/ppo` module is gated on `feature = "training"`
+//! and pulls in tch types at the top of every file. Putting the Burn
+//! port under `train/ppo` would mean either:
+//!
+//! 1. Loosening the feature gate on the whole tch module, which forces
+//!    every tch-gated file to also be valid under `training-burn` alone;
+//!    or
+//! 2. Pervasive cfg-attr scaffolding inside each file.
+//!
+//! Both are noisy; the parallel-sibling pattern (`ppo` for tch,
+//! `ppo_burn` for Burn) is the same pattern phase 2b used for the
+//! optimizer abstraction (`TchOptimizer` / `BurnOptimizer`) and the
+//! same one the policy module already adopted with `mlp.rs` /
+//! `mlp_burn.rs`. Phase 5 collapses both.
+
+pub mod loss;
+pub mod trainer;
+
+pub use loss::{compute_entropy_loss, compute_policy_loss, compute_value_loss, scalar_f64};
+pub use trainer::PPOTrainerBurn;

--- a/src/train/ppo_burn.rs
+++ b/src/train/ppo_burn.rs
@@ -6,18 +6,19 @@
 //!
 //! # Contents
 //!
-//! - [`loss`] — backend-generic PPO loss math (policy/value/entropy).
-//! - [`trainer`] — `PPOTrainerBurn<B, P, O>` that owns the policy module
-//!   (Burn's optimizer-consumes-module ownership model) and exposes a
-//!   `train_step` that runs the same surrogate-loss / gradient-step /
+//! - [`crate::train::ppo_burn::loss`] — backend-generic PPO loss math
+//!   (policy/value/entropy).
+//! - [`crate::train::ppo_burn::trainer`] — `PPOTrainerBurn<B, P, O>` that owns
+//!   the policy module (Burn's optimizer-consumes-module ownership model) and
+//!   exposes a `train_step` that runs the same surrogate-loss / gradient-step /
 //!   KL-early-stop logic as the tch trainer.
 //!
 //! # Numerical parity
 //!
 //! Identical inputs to the tch PPO loss surface must produce the same
 //! scalar values to **1e-4 absolute tolerance** (DoD on issue #80).
-//! That is enforced by the integration parity tests in
-//! [`crate::train::parity_tests`] (active only when both `training` and
+//! That is enforced by the integration parity tests in the
+//! `parity_tests` module (active only when both `training` and
 //! `training-burn` features are enabled).
 //!
 //! # Why a separate module

--- a/src/train/ppo_burn/loss.rs
+++ b/src/train/ppo_burn/loss.rs
@@ -1,0 +1,275 @@
+//! Burn-backend PPO loss math (phase 3 of the Burn migration, #80).
+//!
+//! Mirrors `crate::train::ppo::loss` (tch path) op-for-op. The tch
+//! versions stay where they are so the existing trainer and tests
+//! continue to work unchanged; this module is the parallel surface that
+//! a backend-agnostic PPO trainer (see [`crate::train::ppo_burn::trainer`])
+//! sits on top of.
+//!
+//! # Numerical parity
+//!
+//! On identical inputs the Burn and tch implementations must agree to
+//! `1e-4` absolute tolerance (DoD on issue #80). The
+//! `crate::train::parity_tests` module enforces this when both
+//! `training` and `training-burn` features are enabled.
+//!
+//! # API differences vs. tch
+//!
+//! - Burn ops are free functions on the tensor (`tensor.clamp(lo, hi)`,
+//!   `tensor.exp()`, `min_pair`, `mean`, etc.) like tch, but Burn's
+//!   `mean()` returns a rank-1 scalar tensor — there is no `Kind::Float`
+//!   argument, and the resulting tensor still carries the backend
+//!   parameter. We expose the scalar-extracting helpers
+//!   ([`scalar_f64`]) that the trainer needs at the loss boundary.
+//! - Burn carries the const rank in the type, so the policy-loss /
+//!   value-loss tensors carry their concrete rank (`Tensor<B, 1>` for
+//!   per-row, scalar at the end). We avoid the scalar-tensor
+//!   ambiguity tch has with `Kind::Float` by always returning the
+//!   scalar tensor and letting the caller decide when to materialize.
+//! - The tch path uses `tch::no_grad` for the metrics extraction
+//!   (clip-fraction / approx-KL) because those values feed reporting,
+//!   not gradients. The Burn path does not need an explicit `no_grad`
+//!   scope — we extract scalars via [`scalar_f64`] which detaches
+//!   implicitly via `.into_scalar()`. The autograd tape is not extended
+//!   beyond the loss tensors we *return*.
+
+use burn::{
+    prelude::ToElement,
+    tensor::{Tensor, backend::Backend},
+};
+
+/// Read a scalar tensor's value into an `f64`.
+///
+/// Burn's `into_scalar()` consumes the tensor and returns
+/// `B::FloatElem`. We use Burn's [`ToElement`] trait to convert it to
+/// `f64` regardless of whether the underlying float type is `f32` or
+/// `f64`. Equivalent to tch's `f64::try_from(&tensor)` pattern, and
+/// (critically) does not extend the autograd tape — the returned `f64`
+/// is a host-side primitive.
+pub fn scalar_f64<B: Backend>(tensor: Tensor<B, 1>) -> f64 {
+    tensor.into_scalar().to_f64()
+}
+
+/// Compute PPO policy (surrogate) loss with clipping.
+///
+/// Returns `(policy_loss, clip_fraction, approx_kl)`. The two `f64`
+/// values are host-side metrics (already detached from the autograd
+/// graph) for trainer-side reporting and KL early stopping.
+///
+/// # Arguments
+///
+/// * `log_probs` - Log-probabilities of the actions under the *current*
+///   policy. `[batch]`.
+/// * `old_log_probs` - Log-probabilities under the *behaviour* policy.
+///   `[batch]`.
+/// * `advantages` - Normalized advantages `[batch]`.
+/// * `clip_range` - PPO clipping parameter `ε`.
+///
+/// # Returns
+///
+/// 1. `policy_loss` — scalar tensor (rank 1, shape `[1]`) carrying the
+///    grad-bearing surrogate loss.
+/// 2. `clip_fraction` — fraction of samples where `|ratio − 1| > ε`.
+///    Diagnostic only.
+/// 3. `approx_kl` — `E[old_log_prob − new_log_prob]`, the standard
+///    biased KL estimator used by SB3/CleanRL for early stopping.
+pub fn compute_policy_loss<B: Backend>(
+    log_probs: Tensor<B, 1>,
+    old_log_probs: Tensor<B, 1>,
+    advantages: Tensor<B, 1>,
+    clip_range: f64,
+) -> (Tensor<B, 1>, f64, f64) {
+    // ratio = exp(new − old)
+    let log_ratio = log_probs.clone() - old_log_probs.clone();
+    let ratio = log_ratio.clone().exp();
+
+    // Clipped surrogate objective (pessimistic min).
+    let clipped_ratio = ratio.clone().clamp(1.0 - clip_range, 1.0 + clip_range);
+    let surrogate_1 = advantages.clone() * ratio.clone();
+    let surrogate_2 = advantages * clipped_ratio;
+    let per_sample = surrogate_1.min_pair(surrogate_2);
+    let policy_loss = per_sample.mean().neg();
+
+    // Clip fraction: mean of (|ratio − 1| > ε).
+    //
+    // Burn 0.21's bool→float cast goes via `.float()`, mirroring
+    // `tch::Kind::Float`. The threshold comparison gives a `Bool`
+    // tensor; we materialize it to a float, take the mean, and pull
+    // the scalar to the host.
+    let one = Tensor::<B, 1>::ones_like(&ratio);
+    let abs_dev = (ratio - one).abs();
+    let clipped_mask = abs_dev.greater_elem(clip_range as f32).float();
+    let clip_fraction = scalar_f64(clipped_mask.mean());
+
+    // Biased KL estimator: E[old − new].
+    let approx_kl = scalar_f64((old_log_probs - log_probs).mean());
+
+    (policy_loss, clip_fraction, approx_kl)
+}
+
+/// Compute the value-function loss with optional clipping.
+///
+/// Implements the *pessimistic* clipped value loss (the SB3/CleanRL
+/// recipe). When `clip_range_vf` is non-finite the clipped branch is
+/// skipped and we fall through to the plain MSE — semantically
+/// identical to the tch path.
+///
+/// # Arguments
+///
+/// * `values` - Current value-function predictions `V(s_t)`. `[batch]`.
+/// * `old_values` - Behaviour-policy value predictions. `[batch]`.
+/// * `returns` - Bootstrap targets (advantages + old_values). `[batch]`.
+/// * `clip_range_vf` - Value clipping parameter; `f64::INFINITY` to
+///   disable.
+///
+/// # Returns
+///
+/// 1. `value_loss` — scalar tensor carrying the grad-bearing value
+///    loss.
+/// 2. `explained_var` — host-side `1 − Var(returns − values) / Var(returns)`.
+pub fn compute_value_loss<B: Backend>(
+    values: Tensor<B, 1>,
+    old_values: Tensor<B, 1>,
+    returns: Tensor<B, 1>,
+    clip_range_vf: f64,
+) -> (Tensor<B, 1>, f64) {
+    let value_loss = if clip_range_vf.is_finite() {
+        let clipped_dev =
+            (values.clone() - old_values.clone()).clamp(-clip_range_vf, clip_range_vf);
+        let values_clipped = old_values + clipped_dev;
+        let vf_loss_1 = (values.clone() - returns.clone()).powf_scalar(2.0_f32);
+        let vf_loss_2 = (values_clipped - returns.clone()).powf_scalar(2.0_f32);
+        vf_loss_1.max_pair(vf_loss_2).mean()
+    } else {
+        (values.clone() - returns.clone()).powf_scalar(2.0_f32).mean()
+    };
+
+    // Explained variance is a pure host-side metric.
+    let returns_vec: Vec<f32> = returns.clone().into_data().to_vec().unwrap_or_default();
+    let values_vec: Vec<f32> = values.into_data().to_vec().unwrap_or_default();
+    let explained_var = host_explained_variance(&returns_vec, &values_vec);
+
+    (value_loss, explained_var)
+}
+
+/// Host-side explained-variance computation.
+///
+/// `1 − Var(returns − values) / Var(returns)`. Mirrors the tch path's
+/// `var(false)` (biased estimator with denominator `n`) so the two
+/// implementations agree numerically.
+fn host_explained_variance(returns: &[f32], values: &[f32]) -> f64 {
+    if returns.is_empty() {
+        return 1.0;
+    }
+    let var_returns = host_variance_biased(returns);
+    if var_returns == 0.0 {
+        return 1.0;
+    }
+    let residual: Vec<f32> = returns.iter().zip(values).map(|(r, v)| r - v).collect();
+    let var_residual = host_variance_biased(&residual);
+    1.0 - var_residual / var_returns
+}
+
+fn host_variance_biased(xs: &[f32]) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    let n = xs.len() as f64;
+    let mean = xs.iter().map(|&x| x as f64).sum::<f64>() / n;
+    let sq_dev = xs.iter().map(|&x| (x as f64 - mean).powi(2)).sum::<f64>();
+    sq_dev / n
+}
+
+/// Entropy loss = `-mean(entropy)` (we minimize loss, so we negate the
+/// entropy bonus before adding it into the total loss).
+pub fn compute_entropy_loss<B: Backend>(entropy: Tensor<B, 1>) -> Tensor<B, 1> {
+    entropy.mean().neg()
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::{
+        backend::{Autodiff, NdArray},
+        tensor::{Tensor, TensorData},
+    };
+
+    use super::*;
+
+    type B = Autodiff<NdArray<f32>>;
+
+    fn tensor1d(data: &[f32]) -> Tensor<B, 1> {
+        let device = Default::default();
+        Tensor::<B, 1>::from_data(TensorData::new(data.to_vec(), [data.len()]), &device)
+    }
+
+    #[test]
+    fn test_compute_policy_loss_shapes_and_ranges() {
+        let log_probs = tensor1d(&[0.0, 0.5, -0.5]);
+        let old_log_probs = tensor1d(&[0.0, 0.0, 0.0]);
+        let advantages = tensor1d(&[1.0, -1.0, 0.5]);
+        let clip_range = 0.2;
+
+        let (loss, clip_frac, kl) =
+            compute_policy_loss(log_probs, old_log_probs, advantages, clip_range);
+
+        // Loss should be a rank-1 scalar tensor of shape [1].
+        assert_eq!(loss.dims(), [1]);
+        assert!((0.0..=1.0).contains(&clip_frac));
+        // The biased KL estimator can go either direction; just sanity
+        // check it's finite.
+        assert!(kl.is_finite());
+    }
+
+    #[test]
+    fn test_compute_value_loss_pessimistic_clip() {
+        // Same construction as the tch test: clipped loss is tiny vs
+        // unclipped, so the pessimistic max must reflect the unclipped
+        // MSE.
+        let old_values = tensor1d(&[0.0_f32, 0.0, 0.0]);
+        let values = tensor1d(&[5.0_f32, 5.0, 5.0]);
+        let returns = tensor1d(&[0.0_f32, 0.0, 0.0]);
+        let clip_range_vf = 0.2;
+
+        let (loss, _) = compute_value_loss(values, old_values, returns, clip_range_vf);
+        let loss_val = scalar_f64(loss);
+
+        let unclipped_mse = 25.0_f64;
+        let eps = 1e-4_f64;
+        assert!(
+            loss_val >= unclipped_mse - eps,
+            "expected pessimistic clipped value loss >= unclipped MSE ({}), got {}",
+            unclipped_mse,
+            loss_val
+        );
+    }
+
+    #[test]
+    fn test_compute_value_loss_infinite_clip_is_plain_mse() {
+        let old_values = tensor1d(&[1.0_f32, 1.5, 0.8]);
+        let values = tensor1d(&[1.0_f32, 2.0, 0.5]);
+        let returns = tensor1d(&[1.2_f32, 2.1, 0.6]);
+
+        let (loss_inf, _) =
+            compute_value_loss(values, old_values, returns, f64::INFINITY);
+        let loss_inf_val = scalar_f64(loss_inf);
+
+        let expected = 0.02_f64;
+        assert!(
+            (loss_inf_val - expected).abs() < 1e-4,
+            "infinite clip should yield plain MSE {}, got {}",
+            expected,
+            loss_inf_val
+        );
+    }
+
+    #[test]
+    fn test_compute_entropy_loss_negates_mean() {
+        let entropy = tensor1d(&[0.5, 1.0, 0.1]);
+        let loss = compute_entropy_loss(entropy);
+        assert_eq!(loss.dims(), [1]);
+        let loss_val = scalar_f64(loss);
+        // mean = (0.5 + 1.0 + 0.1) / 3 = 0.5333...; negated = -0.5333...
+        assert!(loss_val < 0.0);
+        assert!((loss_val - (-0.5333333_f64)).abs() < 1e-4);
+    }
+}

--- a/src/train/ppo_burn/loss.rs
+++ b/src/train/ppo_burn/loss.rs
@@ -16,22 +16,21 @@
 //! # API differences vs. tch
 //!
 //! - Burn ops are free functions on the tensor (`tensor.clamp(lo, hi)`,
-//!   `tensor.exp()`, `min_pair`, `mean`, etc.) like tch, but Burn's
-//!   `mean()` returns a rank-1 scalar tensor — there is no `Kind::Float`
-//!   argument, and the resulting tensor still carries the backend
-//!   parameter. We expose the scalar-extracting helpers
-//!   ([`scalar_f64`]) that the trainer needs at the loss boundary.
-//! - Burn carries the const rank in the type, so the policy-loss /
-//!   value-loss tensors carry their concrete rank (`Tensor<B, 1>` for
-//!   per-row, scalar at the end). We avoid the scalar-tensor
-//!   ambiguity tch has with `Kind::Float` by always returning the
-//!   scalar tensor and letting the caller decide when to materialize.
-//! - The tch path uses `tch::no_grad` for the metrics extraction
-//!   (clip-fraction / approx-KL) because those values feed reporting,
-//!   not gradients. The Burn path does not need an explicit `no_grad`
-//!   scope — we extract scalars via [`scalar_f64`] which detaches
-//!   implicitly via `.into_scalar()`. The autograd tape is not extended
-//!   beyond the loss tensors we *return*.
+//!   `tensor.exp()`, `min_pair`, `mean`, etc.) like tch, but Burn's `mean()`
+//!   returns a rank-1 scalar tensor — there is no `Kind::Float` argument, and
+//!   the resulting tensor still carries the backend parameter. We expose the
+//!   scalar-extracting helpers ([`scalar_f64`]) that the trainer needs at the
+//!   loss boundary.
+//! - Burn carries the const rank in the type, so the policy-loss / value-loss
+//!   tensors carry their concrete rank (`Tensor<B, 1>` for per-row, scalar at
+//!   the end). We avoid the scalar-tensor ambiguity tch has with `Kind::Float`
+//!   by always returning the scalar tensor and letting the caller decide when
+//!   to materialize.
+//! - The tch path uses `tch::no_grad` for the metrics extraction (clip-fraction
+//!   / approx-KL) because those values feed reporting, not gradients. The Burn
+//!   path does not need an explicit `no_grad` scope — we extract scalars via
+//!   [`scalar_f64`] which detaches implicitly via `.into_scalar()`. The
+//!   autograd tape is not extended beyond the loss tensors we *return*.
 
 use burn::{
     prelude::ToElement,
@@ -58,8 +57,8 @@ pub fn scalar_f64<B: Backend>(tensor: Tensor<B, 1>) -> f64 {
 ///
 /// # Arguments
 ///
-/// * `log_probs` - Log-probabilities of the actions under the *current*
-///   policy. `[batch]`.
+/// * `log_probs` - Log-probabilities of the actions under the *current* policy.
+///   `[batch]`.
 /// * `old_log_probs` - Log-probabilities under the *behaviour* policy.
 ///   `[batch]`.
 /// * `advantages` - Normalized advantages `[batch]`.
@@ -69,10 +68,10 @@ pub fn scalar_f64<B: Backend>(tensor: Tensor<B, 1>) -> f64 {
 ///
 /// 1. `policy_loss` — scalar tensor (rank 1, shape `[1]`) carrying the
 ///    grad-bearing surrogate loss.
-/// 2. `clip_fraction` — fraction of samples where `|ratio − 1| > ε`.
-///    Diagnostic only.
-/// 3. `approx_kl` — `E[old_log_prob − new_log_prob]`, the standard
-///    biased KL estimator used by SB3/CleanRL for early stopping.
+/// 2. `clip_fraction` — fraction of samples where `|ratio − 1| > ε`. Diagnostic
+///    only.
+/// 3. `approx_kl` — `E[old_log_prob − new_log_prob]`, the standard biased KL
+///    estimator used by SB3/CleanRL for early stopping.
 pub fn compute_policy_loss<B: Backend>(
     log_probs: Tensor<B, 1>,
     old_log_probs: Tensor<B, 1>,
@@ -119,13 +118,11 @@ pub fn compute_policy_loss<B: Backend>(
 /// * `values` - Current value-function predictions `V(s_t)`. `[batch]`.
 /// * `old_values` - Behaviour-policy value predictions. `[batch]`.
 /// * `returns` - Bootstrap targets (advantages + old_values). `[batch]`.
-/// * `clip_range_vf` - Value clipping parameter; `f64::INFINITY` to
-///   disable.
+/// * `clip_range_vf` - Value clipping parameter; `f64::INFINITY` to disable.
 ///
 /// # Returns
 ///
-/// 1. `value_loss` — scalar tensor carrying the grad-bearing value
-///    loss.
+/// 1. `value_loss` — scalar tensor carrying the grad-bearing value loss.
 /// 2. `explained_var` — host-side `1 − Var(returns − values) / Var(returns)`.
 pub fn compute_value_loss<B: Backend>(
     values: Tensor<B, 1>,
@@ -249,8 +246,7 @@ mod tests {
         let values = tensor1d(&[1.0_f32, 2.0, 0.5]);
         let returns = tensor1d(&[1.2_f32, 2.1, 0.6]);
 
-        let (loss_inf, _) =
-            compute_value_loss(values, old_values, returns, f64::INFINITY);
+        let (loss_inf, _) = compute_value_loss(values, old_values, returns, f64::INFINITY);
         let loss_inf_val = scalar_f64(loss_inf);
 
         let expected = 0.02_f64;

--- a/src/train/ppo_burn/trainer.rs
+++ b/src/train/ppo_burn/trainer.rs
@@ -1,0 +1,420 @@
+//! Burn-backend PPO trainer (phase 3 of the Burn migration, #80).
+//!
+//! Sibling to [`crate::train::ppo::PPOTrainer`] (tch path). Both
+//! trainers implement the same clipped-surrogate, value-clip,
+//! entropy-bonus, KL-early-stop recipe; the only difference is the
+//! tensor backend and the optimizer ownership model.
+//!
+//! # Ownership model
+//!
+//! Burn's `Optimizer<M, B>` is move-through: every gradient step
+//! consumes the module by value and returns the updated copy. Phase
+//! 1's scout (#78) confirmed this is the **single biggest** structural
+//! divergence between the two backends — see
+//! `docs/BURN_MIGRATION_PHASE1_REPORT.md` friction point #1.
+//!
+//! The Burn trainer therefore *owns* the policy module via an
+//! `Option<P>` field and swaps it through the optimizer on every
+//! step:
+//!
+//! ```text
+//! let module = self.policy.take().unwrap();
+//! let grads = loss.backward();
+//! let grads = GradientsParams::from_grads(grads, &module);
+//! let module = self.optimizer.inner_mut().step(lr, module, grads);
+//! self.policy = Some(module);
+//! ```
+//!
+//! The tch trainer is `struct PPOTrainer<P>` with `policy: P`; the
+//! Burn trainer is `struct PPOTrainerBurn<B, P, O>` with the policy
+//! held in `Option<P>`. Phase 5 (#82) collapses the two when the
+//! ownership-model asymmetry goes away (only Burn remains).
+//!
+//! # Evaluating the policy
+//!
+//! The trainer takes a closure `evaluate_fn(&P, observations, actions)`
+//! that returns `(log_probs, entropy, values)` exactly as the tch
+//! trainer does (see `PPOTrainer::train_step_with_policy`). This keeps
+//! the loss math identical and lets the caller plug in any module
+//! whose forward pass yields the right tensor shapes — including, for
+//! phase 4, the proper `MlpBurnPolicy`/`SnakeCnnBurn` ports.
+
+use anyhow::{Result, anyhow};
+use burn::{
+    module::AutodiffModule,
+    optim::{GradientsParams, Optimizer},
+    tensor::{Int, Tensor, backend::AutodiffBackend},
+};
+
+use super::loss::{compute_entropy_loss, compute_policy_loss, compute_value_loss, scalar_f64};
+use crate::train::{
+    optimizer::{BackendOptimizer, BurnOptimizer},
+    ppo::{PPOConfig, TrainingStats, generate_minibatch_indices},
+};
+
+/// Burn-backend PPO trainer.
+///
+/// Generic over:
+/// - `B: AutodiffBackend` — the Burn backend (e.g. `Autodiff<NdArray<f32>>`,
+///   `Autodiff<Wgpu>`, etc.).
+/// - `P: AutodiffModule<B>` — the policy module type.
+/// - `O: Optimizer<P, B>` — the Burn optimizer (typically built from
+///   `AdamConfig::new().init()`).
+///
+/// The policy is held in `Option<P>` because Burn's `Optimizer::step`
+/// consumes the module by value. We use `.take()` / put-back across
+/// each gradient step.
+pub struct PPOTrainerBurn<B, P, O>
+where
+    B: AutodiffBackend,
+    P: AutodiffModule<B>,
+    O: Optimizer<P, B>,
+{
+    config: PPOConfig,
+    policy: Option<P>,
+    optimizer: BurnOptimizer<B, P, O>,
+    total_steps: usize,
+    total_episodes: usize,
+    low_entropy_count: usize,
+}
+
+impl<B, P, O> PPOTrainerBurn<B, P, O>
+where
+    B: AutodiffBackend,
+    P: AutodiffModule<B> + Clone,
+    O: Optimizer<P, B>,
+{
+    /// Build a new Burn PPO trainer.
+    pub fn new(config: PPOConfig, policy: P, optimizer: BurnOptimizer<B, P, O>) -> Result<Self> {
+        config.validate()?;
+        Ok(Self {
+            config,
+            policy: Some(policy),
+            optimizer,
+            total_steps: 0,
+            total_episodes: 0,
+            low_entropy_count: 0,
+        })
+    }
+
+    /// Borrow the configuration.
+    pub fn config(&self) -> &PPOConfig {
+        &self.config
+    }
+
+    /// Borrow the policy. Panics if the trainer is mid-step (the policy
+    /// has been moved into the optimizer); only safe to call between
+    /// `train_step` invocations.
+    pub fn policy(&self) -> &P {
+        self.policy.as_ref().expect("policy is None mid-step")
+    }
+
+    /// Total completed gradient updates.
+    pub fn total_steps(&self) -> usize {
+        self.total_steps
+    }
+
+    /// Total completed episodes (caller increments).
+    pub fn total_episodes(&self) -> usize {
+        self.total_episodes
+    }
+
+    /// Increment the episode counter.
+    pub fn increment_episodes(&mut self, n: usize) {
+        self.total_episodes += n;
+    }
+
+    /// Train for one PPO update.
+    ///
+    /// Implements the same algorithm as
+    /// `PPOTrainer::train_step_with_policy` on the tch path:
+    /// 1. Normalize advantages to zero mean / unit variance.
+    /// 2. For each of `n_epochs` epochs, shuffle the buffer and iterate
+    ///    minibatches.
+    /// 3. Compute surrogate / value / entropy losses.
+    /// 4. `total_loss = policy + vf_coef * value + ent_coef * entropy`.
+    /// 5. Backprop, build `GradientsParams`, step the optimizer.
+    /// 6. KL early stop if `approx_kl > target_kl`.
+    /// 7. Entropy-collapse guard.
+    ///
+    /// The `evaluate_fn` closure receives `(&policy, obs, actions)` and
+    /// must return `(log_probs, entropy, values)` — exactly the same
+    /// shape as the policy network's `evaluate_actions` method.
+    #[allow(clippy::too_many_arguments)]
+    pub fn train_step<F>(
+        &mut self,
+        observations: Tensor<B, 2>,
+        actions: Tensor<B, 1, Int>,
+        old_log_probs: Tensor<B, 1>,
+        old_values: Tensor<B, 1>,
+        advantages: Tensor<B, 1>,
+        returns: Tensor<B, 1>,
+        mut evaluate_fn: F,
+    ) -> Result<TrainingStats>
+    where
+        F: FnMut(&P, Tensor<B, 2>, Tensor<B, 1, Int>) -> (Tensor<B, 1>, Tensor<B, 1>, Tensor<B, 1>),
+    {
+        let device = observations.device();
+        let batch_size = observations.dims()[0];
+        let mut stats_sum = TrainingStats::zeros();
+        let mut num_updates = 0;
+
+        // Advantage normalization (matches the tch trainer).
+        let adv_mean_scalar = scalar_f64(advantages.clone().mean()) as f32;
+        let adv_data: Vec<f32> = advantages.into_data().to_vec().unwrap_or_default();
+        let adv_std = host_std_biased(&adv_data, adv_mean_scalar as f64) as f32;
+        let advantages_normalized_host: Vec<f32> = adv_data
+            .iter()
+            .map(|&a| (a - adv_mean_scalar) / (adv_std + 1e-8))
+            .collect();
+
+        for _epoch in 0..self.config.n_epochs {
+            let batch_indices = generate_minibatch_indices(batch_size, self.config.batch_size);
+
+            for indices in &batch_indices {
+                let mb_obs = select_rows_2d(observations.clone(), indices, &device);
+                let mb_actions = select_rows_int(actions.clone(), indices, &device);
+                let mb_old_log_probs = select_rows_1d(old_log_probs.clone(), indices, &device);
+                let mb_old_values = select_rows_1d(old_values.clone(), indices, &device);
+                let mb_returns = select_rows_1d(returns.clone(), indices, &device);
+                let mb_adv: Vec<f32> = indices
+                    .iter()
+                    .map(|&i| advantages_normalized_host[i])
+                    .collect();
+                let mb_advantages = Tensor::<B, 1>::from_data(
+                    burn::tensor::TensorData::new(mb_adv, [indices.len()]),
+                    &device,
+                );
+
+                // Take the policy out so we can move it through `step`.
+                let policy = self
+                    .policy
+                    .take()
+                    .ok_or_else(|| anyhow!("policy is None; concurrent train_step calls?"))?;
+
+                let (log_probs, entropy, values) =
+                    evaluate_fn(&policy, mb_obs.clone(), mb_actions.clone());
+
+                let (policy_loss, clip_fraction, approx_kl) = compute_policy_loss(
+                    log_probs,
+                    mb_old_log_probs,
+                    mb_advantages,
+                    self.config.clip_range,
+                );
+
+                let (value_loss, explained_var) = compute_value_loss(
+                    values,
+                    mb_old_values,
+                    mb_returns,
+                    self.config.clip_range_vf,
+                );
+
+                let entropy_loss = compute_entropy_loss(entropy.clone());
+
+                // Scalars for stat collection.
+                let policy_loss_val = scalar_f64(policy_loss.clone());
+                let value_loss_val = scalar_f64(value_loss.clone());
+                let entropy_val = scalar_f64(entropy.mean());
+
+                // total_loss = policy_loss + vf_coef * value_loss + ent_coef * entropy_loss
+                let total_loss = policy_loss
+                    + value_loss.mul_scalar(self.config.vf_coef as f32)
+                    + entropy_loss.mul_scalar(self.config.ent_coef as f32);
+                let total_loss_val = scalar_f64(total_loss.clone());
+
+                // Burn gradient flow: backward → GradientsParams → step.
+                let grads = total_loss.backward();
+                let grads = GradientsParams::from_grads(grads, &policy);
+                let lr = self.optimizer.learning_rate();
+                let policy = self.optimizer.inner_mut().step(lr, policy, grads);
+                self.policy = Some(policy);
+
+                let step_stats = TrainingStats::new(
+                    policy_loss_val,
+                    value_loss_val,
+                    entropy_val,
+                    total_loss_val,
+                    clip_fraction,
+                    approx_kl,
+                    explained_var,
+                );
+                stats_sum.add(&step_stats);
+                num_updates += 1;
+
+                if approx_kl > self.config.target_kl {
+                    break;
+                }
+            }
+        }
+
+        self.total_steps += num_updates;
+        let avg_stats = stats_sum.average();
+
+        // Entropy-collapse guard (matches the tch trainer).
+        const ENTROPY_THRESHOLD: f64 = 0.05;
+        const MAX_LOW_ENTROPY_COUNT: usize = 3;
+        if avg_stats.entropy < ENTROPY_THRESHOLD {
+            self.low_entropy_count += 1;
+            if self.low_entropy_count >= MAX_LOW_ENTROPY_COUNT {
+                return Err(anyhow!(
+                    "Training stopped due to entropy collapse (entropy < {} for {} updates)",
+                    ENTROPY_THRESHOLD,
+                    MAX_LOW_ENTROPY_COUNT
+                ));
+            }
+        } else {
+            self.low_entropy_count = 0;
+        }
+
+        Ok(avg_stats)
+    }
+}
+
+/// Biased standard deviation (denominator `n`), matching `tch::Tensor::std(false)`.
+fn host_std_biased(xs: &[f32], mean: f64) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    let n = xs.len() as f64;
+    let sq_dev = xs.iter().map(|&x| (x as f64 - mean).powi(2)).sum::<f64>();
+    (sq_dev / n).sqrt()
+}
+
+/// Select `indices` rows from a rank-2 tensor.
+fn select_rows_2d<B: AutodiffBackend>(
+    tensor: Tensor<B, 2>,
+    indices: &[usize],
+    device: &B::Device,
+) -> Tensor<B, 2> {
+    let cols = tensor.dims()[1];
+    let host: Vec<f32> = tensor.into_data().to_vec().unwrap_or_default();
+    let mut out = Vec::with_capacity(indices.len() * cols);
+    for &i in indices {
+        let start = i * cols;
+        out.extend_from_slice(&host[start..start + cols]);
+    }
+    Tensor::<B, 2>::from_data(
+        burn::tensor::TensorData::new(out, [indices.len(), cols]),
+        device,
+    )
+}
+
+/// Select `indices` rows from a rank-1 float tensor.
+fn select_rows_1d<B: AutodiffBackend>(
+    tensor: Tensor<B, 1>,
+    indices: &[usize],
+    device: &B::Device,
+) -> Tensor<B, 1> {
+    let host: Vec<f32> = tensor.into_data().to_vec().unwrap_or_default();
+    let out: Vec<f32> = indices.iter().map(|&i| host[i]).collect();
+    Tensor::<B, 1>::from_data(
+        burn::tensor::TensorData::new(out, [indices.len()]),
+        device,
+    )
+}
+
+/// Select `indices` rows from a rank-1 int tensor.
+fn select_rows_int<B: AutodiffBackend>(
+    tensor: Tensor<B, 1, Int>,
+    indices: &[usize],
+    device: &B::Device,
+) -> Tensor<B, 1, Int> {
+    let host: Vec<i64> = tensor.into_data().to_vec().unwrap_or_default();
+    let out: Vec<i64> = indices.iter().map(|&i| host[i]).collect();
+    Tensor::<B, 1, Int>::from_data(
+        burn::tensor::TensorData::new(out, [indices.len()]),
+        device,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::{
+        backend::{Autodiff, NdArray},
+        optim::AdamConfig,
+    };
+
+    use super::*;
+    use crate::{
+        policy::mlp_burn::MlpBurnPolicy, train::optimizer::BurnOptimizer,
+    };
+
+    type B = Autodiff<NdArray<f32>>;
+
+    /// Smoke test: a Burn PPO trainer constructs and exposes the same
+    /// config back through `config()`.
+    #[test]
+    fn ppo_trainer_burn_constructs() {
+        let device = Default::default();
+        let policy = MlpBurnPolicy::<B>::new(4, 2, 32, &device);
+        let inner_opt = AdamConfig::new().init();
+        let burn_opt: BurnOptimizer<B, MlpBurnPolicy<B>, _> = BurnOptimizer::new(inner_opt, 3e-4);
+        let trainer = PPOTrainerBurn::new(PPOConfig::default(), policy, burn_opt).unwrap();
+        assert_eq!(trainer.total_steps(), 0);
+    }
+
+    /// End-to-end: a single train_step against a synthetic batch
+    /// completes without error, moves through the optimizer, and
+    /// records `num_updates > 0`.
+    #[test]
+    fn ppo_trainer_burn_train_step_runs() {
+        let device = Default::default();
+        let policy = MlpBurnPolicy::<B>::new(4, 2, 16, &device);
+        let inner_opt = AdamConfig::new().init();
+        let burn_opt: BurnOptimizer<B, MlpBurnPolicy<B>, _> = BurnOptimizer::new(inner_opt, 1e-3);
+        // Smaller batch_size so the synthetic 8-row batch produces > 1
+        // minibatch per epoch.
+        let config = PPOConfig::default().batch_size(4).n_epochs(1);
+        let mut trainer = PPOTrainerBurn::new(config, policy, burn_opt).unwrap();
+
+        let batch = 8;
+        let obs_dim = 4;
+        let mut obs_data = Vec::with_capacity(batch * obs_dim);
+        for i in 0..batch * obs_dim {
+            obs_data.push((i as f32) * 0.01);
+        }
+        let observations = Tensor::<B, 2>::from_data(
+            burn::tensor::TensorData::new(obs_data, [batch, obs_dim]),
+            &device,
+        );
+        let actions = Tensor::<B, 1, Int>::from_data(
+            burn::tensor::TensorData::new(vec![0i64, 1, 0, 1, 0, 1, 0, 1], [batch]),
+            &device,
+        );
+        let old_log_probs = Tensor::<B, 1>::from_data(
+            burn::tensor::TensorData::new(vec![-0.7f32; batch], [batch]),
+            &device,
+        );
+        let old_values = Tensor::<B, 1>::from_data(
+            burn::tensor::TensorData::new(vec![0.0f32; batch], [batch]),
+            &device,
+        );
+        let advantages = Tensor::<B, 1>::from_data(
+            burn::tensor::TensorData::new(
+                vec![1.0f32, -1.0, 0.5, -0.5, 1.0, -1.0, 0.5, -0.5],
+                [batch],
+            ),
+            &device,
+        );
+        let returns = Tensor::<B, 1>::from_data(
+            burn::tensor::TensorData::new(vec![1.0f32; batch], [batch]),
+            &device,
+        );
+
+        let stats = trainer
+            .train_step(
+                observations,
+                actions,
+                old_log_probs,
+                old_values,
+                advantages,
+                returns,
+                |p, o, a| p.evaluate_actions(o, a),
+            )
+            .unwrap();
+        assert!(trainer.total_steps() > 0);
+        // Stats should be finite.
+        assert!(stats.policy_loss.is_finite());
+        assert!(stats.value_loss.is_finite());
+    }
+}

--- a/src/train/ppo_burn/trainer.rs
+++ b/src/train/ppo_burn/trainer.rs
@@ -163,10 +163,8 @@ where
         let adv_mean_scalar = scalar_f64(advantages.clone().mean()) as f32;
         let adv_data: Vec<f32> = advantages.into_data().to_vec().unwrap_or_default();
         let adv_std = host_std_biased(&adv_data, adv_mean_scalar as f64) as f32;
-        let advantages_normalized_host: Vec<f32> = adv_data
-            .iter()
-            .map(|&a| (a - adv_mean_scalar) / (adv_std + 1e-8))
-            .collect();
+        let advantages_normalized_host: Vec<f32> =
+            adv_data.iter().map(|&a| (a - adv_mean_scalar) / (adv_std + 1e-8)).collect();
 
         for _epoch in 0..self.config.n_epochs {
             let batch_indices = generate_minibatch_indices(batch_size, self.config.batch_size);
@@ -177,10 +175,8 @@ where
                 let mb_old_log_probs = select_rows_1d(old_log_probs.clone(), indices, &device);
                 let mb_old_values = select_rows_1d(old_values.clone(), indices, &device);
                 let mb_returns = select_rows_1d(returns.clone(), indices, &device);
-                let mb_adv: Vec<f32> = indices
-                    .iter()
-                    .map(|&i| advantages_normalized_host[i])
-                    .collect();
+                let mb_adv: Vec<f32> =
+                    indices.iter().map(|&i| advantages_normalized_host[i]).collect();
                 let mb_advantages = Tensor::<B, 1>::from_data(
                     burn::tensor::TensorData::new(mb_adv, [indices.len()]),
                     &device,
@@ -270,7 +266,8 @@ where
     }
 }
 
-/// Biased standard deviation (denominator `n`), matching `tch::Tensor::std(false)`.
+/// Biased standard deviation (denominator `n`), matching
+/// `tch::Tensor::std(false)`.
 fn host_std_biased(xs: &[f32], mean: f64) -> f64 {
     if xs.is_empty() {
         return 0.0;
@@ -293,10 +290,7 @@ fn select_rows_2d<B: AutodiffBackend>(
         let start = i * cols;
         out.extend_from_slice(&host[start..start + cols]);
     }
-    Tensor::<B, 2>::from_data(
-        burn::tensor::TensorData::new(out, [indices.len(), cols]),
-        device,
-    )
+    Tensor::<B, 2>::from_data(burn::tensor::TensorData::new(out, [indices.len(), cols]), device)
 }
 
 /// Select `indices` rows from a rank-1 float tensor.
@@ -307,10 +301,7 @@ fn select_rows_1d<B: AutodiffBackend>(
 ) -> Tensor<B, 1> {
     let host: Vec<f32> = tensor.into_data().to_vec().unwrap_or_default();
     let out: Vec<f32> = indices.iter().map(|&i| host[i]).collect();
-    Tensor::<B, 1>::from_data(
-        burn::tensor::TensorData::new(out, [indices.len()]),
-        device,
-    )
+    Tensor::<B, 1>::from_data(burn::tensor::TensorData::new(out, [indices.len()]), device)
 }
 
 /// Select `indices` rows from a rank-1 int tensor.
@@ -321,10 +312,7 @@ fn select_rows_int<B: AutodiffBackend>(
 ) -> Tensor<B, 1, Int> {
     let host: Vec<i64> = tensor.into_data().to_vec().unwrap_or_default();
     let out: Vec<i64> = indices.iter().map(|&i| host[i]).collect();
-    Tensor::<B, 1, Int>::from_data(
-        burn::tensor::TensorData::new(out, [indices.len()]),
-        device,
-    )
+    Tensor::<B, 1, Int>::from_data(burn::tensor::TensorData::new(out, [indices.len()]), device)
 }
 
 #[cfg(test)]
@@ -335,9 +323,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::{
-        policy::mlp_burn::MlpBurnPolicy, train::optimizer::BurnOptimizer,
-    };
+    use crate::{policy::mlp_burn::MlpBurnPolicy, train::optimizer::BurnOptimizer};
 
     type B = Autodiff<NdArray<f32>>;
 


### PR DESCRIPTION
## Summary

Phase 3 of the Burn migration epic (#65). Ports the PPO and DQN algorithm bodies (loss math + train step) to compile under both backends (tch and Burn), sitting on top of phase 2b's `BackendOptimizer` trait abstraction. The tch path is left byte-equivalent to before this PR; phase 5 (#82) is the deletion phase.

Closes #80.

## What is new

### New ppo_burn and dqn_burn modules

Parallel-sibling pattern (same shape as `policy::mlp` / `policy::mlp_burn` from phase 1):

- `src/train/ppo_burn/loss.rs` -- backend-generic `compute_policy_loss`, `compute_value_loss`, `compute_entropy_loss`.
- `src/train/ppo_burn/trainer.rs` -- `PPOTrainerBurn<B, P, O>` that holds the policy through Burn's optimizer-consumes-module ownership model (`policy: Option<P>`, swapped via `.take()` -> `step` -> put-back).
- `src/train/dqn_burn/loss.rs` -- `compute_td_target`, `compute_td_target_double`, `gather_action_q`, `compute_loss` (Smooth-L1), plus `huber_per_sample` for the eventual PER path. `tch::no_grad(...)` blocks become `Tensor::detach()` calls.
- `src/train/dqn_burn/trainer.rs` -- `DQNTrainerBurn<B, Q, O>` with Double-DQN target, hard / soft (Polyak) target sync. Prioritized replay is deferred; constructor rejects `prioritized_replay = true` with a clear error.

### Backend-agnostic refactors

- `src/train/ppo.rs` / `src/train/dqn.rs`: hoist `PPOConfig`, `DQNConfig`, `TrainingStats`, `AggregatedStats`, `generate_minibatch_indices` out from under the `feature = "training"` gate so the Burn trainer can share them.
- `src/multi_agent/messages.rs`: `Experience::{observation, next_observation}` move from `tch::Tensor` to `Vec<f32>` host buffers. The simulator and learner already do the host<->tch conversion at the boundary; phase 3 inlines that and removes the redundant round-trip. No behavioral change -- message protocol is now backend-agnostic.

### Numerical parity tests

`src/train/parity_tests.rs` -- 8 tests that pin tch <-> Burn agreement at 1e-4 absolute tolerance (DoD on issue #80):

- `parity_ppo_policy_loss` -- surrogate loss + clip fraction + approx KL
- `parity_ppo_value_loss_with_clip` -- pessimistic clipped MSE
- `parity_ppo_value_loss_infinite_clip` -- short-circuit to plain MSE
- `parity_ppo_entropy_loss` -- `-mean(entropy)`
- `parity_dqn_td_target` -- vanilla `r + gamma(1-done) max Q`
- `parity_dqn_td_target_double` -- Double-DQN with online argmax
- `parity_dqn_gather_action_q` -- `[batch, n] -> [batch]` gather
- `parity_dqn_compute_loss` -- Smooth-L1 / Huber mean

These run only when both features are enabled (`cargo test --features training,training-burn`).

## Acceptance criteria mapping

- [x] `cargo build --features training` succeeds; all existing tests pass (219/219 lib + integration).
- [x] `cargo build --no-default-features --features training-burn` succeeds (164/164 lib tests).
- [x] Loss math unit tests duplicated to run against both backends with 1e-4 absolute tolerance.
- [x] No new `unsafe`.
- [ ] Deferred -- Burn DQN end-to-end CartPole parity over 3 seeds is gated on phase 4's `QNetworkBurn` port. `MlpBurnPolicy` is a stand-in that exercises the trainer plumbing but its Kaiming init does not match the tch baseline's orthogonal init; chasing parity now would be misleading. Punted to the phase-4 PR.

## Size

LOC delta (not counting tests): ~1163 production LOC. Over the original 800-LOC target due to the trainer scaffolding plus the loss-math + parity-tests fence post. Splitting into 3a/3b was considered but rejected: the two trainers share the ownership-model rewrite and parity-tests boilerplate, so a 3a/3b split would have duplicated more than it saved.

## Test plan

- [x] `cargo build --features training` (libtorch via venv)
- [x] `cargo build --no-default-features --features training-burn`
- [x] `cargo build --features training,training-burn`
- [x] `cargo test --features training --lib` -> 219/219 passed
- [x] `cargo test --no-default-features --features training-burn --lib` -> 164/164 passed
- [x] `cargo test --features training,training-burn --lib` -> 253/253 passed (incl. 8 parity tests)
- [x] `cargo test --features training --tests` -> all integration tests pass

Generated with [Claude Code](https://claude.com/claude-code)