### PR TITLE
Burn migration phase 4: port four policy networks to Burn Module

### DIFF
--- a/src/policy/mlp_burn.rs
+++ b/src/policy/mlp_burn.rs
@@ -1,62 +1,215 @@
-//! Minimal MLP actor-critic policy implemented over the Burn 0.21 tensor
-//! framework.
+//! Burn-backend MLP actor-critic policy (phase 4 of the Burn migration, #65).
 //!
-//! # Scope
+//! Sibling to [`crate::policy::mlp::MlpPolicy`] (tch path). The two
+//! modules implement the same 2/3-layer MLP actor-critic architecture
+//! with orthogonal initialization (PPO recipe — gain `sqrt(2)` on the
+//! trunk, `0.01` on the output heads); the only difference is the
+//! tensor framework.
 //!
-//! This module is **scoped to the phase-1 Burn migration scout** (issue #78).
-//! It is intentionally not feature-complete: it provides only the surface area
-//! the bandit trainer needs (forward pass returning `(logits, value)`, action
-//! sampling, action evaluation). It is **not** intended to be the production
-//! design — that work lands in later phases of the migration epic (#65).
+//! # History
 //!
-//! Compared to [`crate::policy::mlp::MlpPolicy`] (tch path), the salient
-//! differences are documented in `docs/BURN_MIGRATION_PHASE1_REPORT.md`.
+//! - **Phase 1 (#78)**: scout port covered only what the
+//!   `train_simple_bandit_burn` example needed (random Kaiming init, 2 layers,
+//!   no `MlpConfig`-style surface). That entry point is preserved as
+//!   [`MlpBurnPolicy::new`] for backward compatibility with the scout binary
+//!   and the parity tests already wired up against it.
+//! - **Phase 4 (#81)**: this module — productionizes the scout. Adds
+//!   [`MlpBurnConfig`] (mirroring `MlpConfig` on the tch path) with orthogonal
+//!   init / activation / depth knobs, a 3-layer variant, and the encoder-tap
+//!   helper the multi-agent regularizers want.
 //!
 //! # Why generic over `B: Backend`?
 //!
-//! Burn's idiomatic pattern is to make every `Module` generic over a `Backend`
-//! type parameter (CPU `NdArray`, GPU `Wgpu`/`Cuda`, autodiff-decorated
-//! variants, etc.). This mirrors `geode-fem`'s pattern. The bandit trainer
-//! picks `NdArray<f32>` wrapped in `Autodiff` at the top level.
+//! Burn's idiomatic pattern is to make every `Module` generic over a
+//! `Backend` type parameter (CPU `NdArray`, GPU `Wgpu`/`Cuda`,
+//! autodiff-decorated variants, etc.). The bandit scout picks
+//! `Autodiff<NdArray<f32>>` at the top level; production trainers can
+//! re-use the same modules with a different backend at the top of the
+//! binary without touching the policy code.
 
 use burn::{
-    module::Module,
-    nn::{Linear, LinearConfig},
+    module::{Module, Param},
+    nn::{Initializer, Linear, LinearConfig},
     tensor::{Int, Tensor, activation, backend::Backend},
 };
 
-/// Two-layer MLP actor-critic for **discrete** action spaces, ported to Burn.
+/// Build a [`Linear`] layer with an explicit weight initializer and a
+/// zeroed bias.
 ///
-/// Layout matches [`crate::policy::mlp::MlpPolicy`] at a high level:
+/// Burn's `LinearConfig::with_initializer` applies the same initializer
+/// to both the weight and the bias, but [`Initializer::Orthogonal`]
+/// requires a rank-≥2 tensor and panics on the 1D bias. The PPO recipe
+/// (mirrored on the tch path) initializes biases to zero anyway, so the
+/// idiomatic Burn analogue is "Orthogonal on the weight, zero on the
+/// bias". This helper packages that two-step setup.
+///
+/// Re-used by [`MlpBurnPolicy`],
+/// [`crate::policy::multi_discrete_mlp_burn::MultiDiscreteMlpBurnPolicy`],
+/// [`crate::policy::q_network_burn::QNetworkBurn`], and
+/// [`crate::policy::snake_cnn_burn::SnakeCnnBurnPolicy`].
+pub(crate) fn linear_with_init<B: Backend>(
+    d_input: usize,
+    d_output: usize,
+    initializer: Initializer,
+    device: &B::Device,
+) -> Linear<B> {
+    // Build a 2D weight Param via the initializer, and a 1D zero bias
+    // Param via Param::from_tensor. `LinearConfig::with_initializer`
+    // can't help here because it applies the same initializer to both
+    // weight and bias, and `Initializer::Orthogonal` panics on the
+    // rank-1 bias tensor (it requires `D >= 2`).
+    let weight: Param<Tensor<B, 2>> = initializer.init_with::<B, 2, _>(
+        [d_input, d_output],
+        Some(d_input),
+        Some(d_output),
+        device,
+    );
+    let bias_tensor = Tensor::<B, 1>::zeros([d_output], device);
+    Linear::<B> { weight, bias: Some(Param::from_tensor(bias_tensor)) }
+}
+
+/// Activation function applied between hidden layers in
+/// [`MlpBurnPolicy`] (and its multi-discrete sibling).
+///
+/// Mirrors [`crate::policy::mlp::Activation`] on the tch path; the two
+/// enums are deliberately separate so the Burn module does not pull in
+/// `tch` types under `--features training-burn` alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BurnActivation {
+    /// Rectified linear unit (`max(0, x)`).
+    ReLU,
+    /// Hyperbolic tangent (`tanh(x)`).
+    Tanh,
+}
+
+/// Configuration for [`MlpBurnPolicy`] architecture.
+///
+/// Mirrors [`crate::policy::mlp::MlpConfig`] on the tch path. Stored
+/// inside the policy so the parity tests can compare both backends on
+/// identical hyperparameters.
+#[derive(Debug, Clone, Copy)]
+pub struct MlpBurnConfig {
+    /// Number of hidden layers in the shared trunk. Only `2` or `3` are
+    /// supported; anything else is treated as `2`.
+    pub num_layers: usize,
+    /// Width of every hidden layer.
+    pub hidden_dim: usize,
+    /// If `true`, initialize hidden-layer weights with
+    /// [`Initializer::Orthogonal`] (gain `sqrt(2)`) and output heads
+    /// with `Initializer::Orthogonal { gain = 0.01 }`. Set `false` to
+    /// fall back to Burn's default Kaiming-uniform init.
+    pub use_orthogonal_init: bool,
+    /// Activation applied between hidden layers.
+    pub activation: BurnActivation,
+}
+
+impl Default for MlpBurnConfig {
+    fn default() -> Self {
+        Self {
+            num_layers: 2,
+            hidden_dim: 64,
+            use_orthogonal_init: true,
+            activation: BurnActivation::Tanh,
+        }
+    }
+}
+
+/// Two- or three-layer MLP actor-critic for **discrete** action spaces,
+/// ported to Burn.
+///
+/// Layout mirrors [`crate::policy::mlp::MlpPolicy`] at a high level:
 ///
 /// ```text
-/// obs ──► fc1 ─tanh─► fc2 ─tanh─► policy_head (logits over n actions)
-///                              └─► value_head  (scalar V(s))
+/// obs → fc1 →act→ fc2 →act→ (fc3 →act→)? policy_head (logits)
+///                                       └─ value_head  (V(s))
 /// ```
 ///
-/// The two heads share the trunk activations, which is the standard PPO
-/// actor-critic recipe. `hidden_dim` is the width of both hidden layers.
+/// Both heads share the trunk activations — standard PPO actor-critic.
+///
+/// # Numerical parity
+///
+/// When constructed with `use_orthogonal_init = true` (the default), the
+/// trunk uses [`Initializer::Orthogonal { gain: sqrt(2) }`] and the
+/// output heads use `gain = 0.01`. These match the tch policy's init
+/// gains exactly (see [`crate::policy::mlp::MlpPolicy::with_config`]),
+/// which is the necessary precondition for the phase-4 numerical-parity
+/// check called out on issue #81.
 #[derive(Module, Debug)]
 pub struct MlpBurnPolicy<B: Backend> {
     fc1: Linear<B>,
     fc2: Linear<B>,
+    fc3: Option<Linear<B>>,
     policy_head: Linear<B>,
     value_head: Linear<B>,
+    activation: BurnActivation,
 }
 
 impl<B: Backend> MlpBurnPolicy<B> {
-    /// Build a fresh policy on `device` with the given dims.
+    /// Backward-compatible 2-layer constructor (the phase 1 scout
+    /// signature). Uses Burn's default Kaiming-uniform init — kept so
+    /// the existing bandit trainer and parity tests are not perturbed.
     ///
-    /// Burn's default `LinearConfig` initializes weights with a Kaiming-uniform
-    /// scheme — adequate for the bandit smoke test; the orthogonal init the
-    /// tch policy uses is a known follow-up (documented in the friction
-    /// report).
+    /// New call sites that want PPO-style orthogonal init should call
+    /// [`MlpBurnPolicy::with_config`] instead.
     pub fn new(obs_dim: usize, action_dim: usize, hidden_dim: usize, device: &B::Device) -> Self {
-        Self {
-            fc1: LinearConfig::new(obs_dim, hidden_dim).init(device),
-            fc2: LinearConfig::new(hidden_dim, hidden_dim).init(device),
-            policy_head: LinearConfig::new(hidden_dim, action_dim).init(device),
-            value_head: LinearConfig::new(hidden_dim, 1).init(device),
+        let config = MlpBurnConfig {
+            num_layers: 2,
+            hidden_dim,
+            // Preserve scout behavior — the phase 1 scout used the
+            // default LinearConfig init (Kaiming uniform), not the
+            // PPO orthogonal recipe.
+            use_orthogonal_init: false,
+            activation: BurnActivation::Tanh,
+        };
+        Self::with_config(obs_dim, action_dim, config, device)
+    }
+
+    /// Build a fresh policy on `device` with the given configuration.
+    ///
+    /// This is the production constructor for phase 4 onwards. Mirrors
+    /// [`crate::policy::mlp::MlpPolicy::with_config`].
+    pub fn with_config(
+        obs_dim: usize,
+        action_dim: usize,
+        config: MlpBurnConfig,
+        device: &B::Device,
+    ) -> Self {
+        let hidden_init = if config.use_orthogonal_init {
+            Initializer::Orthogonal { gain: 2.0_f64.sqrt() }
+        } else {
+            // Burn's default — see LinearConfig docs.
+            Initializer::KaimingUniform { gain: 1.0_f64 / 3.0_f64.sqrt(), fan_out_only: false }
+        };
+        let output_init = if config.use_orthogonal_init {
+            Initializer::Orthogonal { gain: 0.01 }
+        } else {
+            Initializer::KaimingUniform { gain: 1.0_f64 / 3.0_f64.sqrt(), fan_out_only: false }
+        };
+
+        let fc1 = linear_with_init::<B>(obs_dim, config.hidden_dim, hidden_init.clone(), device);
+        let fc2 = linear_with_init::<B>(
+            config.hidden_dim,
+            config.hidden_dim,
+            hidden_init.clone(),
+            device,
+        );
+        let fc3 = if config.num_layers >= 3 {
+            Some(linear_with_init::<B>(config.hidden_dim, config.hidden_dim, hidden_init, device))
+        } else {
+            None
+        };
+
+        let policy_head =
+            linear_with_init::<B>(config.hidden_dim, action_dim, output_init.clone(), device);
+        let value_head = linear_with_init::<B>(config.hidden_dim, 1, output_init, device);
+
+        Self { fc1, fc2, fc3, policy_head, value_head, activation: config.activation }
+    }
+
+    fn apply_activation<const D: usize>(&self, x: Tensor<B, D>) -> Tensor<B, D> {
+        match self.activation {
+            BurnActivation::ReLU => activation::relu(x),
+            BurnActivation::Tanh => activation::tanh(x),
         }
     }
 
@@ -66,24 +219,39 @@ impl<B: Backend> MlpBurnPolicy<B> {
     /// * `logits` is shape `[batch, action_dim]` (pre-softmax).
     /// * `value` is shape `[batch]` (squeezed from `[batch, 1]`).
     pub fn forward(&self, obs: Tensor<B, 2>) -> (Tensor<B, 2>, Tensor<B, 1>) {
-        let h = activation::tanh(self.fc1.forward(obs));
-        let h = activation::tanh(self.fc2.forward(h));
+        let h = self.encoder_features(obs);
         let logits = self.policy_head.forward(h.clone());
         let value = self.value_head.forward(h).squeeze_dim::<1>(1);
         (logits, value)
     }
 
-    /// Sample one action per row from the policy's categorical distribution
-    /// and return `(actions_host, log_probs_host, values_host)` as plain
-    /// `Vec`s.
+    /// Compute the shared-trunk feature representation for `obs`.
     ///
-    /// The trainer-side rollout loop does not need gradient flow through the
-    /// sampled action (only the eventual `evaluate_actions` call on the
-    /// stored transitions matters for the PPO surrogate). We therefore do
-    /// the categorical draw on the host with `rand`, which sidesteps Burn
-    /// 0.21's lack of a first-class `multinomial` op — documented in the
-    /// friction report as a real gap for any port that needs on-device
-    /// sampling (Snake CNN, multi-agent self-play).
+    /// Mirrors [`crate::policy::mlp::MlpPolicy::encoder_features`] —
+    /// auxiliary regularizers (cross-agent redundancy penalties,
+    /// behavioural-diversity bonuses) tap this directly.
+    ///
+    /// Gradients flow back into the trunk.
+    pub fn encoder_features(&self, obs: Tensor<B, 2>) -> Tensor<B, 2> {
+        let h = self.apply_activation(self.fc1.forward(obs));
+        let h = self.apply_activation(self.fc2.forward(h));
+        if let Some(fc3) = &self.fc3 {
+            self.apply_activation(fc3.forward(h))
+        } else {
+            h
+        }
+    }
+
+    /// Sample one action per row from the policy's categorical
+    /// distribution and return `(actions_host, log_probs_host,
+    /// values_host)` as plain `Vec`s.
+    ///
+    /// The trainer-side rollout loop does not need gradient flow
+    /// through the sampled action (only the eventual
+    /// [`MlpBurnPolicy::evaluate_actions`] call on the stored
+    /// transitions matters for the PPO surrogate). We therefore do the
+    /// categorical draw on the host with `rand`, sidestepping Burn
+    /// 0.21's lack of a first-class `multinomial` op.
     pub fn get_action_host(&self, obs: Tensor<B, 2>) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
         use rand::Rng;
         let (logits, value) = self.forward(obs);
@@ -121,9 +289,13 @@ impl<B: Backend> MlpBurnPolicy<B> {
 
     /// Evaluate a batch of `(obs, actions)` pairs.
     ///
-    /// Returns `(action_log_probs, entropy_per_row, values)` — the quantities
-    /// the PPO surrogate loss needs. Entropy is per-row here (not the mean):
-    /// the caller decides how to aggregate.
+    /// Returns `(action_log_probs, entropy_per_row, values)` — the
+    /// quantities the PPO surrogate loss needs. Entropy is per-row here
+    /// (not the mean): the caller decides how to aggregate. This
+    /// matches the tch policy's contract (the tch
+    /// `evaluate_actions` returns a scalar mean; the trainer reduces
+    /// per-row entropy on the Burn path inside
+    /// [`crate::train::ppo_burn::trainer::PPOTrainerBurn::train_step`]).
     pub fn evaluate_actions(
         &self,
         obs: Tensor<B, 2>,
@@ -139,5 +311,87 @@ impl<B: Backend> MlpBurnPolicy<B> {
         let entropy = -(probs * log_probs).sum_dim(1).squeeze_dim::<1>(1);
 
         (action_log_probs, entropy, value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::backend::{Autodiff, NdArray};
+
+    use super::*;
+
+    type B = Autodiff<NdArray<f32>>;
+
+    #[test]
+    fn test_policy_creation_default() {
+        let device = Default::default();
+        let _policy = MlpBurnPolicy::<B>::new(4, 2, 64, &device);
+    }
+
+    #[test]
+    fn test_with_config_two_layer() {
+        let device = Default::default();
+        let cfg = MlpBurnConfig::default();
+        let policy = MlpBurnPolicy::<B>::with_config(4, 2, cfg, &device);
+        assert!(policy.fc3.is_none());
+    }
+
+    #[test]
+    fn test_with_config_three_layer() {
+        let device = Default::default();
+        let cfg = MlpBurnConfig { num_layers: 3, ..Default::default() };
+        let policy = MlpBurnPolicy::<B>::with_config(4, 2, cfg, &device);
+        assert!(policy.fc3.is_some());
+    }
+
+    #[test]
+    fn test_forward_pass_two_layer() {
+        let device = Default::default();
+        let cfg = MlpBurnConfig::default();
+        let policy = MlpBurnPolicy::<B>::with_config(4, 2, cfg, &device);
+        let obs = Tensor::<B, 2>::zeros([8, 4], &device);
+        let (logits, values) = policy.forward(obs);
+        assert_eq!(logits.dims(), [8, 2]);
+        assert_eq!(values.dims(), [8]);
+    }
+
+    #[test]
+    fn test_forward_pass_three_layer() {
+        let device = Default::default();
+        let cfg = MlpBurnConfig { num_layers: 3, ..Default::default() };
+        let policy = MlpBurnPolicy::<B>::with_config(4, 2, cfg, &device);
+        let obs = Tensor::<B, 2>::zeros([8, 4], &device);
+        let (logits, values) = policy.forward(obs);
+        assert_eq!(logits.dims(), [8, 2]);
+        assert_eq!(values.dims(), [8]);
+    }
+
+    #[test]
+    fn test_evaluate_actions_shapes() {
+        let device = Default::default();
+        let policy = MlpBurnPolicy::<B>::with_config(4, 2, MlpBurnConfig::default(), &device);
+        let obs = Tensor::<B, 2>::zeros([8, 4], &device);
+        let actions = Tensor::<B, 1, Int>::from_data(
+            burn::tensor::TensorData::new(vec![0i64, 1, 0, 1, 0, 1, 0, 1], [8]),
+            &device,
+        );
+        let (log_probs, entropy, values) = policy.evaluate_actions(obs, actions);
+        assert_eq!(log_probs.dims(), [8]);
+        assert_eq!(entropy.dims(), [8]);
+        assert_eq!(values.dims(), [8]);
+    }
+
+    #[test]
+    fn test_relu_activation_branch() {
+        let device = Default::default();
+        let cfg = MlpBurnConfig {
+            activation: BurnActivation::ReLU,
+            use_orthogonal_init: false,
+            ..Default::default()
+        };
+        let policy = MlpBurnPolicy::<B>::with_config(4, 2, cfg, &device);
+        let obs = Tensor::<B, 2>::zeros([2, 4], &device);
+        let (logits, _values) = policy.forward(obs);
+        assert_eq!(logits.dims(), [2, 2]);
     }
 }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -22,7 +22,28 @@ pub mod snake_cnn;
 pub use q_network::QNetwork;
 
 // Burn-backend MLP policy — scout for issue #78 / phase 1 of the
-// Burn migration. Deliberately minimal (only what the bandit trainer
-// needs) and decoupled from the tch `MlpPolicy`; both can coexist.
+// Burn migration. Phase 4 (#81) productionized this to mirror the full
+// `MlpPolicy` surface (orthogonal init, 2/3-layer, encoder tap), and
+// added the sibling modules below for the other three policy networks
+// the training stack uses. The tch and Burn variants coexist until
+// phase 5 (#82) deletes the tch path.
 #[cfg(feature = "training-burn")]
 pub mod mlp_burn;
+
+/// Burn-backend multi-discrete MLP — phase 4 sibling of
+/// [`multi_discrete_mlp`]. Used by environments like Bucket Brigade
+/// and Snake/Pong's multi-discrete heads.
+#[cfg(feature = "training-burn")]
+pub mod multi_discrete_mlp_burn;
+
+/// Burn-backend Snake CNN — phase 4 sibling of [`snake_cnn`]. Same
+/// 3-conv + 2-fc topology.
+#[cfg(feature = "training-burn")]
+pub mod snake_cnn_burn;
+
+/// Burn-backend Q-Network — phase 4 sibling of [`q_network`]. Same
+/// MLP backbone as `MlpPolicy` but with a single Q-head (no value
+/// head); DQN target-net sync uses Burn's record-based clone instead
+/// of `VarStore::copy`.
+#[cfg(feature = "training-burn")]
+pub mod q_network_burn;

--- a/src/policy/multi_discrete_mlp_burn.rs
+++ b/src/policy/multi_discrete_mlp_burn.rs
@@ -1,0 +1,249 @@
+//! Burn-backend multi-discrete actor-critic MLP for factored action
+//! spaces (phase 4 of the Burn migration, #65).
+//!
+//! Sibling to [`crate::policy::multi_discrete_mlp::MultiDiscreteMlpPolicy`]
+//! (tch path). The two modules implement the same shared-trunk +
+//! per-dim head architecture; the only difference is the tensor
+//! framework. Used by environments like Bucket Brigade and the
+//! multi-agent self-play paths that need a factored
+//! `[house_index, mode]` action.
+//!
+//! # Why a separate sibling instead of generalizing the tch version
+//!
+//! Same rationale as `mlp_burn.rs` — see the module-level doc in
+//! `src/train/ppo_burn.rs`. The two backends have different generic
+//! parameters (`<B: Backend>` for Burn vs no generic for tch + a
+//! `VarStore` field), and phase 5 (#82) collapses the two when the
+//! tch path is dropped.
+
+use burn::{
+    module::Module,
+    nn::{Initializer, Linear},
+    tensor::{Int, Tensor, activation, backend::Backend},
+};
+
+use super::mlp_burn::{BurnActivation, MlpBurnConfig, linear_with_init};
+
+/// Multi-discrete MLP actor-critic policy on Burn.
+///
+/// Mirrors [`crate::policy::multi_discrete_mlp::MultiDiscreteMlpPolicy`]:
+/// shared trunk built from the same [`MlpBurnConfig`] knobs the
+/// single-action [`crate::policy::mlp_burn::MlpBurnPolicy`] consumes,
+/// plus one [`Linear`] action head per dimension. Per-step log-probs
+/// are summed across dims (treating the dims as conditionally
+/// independent given the state), and per-step entropies are averaged
+/// — the same convention as the tch path so the parity tests can
+/// compare both implementations on identical inputs.
+#[derive(Module, Debug)]
+pub struct MultiDiscreteMlpBurnPolicy<B: Backend> {
+    fc1: Linear<B>,
+    fc2: Linear<B>,
+    fc3: Option<Linear<B>>,
+    action_heads: Vec<Linear<B>>,
+    value_head: Linear<B>,
+    activation: BurnActivation,
+}
+
+impl<B: Backend> MultiDiscreteMlpBurnPolicy<B> {
+    /// Build a fresh multi-discrete policy with the default 2-layer
+    /// architecture (mirrors
+    /// [`crate::policy::multi_discrete_mlp::MultiDiscreteMlpPolicy::new`]).
+    pub fn new(
+        obs_dim: usize,
+        action_dims: Vec<usize>,
+        hidden_dim: usize,
+        device: &B::Device,
+    ) -> Self {
+        let config = MlpBurnConfig { hidden_dim, ..Default::default() };
+        Self::with_config(obs_dim, action_dims, config, device)
+    }
+
+    /// Build a fresh multi-discrete policy with custom configuration.
+    pub fn with_config(
+        obs_dim: usize,
+        action_dims: Vec<usize>,
+        config: MlpBurnConfig,
+        device: &B::Device,
+    ) -> Self {
+        assert!(!action_dims.is_empty(), "action_dims must have at least one element");
+        for (i, d) in action_dims.iter().enumerate() {
+            assert!(*d >= 1, "action_dims[{i}] = {d}; must be >= 1");
+        }
+
+        let hidden_init = if config.use_orthogonal_init {
+            Initializer::Orthogonal { gain: 2.0_f64.sqrt() }
+        } else {
+            Initializer::KaimingUniform { gain: 1.0_f64 / 3.0_f64.sqrt(), fan_out_only: false }
+        };
+        let output_init = if config.use_orthogonal_init {
+            Initializer::Orthogonal { gain: 0.01 }
+        } else {
+            Initializer::KaimingUniform { gain: 1.0_f64 / 3.0_f64.sqrt(), fan_out_only: false }
+        };
+
+        let fc1 = linear_with_init::<B>(obs_dim, config.hidden_dim, hidden_init.clone(), device);
+        let fc2 = linear_with_init::<B>(
+            config.hidden_dim,
+            config.hidden_dim,
+            hidden_init.clone(),
+            device,
+        );
+        let fc3 = if config.num_layers >= 3 {
+            Some(linear_with_init::<B>(config.hidden_dim, config.hidden_dim, hidden_init, device))
+        } else {
+            None
+        };
+
+        let action_heads: Vec<Linear<B>> = action_dims
+            .iter()
+            .map(|&dim| linear_with_init::<B>(config.hidden_dim, dim, output_init.clone(), device))
+            .collect();
+        let value_head = linear_with_init::<B>(config.hidden_dim, 1, output_init, device);
+
+        Self { fc1, fc2, fc3, action_heads, value_head, activation: config.activation }
+    }
+
+    fn apply_activation<const D: usize>(&self, x: Tensor<B, D>) -> Tensor<B, D> {
+        match self.activation {
+            BurnActivation::ReLU => activation::relu(x),
+            BurnActivation::Tanh => activation::tanh(x),
+        }
+    }
+
+    /// Shared-trunk features (mirrors
+    /// [`crate::policy::multi_discrete_mlp::MultiDiscreteMlpPolicy::encoder_features`]).
+    pub fn encoder_features(&self, obs: Tensor<B, 2>) -> Tensor<B, 2> {
+        let h = self.apply_activation(self.fc1.forward(obs));
+        let h = self.apply_activation(self.fc2.forward(h));
+        if let Some(fc3) = &self.fc3 {
+            self.apply_activation(fc3.forward(h))
+        } else {
+            h
+        }
+    }
+
+    /// Forward pass: per-dim action logits plus value estimate.
+    ///
+    /// Returns `(Vec<logits_i>, value)` where
+    /// `logits_i: [batch, action_dims[i]]` and `value: [batch]`.
+    pub fn forward(&self, obs: Tensor<B, 2>) -> (Vec<Tensor<B, 2>>, Tensor<B, 1>) {
+        let features = self.encoder_features(obs);
+        let logits: Vec<Tensor<B, 2>> =
+            self.action_heads.iter().map(|h| h.forward(features.clone())).collect();
+        let value = self.value_head.forward(features).squeeze_dim::<1>(1);
+        (logits, value)
+    }
+
+    /// Number of action dimensions (heads).
+    pub fn num_action_dims(&self) -> usize {
+        self.action_heads.len()
+    }
+
+    /// Evaluate given actions: per-step summed log-prob, per-step mean
+    /// entropy (across dims), and value.
+    ///
+    /// # Arguments
+    /// * `obs`     - `[batch, obs_dim]`
+    /// * `actions` - `[batch, num_dims]` int (one action per dim per row)
+    ///
+    /// # Returns
+    /// `(log_probs [batch], entropy [batch], values [batch])`.
+    /// `log_probs` is summed across dims; `entropy` is averaged across
+    /// dims (matching the tch convention so parity holds).
+    pub fn evaluate_actions(
+        &self,
+        obs: Tensor<B, 2>,
+        actions: Tensor<B, 2, Int>,
+    ) -> (Tensor<B, 1>, Tensor<B, 1>, Tensor<B, 1>) {
+        let (logits_per_dim, value) = self.forward(obs);
+
+        let num_dims = logits_per_dim.len();
+        assert!(num_dims > 0, "logits_per_dim must be non-empty");
+
+        let mut summed_log_probs: Option<Tensor<B, 1>> = None;
+        let mut summed_entropy: Option<Tensor<B, 1>> = None;
+
+        for (i, logits) in logits_per_dim.into_iter().enumerate() {
+            let log_probs = activation::log_softmax(logits, 1);
+            let probs = log_probs.clone().exp();
+            let per_dim_entropy: Tensor<B, 1> =
+                -(probs * log_probs.clone()).sum_dim(1).squeeze_dim::<1>(1);
+
+            // actions[:, i] as [batch, 1] int then gather → [batch]
+            let actions_i: Tensor<B, 1, Int> =
+                actions.clone().slice([0..actions.dims()[0], i..i + 1]).squeeze_dim::<1>(1);
+            let per_dim_log_p: Tensor<B, 1> =
+                log_probs.gather(1, actions_i.unsqueeze_dim::<2>(1)).squeeze_dim::<1>(1);
+
+            summed_log_probs = Some(match summed_log_probs.take() {
+                Some(acc) => acc + per_dim_log_p,
+                None => per_dim_log_p,
+            });
+            summed_entropy = Some(match summed_entropy.take() {
+                Some(acc) => acc + per_dim_entropy,
+                None => per_dim_entropy,
+            });
+        }
+
+        let log_probs = summed_log_probs.expect("at least one dim");
+        // Mean entropy across dims (matches the tch trainer convention).
+        let entropy = summed_entropy.expect("at least one dim").div_scalar(num_dims as f32);
+
+        (log_probs, entropy, value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::backend::{Autodiff, NdArray};
+
+    use super::*;
+
+    type B = Autodiff<NdArray<f32>>;
+
+    #[test]
+    fn test_creation_default() {
+        let device = Default::default();
+        let _policy = MultiDiscreteMlpBurnPolicy::<B>::new(4, vec![10, 2], 32, &device);
+    }
+
+    #[test]
+    fn test_forward_shapes() {
+        let device = Default::default();
+        let policy = MultiDiscreteMlpBurnPolicy::<B>::with_config(
+            4,
+            vec![10, 2],
+            MlpBurnConfig::default(),
+            &device,
+        );
+        let obs = Tensor::<B, 2>::zeros([3, 4], &device);
+        let (logits, value) = policy.forward(obs);
+        assert_eq!(logits.len(), 2);
+        assert_eq!(logits[0].dims(), [3, 10]);
+        assert_eq!(logits[1].dims(), [3, 2]);
+        assert_eq!(value.dims(), [3]);
+    }
+
+    #[test]
+    fn test_evaluate_actions_shapes() {
+        let device = Default::default();
+        let policy = MultiDiscreteMlpBurnPolicy::<B>::new(4, vec![3, 4], 16, &device);
+        let obs = Tensor::<B, 2>::zeros([5, 4], &device);
+        let actions_data: Vec<i64> = vec![0, 1, 1, 2, 2, 0, 0, 3, 1, 2];
+        let actions = Tensor::<B, 2, Int>::from_data(
+            burn::tensor::TensorData::new(actions_data, [5, 2]),
+            &device,
+        );
+        let (log_probs, entropy, values) = policy.evaluate_actions(obs, actions);
+        assert_eq!(log_probs.dims(), [5]);
+        assert_eq!(entropy.dims(), [5]);
+        assert_eq!(values.dims(), [5]);
+    }
+
+    #[test]
+    fn test_num_action_dims() {
+        let device = Default::default();
+        let policy = MultiDiscreteMlpBurnPolicy::<B>::new(4, vec![10, 2, 5], 32, &device);
+        assert_eq!(policy.num_action_dims(), 3);
+    }
+}

--- a/src/policy/q_network_burn.rs
+++ b/src/policy/q_network_burn.rs
@@ -1,0 +1,229 @@
+//! Burn-backend Q-Network for DQN training (phase 4 of the Burn
+//! migration, #65).
+//!
+//! Sibling to [`crate::policy::q_network::QNetwork`] (tch path). The two
+//! modules share the same 2-layer Tanh backbone as
+//! [`crate::policy::mlp::MlpPolicy`] /
+//! [`crate::policy::mlp_burn::MlpBurnPolicy`] with PPO-style orthogonal
+//! initialization (gain `sqrt(2)` on the trunk, `0.01` on the Q-head). Unlike
+//! the MLP policy this network has a single output head — its outputs are
+//! interpreted directly as `Q(s, a)` values (no softmax).
+//!
+//! # Architecture
+//!
+//! ```text
+//! Input [batch, obs_dim]
+//!     → fc1 → Tanh
+//!     → fc2 → Tanh
+//!     → q_head
+//!  Q-values [batch, n_actions]
+//! ```
+//!
+//! # Target-net sync
+//!
+//! The tch path's `VarStore::copy(&source)` is replaced by Burn's
+//! record-based clone:
+//!
+//! ```ignore
+//! let snapshot = online.clone();           // cheap — Burn Modules clone
+//! target = target.load_record(snapshot.into_record());
+//! ```
+//!
+//! This is exposed as [`crate::policy::q_network_burn::QNetworkBurn::copy_params_from`]
+//! so the Burn DQN trainer (phase 5) can drop in the same
+//! `target.copy_params_from(&online)` call site shape the tch trainer uses.
+
+use burn::{
+    module::Module,
+    nn::{Initializer, Linear},
+    tensor::{Tensor, activation, backend::Backend},
+};
+
+use super::mlp_burn::linear_with_init;
+
+/// Configuration for [`QNetworkBurn`] architecture.
+///
+/// Held as a separate type from
+/// [`crate::policy::mlp_burn::MlpBurnConfig`] so that callers can
+/// independently tune the Q-network (e.g. wider hidden_dim for richer
+/// observation spaces) without dragging the policy module along.
+#[derive(Debug, Clone, Copy)]
+pub struct QNetworkBurnConfig {
+    /// Width of every hidden layer.
+    pub hidden_dim: usize,
+    /// If `true`, initialize hidden-layer weights with orthogonal
+    /// (gain `sqrt(2)`) and the Q-head with `gain = 0.01`. Set
+    /// `false` for Burn's stock Kaiming-uniform default.
+    pub use_orthogonal_init: bool,
+}
+
+impl Default for QNetworkBurnConfig {
+    fn default() -> Self {
+        Self { hidden_dim: 64, use_orthogonal_init: true }
+    }
+}
+
+/// Two-layer Tanh Q-network on Burn.
+#[derive(Module, Debug)]
+pub struct QNetworkBurn<B: Backend> {
+    fc1: Linear<B>,
+    fc2: Linear<B>,
+    q_head: Linear<B>,
+}
+
+impl<B: Backend> QNetworkBurn<B> {
+    /// Build a fresh Q-network with the default orthogonal-init config.
+    pub fn new(obs_dim: usize, n_actions: usize, hidden_dim: usize, device: &B::Device) -> Self {
+        Self::with_config(
+            obs_dim,
+            n_actions,
+            QNetworkBurnConfig { hidden_dim, ..Default::default() },
+            device,
+        )
+    }
+
+    /// Build a fresh Q-network with the given configuration.
+    pub fn with_config(
+        obs_dim: usize,
+        n_actions: usize,
+        config: QNetworkBurnConfig,
+        device: &B::Device,
+    ) -> Self {
+        let hidden_init = if config.use_orthogonal_init {
+            Initializer::Orthogonal { gain: 2.0_f64.sqrt() }
+        } else {
+            Initializer::KaimingUniform { gain: 1.0_f64 / 3.0_f64.sqrt(), fan_out_only: false }
+        };
+        let output_init = if config.use_orthogonal_init {
+            Initializer::Orthogonal { gain: 0.01 }
+        } else {
+            Initializer::KaimingUniform { gain: 1.0_f64 / 3.0_f64.sqrt(), fan_out_only: false }
+        };
+
+        let fc1 = linear_with_init::<B>(obs_dim, config.hidden_dim, hidden_init.clone(), device);
+        let fc2 = linear_with_init::<B>(config.hidden_dim, config.hidden_dim, hidden_init, device);
+        let q_head = linear_with_init::<B>(config.hidden_dim, n_actions, output_init, device);
+
+        Self { fc1, fc2, q_head }
+    }
+
+    /// Forward pass: compute `Q(s, a)` for every action `a`.
+    ///
+    /// * `obs` shape `[batch, obs_dim]`.
+    /// * Returns Q-values of shape `[batch, n_actions]`.
+    pub fn forward(&self, obs: Tensor<B, 2>) -> Tensor<B, 2> {
+        let h = activation::tanh(self.fc1.forward(obs));
+        let h = activation::tanh(self.fc2.forward(h));
+        self.q_head.forward(h)
+    }
+
+    /// Replace this network's parameters with a deep copy of `source`'s
+    /// parameters.
+    ///
+    /// Burn's idiomatic equivalent of `tch::nn::VarStore::copy` —
+    /// returns a new module with the same architecture but the
+    /// source's records. The Burn `Optimizer` ownership model
+    /// (`step` consumes the module by value) means we return `Self`
+    /// rather than mutating `&mut self`; the DQN trainer holds the
+    /// target net in an `Option<Self>` and swaps it through this call.
+    ///
+    /// Mirrors [`crate::policy::q_network::QNetwork::copy_params_from`].
+    pub fn copy_params_from(self, source: &QNetworkBurn<B>) -> QNetworkBurn<B>
+    where
+        B: Backend,
+    {
+        // Burn modules can clone their record cheaply (the record is a
+        // tree of `Param`s; each `Param` is cheap to clone since the
+        // underlying tensors are reference-counted on the autodiff
+        // path). `load_record` consumes the receiver and returns a new
+        // module with the source's parameters.
+        self.load_record(source.clone().into_record())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::backend::{Autodiff, NdArray};
+
+    use super::*;
+
+    type B = Autodiff<NdArray<f32>>;
+
+    #[test]
+    fn test_q_network_burn_creation() {
+        let device = Default::default();
+        let _q_net = QNetworkBurn::<B>::new(4, 2, 64, &device);
+    }
+
+    #[test]
+    fn test_q_network_burn_forward_shape() {
+        let device = Default::default();
+        let q_net = QNetworkBurn::<B>::new(4, 3, 32, &device);
+        let obs = Tensor::<B, 2>::zeros([8, 4], &device);
+        let q_values = q_net.forward(obs);
+        assert_eq!(q_values.dims(), [8, 3]);
+    }
+
+    /// Mirrors `q_network::tests::test_copy_params_from_byte_equal`
+    /// from the tch path: after copying online → target, their forward
+    /// outputs must agree exactly.
+    #[test]
+    fn test_copy_params_from_matches_online() {
+        let device = Default::default();
+        let online = QNetworkBurn::<B>::with_config(
+            4,
+            2,
+            QNetworkBurnConfig { hidden_dim: 16, use_orthogonal_init: false },
+            &device,
+        );
+        let target = QNetworkBurn::<B>::with_config(
+            4,
+            2,
+            QNetworkBurnConfig { hidden_dim: 16, use_orthogonal_init: false },
+            &device,
+        );
+
+        // Build a simple synthetic batch.
+        let obs = Tensor::<B, 2>::from_data(
+            burn::tensor::TensorData::new(vec![0.1f32, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8], [2, 4]),
+            &device,
+        );
+
+        // Sanity check: fresh nets should disagree (different orthogonal
+        // draws). We compare via host floats since we don't have a
+        // direct |a - b| reduction here.
+        let q_online_before: Vec<f32> = online.forward(obs.clone()).into_data().to_vec().unwrap();
+        let q_target_before: Vec<f32> = target.forward(obs.clone()).into_data().to_vec().unwrap();
+        let any_diff_before =
+            q_online_before.iter().zip(&q_target_before).any(|(a, b)| (a - b).abs() > 1e-6);
+        assert!(any_diff_before, "expected fresh nets to disagree before copy");
+
+        // Sync target ← online.
+        let online_for_recall = QNetworkBurn::<B>::with_config(
+            4,
+            2,
+            QNetworkBurnConfig { hidden_dim: 16, use_orthogonal_init: false },
+            &device,
+        );
+        // To compare, we want the sync to make `target` match `online`
+        // exactly. The Burn idiom returns a fresh module, which we
+        // re-bind:
+        let target_copied = target.copy_params_from(&online);
+        let q_online_after: Vec<f32> = online.forward(obs.clone()).into_data().to_vec().unwrap();
+        let q_target_after: Vec<f32> =
+            target_copied.forward(obs.clone()).into_data().to_vec().unwrap();
+        for (a, b) in q_online_after.iter().zip(&q_target_after) {
+            assert!(
+                (a - b).abs() < 1e-6,
+                "Q output mismatch after copy_params_from: online={a} target={b}"
+            );
+        }
+
+        // And a *fresh* `online_for_recall` (independent draws) should
+        // still disagree with the synced target — confirms we copied
+        // online's specific draws, not "any zero-init".
+        let q_fresh: Vec<f32> = online_for_recall.forward(obs).into_data().to_vec().unwrap();
+        let still_differs = q_fresh.iter().zip(&q_target_after).any(|(a, b)| (a - b).abs() > 1e-6);
+        assert!(still_differs, "synced target unexpectedly matched a *different* fresh net");
+    }
+}

--- a/src/policy/q_network_burn.rs
+++ b/src/policy/q_network_burn.rs
@@ -29,7 +29,8 @@
 //! target = target.load_record(snapshot.into_record());
 //! ```
 //!
-//! This is exposed as [`crate::policy::q_network_burn::QNetworkBurn::copy_params_from`]
+//! This is exposed as
+//! [`crate::policy::q_network_burn::QNetworkBurn::copy_params_from`]
 //! so the Burn DQN trainer (phase 5) can drop in the same
 //! `target.copy_params_from(&online)` call site shape the tch trainer uses.
 

--- a/src/policy/snake_cnn_burn.rs
+++ b/src/policy/snake_cnn_burn.rs
@@ -1,0 +1,154 @@
+//! Burn-backend CNN policy for the Snake environment (phase 4 of the
+//! Burn migration, #65).
+//!
+//! Sibling to [`crate::policy::snake_cnn::SnakeCNN`] (tch path). The two
+//! modules implement the same compact 3-conv + 2-fc topology used by
+//! multi-agent Snake gameplay:
+//!
+//! ```text
+//! grid [B, C_in, H, W]
+//!   → conv1 (3x3, pad=1, 8 ch)  → ReLU
+//!   → conv2 (3x3, pad=1, 16 ch) → ReLU
+//!   → conv3 (3x3, pad=1, 16 ch) → ReLU
+//!   → flatten → fc_common (-> 64) → ReLU
+//!   → policy_head (64 -> 4)   [action logits]
+//!   → value_head  (64 -> 1)   [state value]
+//! ```
+//!
+//! Channel layout (matches the tch path):
+//!  - 0: Own snake body
+//!  - 1: Own snake head
+//!  - 2: Other snakes
+//!  - 3: Food
+//!  - 4: Walls / boundaries
+//!
+//! The intentionally-small width (8/16/16/64) is the same WASM-friendly
+//! recipe the tch network uses. Output layout — `(logits [B, 4],
+//! values [B, 1])` — also matches the tch path so the multi-agent
+//! trainer can drop in either backend.
+
+use burn::{
+    module::Module,
+    nn::{
+        Linear, PaddingConfig2d,
+        conv::{Conv2d, Conv2dConfig},
+    },
+    tensor::{Tensor, activation, backend::Backend},
+};
+
+use super::mlp_burn::linear_with_init;
+
+/// Compact convolutional Snake policy on Burn.
+#[derive(Module, Debug)]
+pub struct SnakeCnnBurnPolicy<B: Backend> {
+    conv1: Conv2d<B>,
+    conv2: Conv2d<B>,
+    conv3: Conv2d<B>,
+    fc_common: Linear<B>,
+    fc_policy: Linear<B>,
+    fc_value: Linear<B>,
+    /// Cached `grid_size * grid_size * 16` so [`Self::forward`] can
+    /// reshape the post-conv activations without re-deriving the
+    /// flattened length from the runtime tensor dims. Stored as a
+    /// plain field so it lands in the `Record` and survives
+    /// `Module::load_record`.
+    flat_size: usize,
+}
+
+impl<B: Backend> SnakeCnnBurnPolicy<B> {
+    /// Construct a fresh Snake CNN policy on `device`.
+    ///
+    /// # Arguments
+    /// * `grid_size`      - Spatial extent of the (square) grid.
+    /// * `input_channels` - Number of input channels (typically 5).
+    /// * `device`         - Burn backend device.
+    pub fn new(grid_size: usize, input_channels: usize, device: &B::Device) -> Self {
+        // The tch path uses `nn::ConvConfig { padding: 1, ..Default }`
+        // (padding=1 with kernel=3 = "same" output spatial dims).
+        // Burn's PaddingConfig2d::Explicit([1, 1]) is the direct
+        // equivalent.
+        let conv1 = Conv2dConfig::new([input_channels, 8], [3, 3])
+            .with_padding(PaddingConfig2d::Same)
+            .init(device);
+        let conv2 = Conv2dConfig::new([8, 16], [3, 3])
+            .with_padding(PaddingConfig2d::Same)
+            .init(device);
+        let conv3 = Conv2dConfig::new([16, 16], [3, 3])
+            .with_padding(PaddingConfig2d::Same)
+            .init(device);
+
+        let flat_size = 16 * grid_size * grid_size;
+
+        // FC layers — same Kaiming-uniform default as the tch path
+        // (`Default::default()` for `nn::LinearConfig`). We re-use
+        // `linear_with_init` with Kaiming so the bias is explicitly
+        // zeroed and the call sites are uniform across all four
+        // policies; the weight init still matches what Burn's stock
+        // `LinearConfig::default()` would do.
+        let init = burn::nn::Initializer::KaimingUniform {
+            gain: 1.0_f64 / 3.0_f64.sqrt(),
+            fan_out_only: false,
+        };
+        let fc_common = linear_with_init::<B>(flat_size, 64, init.clone(), device);
+        let fc_policy = linear_with_init::<B>(64, 4, init.clone(), device);
+        let fc_value = linear_with_init::<B>(64, 1, init, device);
+
+        Self { conv1, conv2, conv3, fc_common, fc_policy, fc_value, flat_size }
+    }
+
+    /// Forward pass through the network.
+    ///
+    /// * `grid` shape `[batch, channels, height, width]`.
+    /// * Returns `(action_logits [batch, 4], values [batch, 1])` — value
+    ///   retains the rank-2 layout the tch path uses (so the multi-agent
+    ///   trainer code that calls `.squeeze_dim(-1)` itself stays portable).
+    pub fn forward(&self, grid: Tensor<B, 4>) -> (Tensor<B, 2>, Tensor<B, 2>) {
+        let x = activation::relu(self.conv1.forward(grid));
+        let x = activation::relu(self.conv2.forward(x));
+        let x = activation::relu(self.conv3.forward(x));
+
+        // Flatten: [B, C, H, W] -> [B, C*H*W]
+        let batch = x.dims()[0];
+        let x_flat: Tensor<B, 2> = x.reshape([batch, self.flat_size]);
+
+        let features = activation::relu(self.fc_common.forward(x_flat));
+        let logits = self.fc_policy.forward(features.clone());
+        let values = self.fc_value.forward(features);
+        (logits, values)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::backend::{Autodiff, NdArray};
+
+    use super::*;
+
+    type B = Autodiff<NdArray<f32>>;
+
+    #[test]
+    fn test_snake_cnn_creation() {
+        let device = Default::default();
+        let _policy = SnakeCnnBurnPolicy::<B>::new(20, 5, &device);
+    }
+
+    #[test]
+    fn test_snake_cnn_forward_shape() {
+        let device = Default::default();
+        let policy = SnakeCnnBurnPolicy::<B>::new(20, 5, &device);
+        let grid = Tensor::<B, 4>::zeros([1, 5, 20, 20], &device);
+        let (logits, values) = policy.forward(grid);
+        assert_eq!(logits.dims(), [1, 4]);
+        assert_eq!(values.dims(), [1, 1]);
+    }
+
+    #[test]
+    fn test_snake_cnn_batch_forward_shape() {
+        let device = Default::default();
+        let policy = SnakeCnnBurnPolicy::<B>::new(10, 5, &device);
+        let grid = Tensor::<B, 4>::zeros([4, 5, 10, 10], &device);
+        let (logits, values) = policy.forward(grid);
+        assert_eq!(logits.dims(), [4, 4]);
+        assert_eq!(values.dims(), [4, 1]);
+    }
+}


### PR DESCRIPTION
Closes #81.

## Summary

Adds Burn-backend variants for the four neural-net policies that make up the training stack, completing phase 4 of the Burn migration epic (#65).

- **`src/policy/mlp_burn.rs`** — productionized from the phase-1 scout. Adds `MlpBurnConfig` (orthogonal init / 2-3 layer / activation knobs mirroring the tch `MlpConfig` surface), `encoder_features` helper, and the `linear_with_init` helper shared with the other three modules. Backward-compatible `MlpBurnPolicy::new` preserved so the bandit scout and existing parity tests are not perturbed.

- **`src/policy/multi_discrete_mlp_burn.rs`** (new) — sibling to `multi_discrete_mlp.rs`: shared trunk + per-dim `Linear` action heads for factored action spaces (Bucket Brigade, Snake/Pong multi-discrete). Per-step log-probs summed across dims, entropies averaged — same convention as the tch path.

- **`src/policy/snake_cnn_burn.rs`** (new) — sibling to `snake_cnn.rs`: 3 conv (8/16/16 channels, 3x3 with `Same` padding) + flatten + `fc_common` (64) + policy/value heads. Output layout `(logits [B, 4], values [B, 1])` matches the tch path so the multi-agent trainer is portable.

- **`src/policy/q_network_burn.rs`** (new) — sibling to `q_network.rs`: 2-layer Tanh MLP backbone + Q-head, plus `copy_params_from` implemented via Burn's record-based clone (`load_record(into_record())`) as the idiomatic equivalent of tch's `VarStore::copy`.

## Implementation note: `linear_with_init`

Burn's `LinearConfig::with_initializer` applies the same `Initializer` to both the weight and the bias. But `Initializer::Orthogonal` requires rank >= 2 and panics on the rank-1 bias tensor. The PPO recipe (mirrored from the tch path) initializes biases to zero anyway, so I added a small `linear_with_init` helper that applies the requested initializer to the weight and zeroes the bias. All four Burn policy modules share it; the helper is the seam Burn 0.21's API forces.

## Scope of this PR

Per the issue's "Recommend (b)" guidance, this PR focuses on **the policy networks themselves**. Multi-agent (`src/multi_agent/`) and example trainers remain on tch and will be migrated in phase 4b / phase 5. The four policies are the priority — once their surface is stable, downstream code can mechanically follow.

## CI gate (all run locally before push)

- `cargo fmt -- --check` - pass
- `cargo check --no-default-features` - pass
- `cargo build --no-default-features --features training-burn` - pass
- `cargo build --features training` - pass
- `cargo build --features "training training-burn"` - pass
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features` - pass
- `cargo test --features training` - 219 lib + integration + 6 doc tests pass
- `cargo test --features "training training-burn" --lib` - 270 tests pass (includes phase-3 parity_tests)
- `cargo test --no-default-features --features training-burn --lib` - 181 tests pass

## Test plan

- [x] Each new policy module has unit tests for construction, forward shape, evaluate-actions / copy semantics (mirroring its tch sibling where applicable)
- [x] All existing tch-side `policy::*` tests still pass unchanged
- [x] Phase-3 `parity_tests` still pass with both backends enabled
- [x] `MlpBurnPolicy::new` keeps its phase-1 (Kaiming) signature so the bandit scout binary and `ppo_burn`/`dqn_burn` smoke tests remain wired up

Generated with Claude Code (https://claude.com/claude-code)