### PR TITLE
Burn migration phase 6 (closure): document WASM inference no-op decision

### DIFF
--- a/WASM_ROADMAP.md
+++ b/WASM_ROADMAP.md
@@ -2,6 +2,30 @@
 
 This document outlines the plan for creating WebAssembly-based visualizations of trained RL agents.
 
+## Backend status (post Burn migration)
+
+After the Burn migration (#65, phases 1–5), the training-side tensor stack
+is **Burn** (NdArray default; optional `wgpu`/`cuda`). The WASM-side
+inference path is deliberately **not** on Burn: it stays in the pure-Rust
+hand-rolled `src/inference/` + `src/policy/{inference,universal_inference}.rs`
+modules. Phase 6 of #65 (unifying WASM inference under Burn's WebGPU
+backend) was evaluated and **deferred indefinitely** — see #83 closure for
+the rationale. In short:
+
+- The pure-Rust inference path is small, deterministic, dependency-free,
+  and meets the existing performance targets (<1ms forward pass).
+- Burn's `wgpu` backend on `wasm32-unknown-unknown` is pre-1.0 and the
+  bundle-size impact would very likely exceed the 2x hard gate the #83
+  issue body specifies.
+- The two-stack maintenance burden (Burn for training, pure Rust for
+  WASM inference) is the cheaper option until Burn's WASM story matures.
+
+The references to "PyTorch / tch / libtorch" further down in this document
+describe the historical pre-Burn architecture and are kept for context;
+**replace any of those mentions with "Burn (NdArray / wgpu / cuda)" when
+adapting these recipes**. The export format described below is the
+JSON-based portable format that survived the migration intact.
+
 ## Vision
 
 Compile Rust inference code to WASM and run trained policies in the browser with interactive visualizations. This allows:

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -1,8 +1,14 @@
 //! Pure Rust inference module for WASM compatibility
 //!
 //! This module provides a lightweight neural network inference engine
-//! that can be compiled to WebAssembly. It avoids dependencies on
-//! libtorch/tch-rs, implementing only forward pass for trained models.
+//! that can be compiled to WebAssembly. It deliberately avoids the Burn
+//! tensor stack used on the training side (see `src/train/`, `src/policy/`)
+//! so the WASM bundle stays small — Burn's WebGPU backend has a
+//! non-trivial WASM bundle-size cost on a pre-1.0 backend. See
+//! `WASM_ROADMAP.md` and Burn migration epic #65 (phase 6 closure) for
+//! the rationale.
+//!
+//! Forward pass only — no autodiff, no training.
 
 pub mod nn;
 pub mod snake;

--- a/src/inference/snake.rs
+++ b/src/inference/snake.rs
@@ -1,14 +1,15 @@
 //! Snake CNN inference for WASM
 //!
-//! Pure Rust implementation of Snake CNN forward pass without PyTorch
-//! dependencies
+//! Pure Rust implementation of Snake CNN forward pass. Stays off the Burn
+//! tensor stack used on the training side so the WASM bundle stays small;
+//! see `crate::inference` module docs and `WASM_ROADMAP.md`.
 
 use serde::{Deserialize, Serialize};
 
 /// A serializable CNN model for Snake inference
 ///
 /// This struct contains all the weights and biases needed to run
-/// CNN inference without any PyTorch dependencies.
+/// CNN inference in pure Rust (no Burn/tensor-stack dependency).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SnakeCNNInference {
     /// Grid width

--- a/src/policy/inference.rs
+++ b/src/policy/inference.rs
@@ -1,7 +1,10 @@
 //! Inference-only model format for WASM deployment
 //!
 //! This module provides a pure Rust implementation of neural network inference
-//! that doesn't depend on PyTorch/LibTorch, making it suitable for WebAssembly.
+//! that stays off the training-side Burn tensor stack so it can compile to
+//! WebAssembly with a minimal bundle size. The training side (PPO/DQN) runs
+//! on Burn; weights are exported as JSON and consumed here for browser
+//! inference. See `crate::inference` module docs and `WASM_ROADMAP.md`.
 
 use std::collections::HashMap;
 
@@ -11,7 +14,7 @@ use serde::{Deserialize, Serialize};
 /// A serializable CNN model for Snake inference
 ///
 /// This struct contains all the weights and biases needed to run
-/// CNN inference without any PyTorch dependencies.
+/// CNN inference in pure Rust (no Burn/tensor-stack dependency).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SnakeCNNInference {
     /// Grid width
@@ -275,7 +278,7 @@ pub struct TrainingMetadata {
 /// A serializable MLP model for inference
 ///
 /// This struct contains all the weights and biases needed to run
-/// inference without any PyTorch dependencies.
+/// inference in pure Rust (no Burn/tensor-stack dependency).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InferenceModel {
     /// Input dimension


### PR DESCRIPTION
## Summary

Closes #83 (Burn migration epic #65, phase 6 — the OPTIONAL final phase).

After review, **Phase 6 is closed as a deliberate no-op**: the WASM
inference path stays on the existing pure-Rust implementation rather
than migrating to Burn's WebGPU backend.

## Decision rationale

The issue body explicitly authorizes a "no-op closure" decision and lists
hard gates (2x WASM bundle-size, 2x latency) that would abort the migration
even if attempted. Combined with #65's own framing — "The WASM inference
path may not need to migrate. It's already pure-Rust by design. The
unification in phase 6 is a 'could', not a 'must'" — the right answer is
to formally close out the epic rather than absorb the risk.

Key factors:

- **Maturity risk.** Burn's `burn-wgpu` backend on `wasm32-unknown-unknown`
  is pre-1.0. Adopting it as the sole WASM inference path would couple
  the browser demos to that pre-1.0 surface.
- **Bundle size risk.** The current pure-Rust path is ~1700 LOC of
  hand-rolled f32 matmul/softmax/conv with no runtime dependencies. A
  Burn-WebGPU port would very likely exceed the 2x hard gate the #83
  issue body specifies.
- **No concrete payoff today.** The two-stack maintenance burden is real
  but small: the inference modules are stable, well-tested, and don't
  see frequent change.
- **Reversible.** If Burn's WASM story matures (post-1.0, smaller
  bundle, better tooling), a future issue can reopen this.

## What this PR actually changes

- `src/inference/mod.rs`, `src/inference/snake.rs`, `src/policy/inference.rs`:
  module headers updated to replace stale "PyTorch / libtorch / tch-rs"
  references (left over from the pre-Burn era) with the correct
  post-migration framing: training is on Burn; the WASM inference path
  deliberately stays off Burn.
- `WASM_ROADMAP.md`: new "Backend status (post Burn migration)" section
  recording the Phase 6 closure decision and linking back to #83 / #65.

No code or behavior changes. The full pure-Rust inference test suite
continues to pass.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --no-default-features` — clean (8 pre-existing
      warnings, unchanged)
- [x] `cargo build --features training` — clean (11 pre-existing
      warnings, unchanged)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` —
      docs build with no warnings
- [x] `cargo test --features training` — 193 tests pass
- [x] `cargo test --no-default-features --features wasm` — 61 tests pass
      (including all 10 pure-Rust inference tests)

WASM-pack / browser bundle measurements intentionally not run, since
this PR explicitly does **not** migrate the WASM path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)