### PR TITLE
Validate Burn wgpu backend with end-to-end CartPole and SimpleBandit training (closes #102)

### DIFF
--- a/docs/BURN_BACKENDS.md
+++ b/docs/BURN_BACKENDS.md
@@ -55,6 +55,92 @@ through libtorch. Linux + an NVIDIA GPU + CUDA toolkit required.
 | Linux box with an NVIDIA GPU | cuda or wgpu |
 | Browser-side inference / training | wgpu (compiles to WebGPU) |
 
+## End-to-end validation runs
+
+Burn's compile-time backend swap is verified by the runs below. Both
+`train_simple_bandit` and `train_cartpole_modern` parameterize their
+`Backend` type alias with a `#[cfg(feature = "wgpu")]` so the same
+trainer source code drives either backend; only the compile-time
+feature flag changes.
+
+### `train_simple_bandit` (#102)
+
+**Host setup**
+
+- macOS (Darwin 25.5).
+- Apple M3 Ultra (Metal backend selected by wgpu).
+- Rust 1.x stable, Burn 0.21, `cubecl_wgpu` 0.21.
+
+**Command**
+
+```bash
+# wgpu (Metal)
+cargo run --release --features "training,wgpu" --example train_simple_bandit
+# NdArray (CPU) baseline
+cargo run --release --example train_simple_bandit
+```
+
+**Result**
+
+| Backend | Final success | Random baseline | Wall clock (50k steps) | env-steps/sec |
+| ------- | ------------- | ---------------- | ----------------------- | -------------- |
+| NdArray (CPU) | **98.3%** | 50% | 6.4s | ~7,800 |
+| wgpu / Metal | **98.3%** | 50% | 85.2s | ~590 |
+
+Both backends learn the same near-optimal policy (action probability
+~1.0 on the correct lever in each of the two contexts). wgpu is roughly
+13x slower wall-clock for this trivial 1-input/2-action MLP because GPU
+kernel launch overhead dominates — see the "performance note" below.
+
+### `train_cartpole_modern` (#102)
+
+**Host setup**: same as above (M3 Ultra / Metal via wgpu).
+
+**Command**
+
+```bash
+# wgpu (Metal)
+TOTAL_TIMESTEPS=40000 cargo run --release \
+    --features "training,wgpu" \
+    --example train_cartpole_modern
+# NdArray (CPU) baseline
+TOTAL_TIMESTEPS=40000 cargo run --release --example train_cartpole_modern
+```
+
+**Result**
+
+| Backend | Final avg episode length (last 100) | Random baseline | Wall clock (~37k steps) | env-steps/sec |
+| ------- | ------------------------------------ | --------------- | ----------------------- | -------------- |
+| NdArray (CPU) | **161.1** | ~22 | 4.1s | ~8,970 |
+| wgpu / Metal | **175.0** | ~22 | 97.5s | ~378 |
+
+Both backends pass the "better than random" bar by an order of
+magnitude on the same 40k-step budget. The small difference between
+runs (161 vs 175) is consistent with run-to-run RNG variance for a
+~9-update PPO smoke run; no correctness regression is implied.
+
+### Bug surfaced during validation
+
+The wgpu run on `train_cartpole_modern` initially panicked with
+`index out of bounds: the len is 0` inside `train::ppo::trainer::select_rows_int`.
+Root cause: `TensorData::to_vec::<E>()` is dtype-strict, and Burn's
+default integer dtype is backend-dependent — `NdArray` stores int
+tensors as `i64`, but `Wgpu<f32, i32>` stores them as `i32`. The old
+code unwrapped the error to a default (empty) vector, which only worked
+by accident on NdArray. Fixed by switching to `TensorData::iter::<i64>()`,
+which performs the cross-dtype cast per-element. See PR resolving #102.
+
+### Performance note
+
+These numbers are validation, not throughput. On a small (1-input or
+4-input, 64-unit) MLP, GPU kernel-launch overhead dominates per-op
+latency, so wgpu/Metal looks slower than the SIMD-friendly NdArray
+path. Burn's wgpu backend autotunes a fusion runtime on first use
+(visible as the ~50s "Created wgpu compute server" log line), which
+also inflates the wall-clock numbers above. Real wins on wgpu show up
+for larger nets, bigger batches, or convolution-heavy workloads
+(Snake CNN, image envs) — see issue #65 follow-ups.
+
 ## Why Burn instead of libtorch?
 
 The pre-v0.1.0 trainer stack used `tch` (Rust bindings to libtorch).

--- a/examples/games/bandit/train_simple_bandit.rs
+++ b/examples/games/bandit/train_simple_bandit.rs
@@ -1,22 +1,32 @@
 //! Train an actor-critic policy on `SimpleBandit` using the Burn 0.21
-//! backend (CPU `NdArray` + `Autodiff`).
+//! backend.
 //!
 //! The bandit trainer is the canonical end-to-end Burn example for the
 //! thrust-rl crate. It demonstrates the rollout/loss/update loop using
 //! the [`MlpBurnPolicy`] module, the move-through optimizer ownership
 //! model, and the `EnvPool` vectorized env wrapper.
 //!
+//! # Backends
+//!
+//! - **Default**: CPU `NdArray` + `Autodiff` (no extra features).
+//! - **Opt-in GPU**: `--features "training,wgpu"` swaps in `Autodiff<Wgpu>`
+//!   (cross-platform GPU via Vulkan / Metal / DX12 / WebGPU). Used by issue
+//!   #102 to validate Burn's GPU path end-to-end.
+//!
 //! Run:
 //!
 //! ```bash
 //! cargo run --example train_simple_bandit --release
+//! # or, on a GPU box:
+//! cargo run --release --features "training,wgpu" --example train_simple_bandit
 //! ```
 //!
-//! Expected: success rate > 0.95 within ~50k env steps.
+//! Expected: success rate > 0.95 within ~50k env steps on either
+//! backend.
 
 use anyhow::Result;
 use burn::{
-    backend::{Autodiff, NdArray},
+    backend::Autodiff,
     module::AutodiffModule,
     optim::{AdamConfig, GradientsParams, Optimizer},
     tensor::{Int, Tensor, TensorData},
@@ -26,11 +36,19 @@ use thrust_rl::{
     policy::mlp::MlpBurnPolicy,
 };
 
-// Pick the concrete backend stack up-front so the rest of the file is
-// monomorphic — keeps the scout simple. CPU only; GPU backends (wgpu, cuda)
-// are deferred to phase 6 of the migration.
-type Backend = Autodiff<NdArray<f32>>;
-type InnerBackend = NdArray<f32>;
+// Concrete backend stack — selected at compile time via Cargo features.
+// `--features "training,wgpu"` swaps the CPU NdArray default for Burn's
+// cross-platform GPU backend (Vulkan / Metal / DX12 / WebGPU).
+#[cfg(not(feature = "wgpu"))]
+type InnerBackend = burn::backend::NdArray<f32>;
+#[cfg(feature = "wgpu")]
+type InnerBackend = burn::backend::Wgpu<f32, i32>;
+type Backend = Autodiff<InnerBackend>;
+
+#[cfg(not(feature = "wgpu"))]
+const BACKEND_LABEL: &str = "NdArray<f32> + Autodiff (CPU)";
+#[cfg(feature = "wgpu")]
+const BACKEND_LABEL: &str = "Wgpu<f32, i32> + Autodiff (GPU: Vulkan/Metal/DX12/WebGPU)";
 
 const NUM_ENVS: usize = 4;
 const NUM_STEPS: usize = 100;
@@ -45,7 +63,8 @@ const HIDDEN_DIM: usize = 64;
 fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter("info").init();
 
-    tracing::info!("SimpleBandit + Burn (NdArray<f32> + Autodiff) scout trainer");
+    tracing::info!("SimpleBandit + Burn ({}) scout trainer", BACKEND_LABEL);
+    let training_start = std::time::Instant::now();
 
     // ---- env setup ---------------------------------------------------------
     let probe = SimpleBandit::new();
@@ -201,7 +220,18 @@ fn main() -> Result<()> {
     }
 
     let final_success = total_reward / total_steps as f64;
-    tracing::info!("Final success rate (burn path): {:.1}%", final_success * 100.0);
+    let elapsed = training_start.elapsed();
+    tracing::info!(
+        "Final success rate (burn path, {}): {:.1}% over {} steps",
+        BACKEND_LABEL,
+        final_success * 100.0,
+        total_steps
+    );
+    tracing::info!(
+        "Training wall-clock: {:.2}s ({:.0} env-steps/sec)",
+        elapsed.as_secs_f64(),
+        total_steps as f64 / elapsed.as_secs_f64()
+    );
 
     // Sanity-check: also confirm the trained policy makes correct argmax
     // choices on the two contexts (eval mode, no autodiff).

--- a/examples/games/cartpole/train_cartpole_modern.rs
+++ b/examples/games/cartpole/train_cartpole_modern.rs
@@ -31,7 +31,7 @@
 
 use anyhow::Result;
 use burn::{
-    backend::{Autodiff, NdArray},
+    backend::Autodiff,
     optim::AdamConfig,
     tensor::{Int, Tensor, TensorData},
 };
@@ -44,7 +44,20 @@ use thrust_rl::{
     },
 };
 
-type Backend = Autodiff<NdArray<f32>>;
+// Concrete backend stack — selected at compile time via Cargo features.
+// `--features "training,wgpu"` swaps the CPU NdArray default for Burn's
+// cross-platform GPU backend (Vulkan / Metal / DX12 / WebGPU). See issue
+// #102 for the GPU validation run.
+#[cfg(not(feature = "wgpu"))]
+type InnerBackend = burn::backend::NdArray<f32>;
+#[cfg(feature = "wgpu")]
+type InnerBackend = burn::backend::Wgpu<f32, i32>;
+type Backend = Autodiff<InnerBackend>;
+
+#[cfg(not(feature = "wgpu"))]
+const BACKEND_LABEL: &str = "NdArray<f32> + Autodiff (CPU)";
+#[cfg(feature = "wgpu")]
+const BACKEND_LABEL: &str = "Wgpu<f32, i32> + Autodiff (GPU: Vulkan/Metal/DX12/WebGPU)";
 
 const NUM_ENVS: usize = 16;
 const NUM_STEPS: usize = 256;
@@ -62,7 +75,7 @@ fn main() -> Result<()> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_TIMESTEPS);
 
-    tracing::info!("Starting Modern CartPole PPO Training (Burn backend)");
+    tracing::info!("Starting Modern CartPole PPO Training (Burn backend: {})", BACKEND_LABEL);
 
     let training_start = std::time::Instant::now();
 

--- a/src/train/ppo/trainer.rs
+++ b/src/train/ppo/trainer.rs
@@ -308,12 +308,21 @@ fn select_rows_1d<B: AutodiffBackend>(
 }
 
 /// Select `indices` rows from a rank-1 int tensor.
+///
+/// NOTE: We can't call `to_vec::<i64>()` directly here because Burn's
+/// integer dtype is backend-dependent — `NdArray` uses `i64`, but `Wgpu`
+/// uses `i32`. `to_vec` requires the requested `E` to match the stored
+/// dtype exactly, so on wgpu it returns `DataError::TypeMismatch` and
+/// `unwrap_or_default()` silently yields an empty vector, triggering an
+/// out-of-bounds panic. Using `.iter::<i64>()` instead lets Burn handle
+/// the per-element cast, so the host buffer is always populated.
 fn select_rows_int<B: AutodiffBackend>(
     tensor: Tensor<B, 1, Int>,
     indices: &[usize],
     device: &B::Device,
 ) -> Tensor<B, 1, Int> {
-    let host: Vec<i64> = tensor.into_data().to_vec().unwrap_or_default();
+    let data = tensor.into_data();
+    let host: Vec<i64> = data.iter::<i64>().collect();
     let out: Vec<i64> = indices.iter().map(|&i| host[i]).collect();
     Tensor::<B, 1, Int>::from_data(burn::tensor::TensorData::new(out, [indices.len()]), device)
 }


### PR DESCRIPTION
Closes #102.

## Summary

PR #98 only ran `cargo check --features "training,wgpu"` — never actually trained anything on wgpu. This PR parameterizes the two surviving Burn trainer examples (`train_simple_bandit` and `train_cartpole_modern`) so the same source compiles against either Burn's CPU NdArray default or the cross-platform wgpu GPU backend, and validates the wgpu path end-to-end on Apple M3 Ultra / Metal. This closes the last remaining acceptance criterion (#6) on epic #65.

## End-to-end validation results

Host: macOS (Darwin 25.5) on Apple M3 Ultra (wgpu picks Metal automatically).

| Trainer | Backend | Final reward | Random baseline | Wall clock |
| ------- | ------- | ------------ | --------------- | ---------- |
| `train_simple_bandit` | NdArray (CPU) | **98.3%** success over 50k steps | 50% | 6.4s |
| `train_simple_bandit` | wgpu / Metal | **98.3%** success over 50k steps | 50% | 85.2s |
| `train_cartpole_modern` | NdArray (CPU) | avg ep length **161.1** | ~22 | 4.1s |
| `train_cartpole_modern` | wgpu / Metal | avg ep length **175.0** | ~22 | 97.5s |

Both backends converge to equivalent quality. wgpu is significantly slower wall-clock because GPU kernel-launch overhead dominates on these tiny 1- or 4-input MLPs (and Burn's wgpu fusion runtime autotunes on first use, adding ~50s of warm-up). Throughput optimization is out of scope; the goal is "does training actually work end-to-end on a non-NdArray backend", and the answer is yes.

## Bug fixed along the way

`train_cartpole_modern` initially panicked at `src/train/ppo/trainer.rs:317` with `index out of bounds: the len is 0 but the index is 2702`. Root cause: `TensorData::to_vec::<E>()` is dtype-strict, and Burn's integer dtype is backend-dependent — `NdArray` stores `Tensor<_, _, Int>` as i64 but `Wgpu<f32, i32>` stores it as i32. The old code unwrapped the resulting `DataError::TypeMismatch` to a default (empty) Vec, then `select_rows_int` panicked on the first index lookup. Fixed by switching from `data.to_vec::<i64>().unwrap_or_default()` to `data.iter::<i64>().collect()`, which performs the cross-dtype cast per-element.

## Changes

- `examples/games/bandit/train_simple_bandit.rs` — `#[cfg(feature = "wgpu")]` swap between `NdArray<f32>` and `Wgpu<f32, i32>`; backend label + total wall-clock in the final log line.
- `examples/games/cartpole/train_cartpole_modern.rs` — same cfg swap and backend-label log line.
- `src/train/ppo/trainer.rs` — `select_rows_int` now uses `TensorData::iter::<i64>()` to handle non-i64 Int dtypes (i.e., wgpu/cuda).
- `docs/BURN_BACKENDS.md` — validation-run section: host setup, commands, comparison numbers, the bug fix note, and a performance caveat.

## CI gates verified locally

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --features training`
- [x] `cargo check --no-default-features`
- [x] `cargo check --features "training,wgpu"`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --features training` — 192 unit + 6 integration + 6 doctests pass.

## Test plan

- [ ] Re-run `cargo run --release --features "training,wgpu" --example train_simple_bandit` and confirm success rate climbs above 95%.
- [ ] Re-run `TOTAL_TIMESTEPS=40000 cargo run --release --features "training,wgpu" --example train_cartpole_modern` and confirm final avg episode length is >> 22.
- [ ] Confirm the NdArray default backend still trains both examples to comparable quality (unchanged from prior `main`).