### PR TITLE
Refactor JointMultiAgentTrainer to ingest per-agent observations (PR 1/4)

### DIFF
--- a/src/multi_agent/joint.rs
+++ b/src/multi_agent/joint.rs
@@ -313,17 +313,20 @@ impl Default for JointTrainerConfig {
 
 /// Synchronized rollout buffer (host-side).
 ///
-/// Every agent sees the *same* observation on every step — the trainer
-/// assumes a globally-shared observation; environments with distinct
-/// per-agent views should pre-concatenate or use only agent 0's view as
-/// the trainer input. Per-agent actions / log-probs / values / rewards
-/// are stored as parallel host buffers and materialized into Burn
-/// tensors lazily inside [`JointMultiAgentTrainer::update`].
+/// Per-agent observations are stored independently so environments with
+/// distinct per-agent views (e.g. partial observability, asymmetric
+/// information) work without any pre-concatenation. Each agent `i`
+/// records its own observation stream into
+/// `observations_per_agent[i]` (a flat `[T * obs_dim]` buffer).
+/// Per-agent actions / log-probs / values / rewards are stored as
+/// parallel host buffers and materialized into Burn tensors lazily
+/// inside [`JointMultiAgentTrainer::update`].
 #[derive(Debug, Clone)]
 pub struct JointRollout {
-    /// Shared observations: flat `[T * obs_dim]`. Same for every agent.
-    pub observations: Vec<f32>,
-    /// Observation dimensionality.
+    /// Per-agent observations: `Vec<N>[T * obs_dim]`. Each inner buffer
+    /// holds the observation stream for one agent across the rollout.
+    pub observations_per_agent: Vec<Vec<f32>>,
+    /// Observation dimensionality (uniform across agents).
     pub obs_dim: usize,
     /// Per-agent actions: `Vec<N>[T * num_action_dims]`. `num_action_dims`
     /// is 1 for scalar discrete, `num_dims` for multi-discrete.
@@ -491,10 +494,12 @@ where
     /// Drive a [`JointEnv`] for `config.rollout_steps` and return the
     /// synchronized rollout buffer.
     ///
-    /// `last_obs` is the persistent "next observation" handed in across
-    /// iterations: pass agent-0's observation from the most recent
-    /// `env.reset_joint()` or step. The trainer updates it in place so
-    /// callers can keep the rollout stream stitched across iterations.
+    /// `last_obs` is the persistent "next observation per agent" handed
+    /// in across iterations: pass the per-agent observations from the
+    /// most recent `env.reset_joint()` or step (i.e. the env's full
+    /// `Vec<Vec<f32>>` shape, length = `num_agents`). The trainer
+    /// updates it in place so callers can keep the rollout stream
+    /// stitched across iterations.
     ///
     /// `rng` is consumed by each per-step
     /// [`JointPolicy::get_action_host_seeded`] call. Pass the
@@ -504,12 +509,19 @@ where
     pub fn collect_rollout<E: JointEnv>(
         &self,
         env: &mut E,
-        last_obs: &mut Vec<f32>,
+        last_obs: &mut [Vec<f32>],
         rng: &mut StdRng,
     ) -> JointRollout {
         let num_steps = self.config.rollout_steps;
         let num_agents = self.config.num_agents;
-        let obs_dim = last_obs.len();
+        assert_eq!(
+            last_obs.len(),
+            num_agents,
+            "collect_rollout: last_obs length ({}) must equal num_agents ({})",
+            last_obs.len(),
+            num_agents,
+        );
+        let obs_dim = last_obs[0].len();
         let device = self.device.clone();
 
         // Probe per-dim action layout from agent 0's policy (shape-only — no
@@ -522,7 +534,8 @@ where
             .action_dims_joint()
             .len();
 
-        let mut obs_buf = vec![0.0_f32; num_steps * obs_dim];
+        let mut obs_buf_per_agent: Vec<Vec<f32>> =
+            (0..num_agents).map(|_| vec![0.0_f32; num_steps * obs_dim]).collect();
         let mut act_buf: Vec<Vec<i64>> =
             (0..num_agents).map(|_| vec![0_i64; num_steps * num_action_dims]).collect();
         let mut lp_buf: Vec<Vec<f32>> = (0..num_agents).map(|_| vec![0.0_f32; num_steps]).collect();
@@ -534,19 +547,22 @@ where
 
         for t in 0..num_steps {
             let start = t * obs_dim;
-            obs_buf[start..start + obs_dim].copy_from_slice(last_obs);
-
-            // Build the rollout-time observation tensor (single-row batch).
-            let obs_t = Tensor::<B, 2>::from_data(
-                burn::tensor::TensorData::new(last_obs.clone(), [1, obs_dim]),
-                &device,
-            );
 
             let mut joint_action: Vec<Vec<i64>> = Vec::with_capacity(num_agents);
             for (i, slot) in self.policies.iter().enumerate() {
                 let policy = slot.as_ref().expect("policy present at rollout time");
+
+                // Per-agent observation: record into the agent-i buffer and
+                // build a single-row obs tensor for the agent-i policy.
+                let agent_obs = &last_obs[i];
+                obs_buf_per_agent[i][start..start + obs_dim].copy_from_slice(agent_obs);
+                let obs_t = Tensor::<B, 2>::from_data(
+                    burn::tensor::TensorData::new(agent_obs.clone(), [1, obs_dim]),
+                    &device,
+                );
+
                 let (actions_host, log_probs_host, values_host) =
-                    policy.get_action_host_seeded(obs_t.clone(), rng);
+                    policy.get_action_host_seeded(obs_t, rng);
 
                 // Extract per-agent action vector (length = num_action_dims).
                 let row: Vec<i64> = actions_host[..num_action_dims].to_vec();
@@ -559,21 +575,21 @@ where
             }
 
             let result = env.step_joint(&joint_action);
-            for i in 0..num_agents {
-                rew_buf[i][t] = result.rewards[i];
+            for (i, rew) in rew_buf.iter_mut().enumerate().take(num_agents) {
+                rew[t] = result.rewards[i];
             }
             done_buf[t] = if result.done { 1.0 } else { 0.0 };
 
             if result.done {
                 let fresh = env.reset_joint(None);
-                *last_obs = fresh[0].clone();
+                last_obs[..num_agents].clone_from_slice(&fresh[..num_agents]);
             } else {
-                *last_obs = result.observations[0].clone();
+                last_obs[..num_agents].clone_from_slice(&result.observations[..num_agents]);
             }
         }
 
         JointRollout {
-            observations: obs_buf,
+            observations_per_agent: obs_buf_per_agent,
             obs_dim,
             actions: act_buf,
             num_action_dims,
@@ -700,7 +716,18 @@ where
             indices.shuffle(rng);
             indices.truncate(mb_size);
 
-            let obs_mb = select_obs(&rollout.observations, rollout.obs_dim, &indices, &device);
+            // Per-agent obs minibatches: agent `i` reads from its own
+            // observation buffer at `rollout.observations_per_agent[i]`.
+            let obs_mb_per_agent: Vec<Tensor<B, 2>> = (0..num_agents)
+                .map(|i| {
+                    select_obs(
+                        &rollout.observations_per_agent[i],
+                        rollout.obs_dim,
+                        &indices,
+                        &device,
+                    )
+                })
+                .collect();
 
             // Per-agent forward + per-agent loss accumulation.
             //
@@ -725,6 +752,7 @@ where
                     .as_ref()
                     .ok_or_else(|| anyhow!("policy {} is None mid-update", i))?;
 
+                let obs_mb_i = obs_mb_per_agent[i].clone();
                 let actions_mb =
                     select_actions(&rollout.actions[i], rollout.num_action_dims, &indices, &device);
                 let old_lp_mb = select_f32_row(&rollout.log_probs[i], &indices, &device);
@@ -733,8 +761,8 @@ where
                 let old_v_mb = select_f32_row(&rollout.values[i], &indices, &device);
 
                 let (new_lp, entropy, values_mb) =
-                    policy.evaluate_actions_joint(obs_mb.clone(), actions_mb);
-                let feat = policy.encoder_features_joint(obs_mb.clone());
+                    policy.evaluate_actions_joint(obs_mb_i.clone(), actions_mb);
+                let feat = policy.encoder_features_joint(obs_mb_i);
 
                 let (policy_loss, clip_frac, kl) =
                     compute_policy_loss(new_lp, old_lp_mb, adv_mb, self.config.clip_range);
@@ -1053,8 +1081,7 @@ mod tests {
             JointMultiAgentTrainer::new(policies, optimizers, config, device).unwrap();
 
         let mut env = MockEnv::new(num_agents, obs_dim);
-        let initial = env.reset_joint(None);
-        let mut last_obs = initial[0].clone();
+        let mut last_obs = env.reset_joint(None);
 
         let mut rng = StdRng::seed_from_u64(0);
         let rollout = trainer.collect_rollout(&mut env, &mut last_obs, &mut rng);
@@ -1095,8 +1122,7 @@ mod tests {
         let trainer = JointMultiAgentTrainer::new(policies, optimizers, config, device).unwrap();
 
         let mut env = MockEnv::new(num_agents, obs_dim);
-        let initial = env.reset_joint(None);
-        let mut last_obs = initial[0].clone();
+        let mut last_obs = env.reset_joint(None);
         let mut rng = StdRng::seed_from_u64(0);
         let rollout = trainer.collect_rollout(&mut env, &mut last_obs, &mut rng);
 
@@ -1104,6 +1130,10 @@ mod tests {
         assert_eq!(rollout.num_agents(), num_agents);
         assert_eq!(rollout.obs_dim, obs_dim);
         assert_eq!(rollout.num_action_dims, 1);
+        assert_eq!(rollout.observations_per_agent.len(), num_agents);
+        for buf in &rollout.observations_per_agent {
+            assert_eq!(buf.len(), t * obs_dim);
+        }
         for a in &rollout.actions {
             assert_eq!(a.len(), t);
         }
@@ -1143,8 +1173,7 @@ mod tests {
             JointMultiAgentTrainer::new(policies, optimizers, config, device).unwrap();
 
         let mut env = MockEnv::new(num_agents, obs_dim);
-        let initial = env.reset_joint(None);
-        let mut last_obs = initial[0].clone();
+        let mut last_obs = env.reset_joint(None);
         let mut rng = StdRng::seed_from_u64(0);
         let rollout = trainer.collect_rollout(&mut env, &mut last_obs, &mut rng);
 
@@ -1187,8 +1216,7 @@ mod tests {
             JointMultiAgentTrainer::new(policies, optimizers, config, device).unwrap();
 
         let mut env = MockEnv::new(num_agents, obs_dim);
-        let initial = env.reset_joint(None);
-        let mut last_obs = initial[0].clone();
+        let mut last_obs = env.reset_joint(None);
         let mut rng = StdRng::seed_from_u64(0);
         let rollout = trainer.collect_rollout(&mut env, &mut last_obs, &mut rng);
 
@@ -1203,5 +1231,96 @@ mod tests {
             })
             .expect("update should not error");
         assert!(stats.total_loss.is_finite());
+    }
+
+    /// Env that returns *distinct* per-agent observations every step:
+    /// agent `i` always sees a one-hot vector with the `i`-th slot set.
+    /// Used as the load-bearing regression assertion that the trainer
+    /// reads agent `i`'s observation for agent `i` (and not agent 0's
+    /// view for everyone) after the per-agent obs refactor.
+    struct PerAgentObsMockEnv {
+        num_agents: usize,
+        obs_dim: usize,
+    }
+
+    impl PerAgentObsMockEnv {
+        fn new(num_agents: usize, obs_dim: usize) -> Self {
+            assert!(obs_dim >= num_agents, "obs_dim must be >= num_agents for one-hot encoding");
+            Self { num_agents, obs_dim }
+        }
+
+        fn per_agent_obs(&self) -> Vec<Vec<f32>> {
+            (0..self.num_agents)
+                .map(|i| {
+                    let mut v = vec![0.0_f32; self.obs_dim];
+                    v[i] = 1.0;
+                    v
+                })
+                .collect()
+        }
+    }
+
+    impl JointEnv for PerAgentObsMockEnv {
+        fn reset_joint(&mut self, _seed: Option<u64>) -> Vec<Vec<f32>> {
+            self.per_agent_obs()
+        }
+
+        fn step_joint(&mut self, _actions: &[Vec<i64>]) -> JointStepResult {
+            JointStepResult {
+                rewards: vec![0.0_f32; self.num_agents],
+                done: false,
+                observations: self.per_agent_obs(),
+            }
+        }
+    }
+
+    #[test]
+    fn test_collect_rollout_reads_per_agent_observations() {
+        // Regression guard for the per-agent observation refactor (PR
+        // #118). The trainer must read agent `i`'s observation for
+        // agent `i` — *not* agent 0's view for everyone. We construct
+        // an env whose `step_joint` returns distinct one-hot
+        // observations per agent and assert that
+        // `rollout.observations_per_agent[i]` at every timestep
+        // contains agent `i`'s one-hot, not agent 0's.
+        let device = Default::default();
+        let num_agents = 3;
+        let obs_dim: usize = 4; // >= num_agents for one-hot encoding
+        let t: usize = 16;
+        let policies = make_mlp_policies(num_agents, obs_dim, 2, 8, &device);
+        let optimizers = build_optimizers::<MlpBurnPolicy<B>>(num_agents, 3e-4);
+
+        let config = JointTrainerConfig {
+            num_agents,
+            rollout_steps: t,
+            n_epochs: 1,
+            minibatch_size: t,
+            ..Default::default()
+        };
+        let trainer = JointMultiAgentTrainer::new(policies, optimizers, config, device).unwrap();
+
+        let mut env = PerAgentObsMockEnv::new(num_agents, obs_dim);
+        let mut last_obs = env.reset_joint(None);
+        let mut rng = StdRng::seed_from_u64(0);
+        let rollout = trainer.collect_rollout(&mut env, &mut last_obs, &mut rng);
+
+        assert_eq!(rollout.observations_per_agent.len(), num_agents);
+        for (i, buf) in rollout.observations_per_agent.iter().enumerate() {
+            assert_eq!(buf.len(), t * obs_dim, "obs buffer for agent {i} has wrong length");
+            // Expected per-step view for agent i: one-hot with slot `i` = 1.0.
+            let mut expected = vec![0.0_f32; obs_dim];
+            expected[i] = 1.0;
+            for step in 0..t {
+                let start = step * obs_dim;
+                let slice = &buf[start..start + obs_dim];
+                assert_eq!(
+                    slice,
+                    expected.as_slice(),
+                    "agent {i} step {step}: observation slice {:?} does not match agent {i}'s view {:?}",
+                    slice,
+                    expected,
+                );
+            }
+        }
     }
 }

--- a/src/multi_agent/nfsp.rs
+++ b/src/multi_agent/nfsp.rs
@@ -50,14 +50,17 @@
 //! held-items' distribution uniform across the entire history of
 //! pushes regardless of stream length.
 //!
-//! # Globally-shared observation assumption
+//! # Per-agent observation handling
 //!
 //! NFSP builds on top of
-//! [`crate::multi_agent::joint::JointMultiAgentTrainer`], which assumes
-//! every agent sees the same observation on every step (see
-//! [`JointRollout`]'s doc comment). Matching pennies and the
-//! bucket-brigade adapter both satisfy this; envs with distinct
-//! per-agent views must pre-concatenate before they can be wrapped.
+//! [`crate::multi_agent::joint::JointMultiAgentTrainer`], which records
+//! a *per-agent* observation stream in
+//! [`JointRollout::observations_per_agent`]. Agent `i`'s reservoir
+//! receives agent `i`'s observation (not agent 0's), so partial-
+//! observability envs supervise the AP module on the correct view.
+//! Matching pennies returns identical observations to both agents,
+//! which keeps the regression tests bit-stable through the per-agent
+//! refactor (PR #118).
 //!
 //! # Determinism dependency on #109
 //!
@@ -616,13 +619,15 @@ where
         let mut env = (self.env_factory)();
         let initial_obs = env.reset_joint(Some(self.config.seed));
         let obs_dim = initial_obs[0].len();
-        let mut last_obs = initial_obs[0].clone();
+        // Per-agent persistent observation: agent `i` carries its own view.
+        let mut last_obs: Vec<Vec<f32>> = initial_obs;
         let device = self.device.clone();
 
         // Probe num_action_dims from BR policy 0.
         let num_action_dims: usize = self.br_policy(0).action_dims_joint().len();
 
-        let mut obs_buf = vec![0.0_f32; num_steps * obs_dim];
+        let mut obs_buf_per_agent: Vec<Vec<f32>> =
+            (0..num_agents).map(|_| vec![0.0_f32; num_steps * obs_dim]).collect();
         let mut act_buf: Vec<Vec<i64>> =
             (0..num_agents).map(|_| vec![0_i64; num_steps * num_action_dims]).collect();
         let mut lp_buf: Vec<Vec<f32>> = (0..num_agents).map(|_| vec![0.0_f32; num_steps]).collect();
@@ -634,13 +639,17 @@ where
 
         for t in 0..num_steps {
             let start = t * obs_dim;
-            obs_buf[start..start + obs_dim].copy_from_slice(&last_obs);
-
-            let obs_t =
-                Tensor::<B, 2>::from_data(TensorData::new(last_obs.clone(), [1, obs_dim]), &device);
 
             let mut joint_action: Vec<Vec<i64>> = Vec::with_capacity(num_agents);
             for i in 0..num_agents {
+                // Per-agent observation: each agent sees its own view.
+                let agent_obs = last_obs[i].clone();
+                obs_buf_per_agent[i][start..start + obs_dim].copy_from_slice(&agent_obs);
+                let obs_t = Tensor::<B, 2>::from_data(
+                    TensorData::new(agent_obs.clone(), [1, obs_dim]),
+                    &device,
+                );
+
                 // Forward the BR policy unconditionally — we use its
                 // log-prob / value as the rollout-time bookkeeping for
                 // the PPO update regardless of which path provided the
@@ -661,8 +670,12 @@ where
                 let take_br = u < self.config.anticipatory_param;
                 let row: Vec<i64> = if take_br {
                     let row = br_actions[..num_action_dims].to_vec();
-                    // Reservoir push for the BR action only.
-                    self.reservoirs[i].push((last_obs.clone(), row[0]));
+                    // Reservoir push for the BR action only. Agent `i`'s
+                    // reservoir gets agent `i`'s observation — not agent
+                    // 0's — so partial-observability envs (PR #118
+                    // refactor) record the correct supervised target for
+                    // the behavior-cloning update.
+                    self.reservoirs[i].push((agent_obs.clone(), row[0]));
                     self.cumulative_br_pushes += 1;
                     row
                 } else {
@@ -671,7 +684,7 @@ where
                     // `self.rng` through the seeded sampler.
                     let ap_policy_i = self.avg_policy(i).clone();
                     let (ap_actions, _, _) =
-                        ap_policy_i.get_action_host_seeded(obs_t.clone(), &mut self.rng);
+                        ap_policy_i.get_action_host_seeded(obs_t, &mut self.rng);
                     ap_actions[..num_action_dims].to_vec()
                 };
 
@@ -695,7 +708,7 @@ where
 
             let result = env.step_joint(&joint_action);
             // Index-based scan: mirrors `JointMultiAgentTrainer::collect_rollout`'s
-            // per-agent reward fan-out at `joint.rs:533`.
+            // per-agent reward fan-out.
             #[allow(clippy::needless_range_loop)]
             for i in 0..num_agents {
                 rew_buf[i][t] = result.rewards[i];
@@ -704,15 +717,15 @@ where
 
             if result.done {
                 let fresh = env.reset_joint(None);
-                last_obs = fresh[0].clone();
+                last_obs[..num_agents].clone_from_slice(&fresh[..num_agents]);
             } else {
-                last_obs = result.observations[0].clone();
+                last_obs[..num_agents].clone_from_slice(&result.observations[..num_agents]);
             }
             self.cumulative_rollout_steps += 1;
         }
 
         Ok(JointRollout {
-            observations: obs_buf,
+            observations_per_agent: obs_buf_per_agent,
             obs_dim,
             actions: act_buf,
             num_action_dims,

--- a/src/multi_agent/psro.rs
+++ b/src/multi_agent/psro.rs
@@ -47,14 +47,16 @@
 //! for the full rationale and the deferred Option 1 (port the Python
 //! solver to Rust upstream).
 //!
-//! # Globally-shared observation assumption
+//! # Per-agent observation handling
 //!
 //! PSRO builds on top of
-//! [`crate::multi_agent::joint::JointMultiAgentTrainer`], which assumes
-//! every agent sees the same observation on every step (see
-//! [`JointRollout`]'s doc comment). Matching pennies and the
-//! bucket-brigade adapter both satisfy this; envs with distinct
-//! per-agent views must pre-concatenate before they can be wrapped.
+//! [`crate::multi_agent::joint::JointMultiAgentTrainer`], which records
+//! a *per-agent* observation stream in
+//! [`JointRollout::observations_per_agent`]. Envs with distinct
+//! per-agent views (partial observability, asymmetric information)
+//! drop in without pre-concatenation. Matching pennies returns
+//! identical observations to both agents, which keeps the regression
+//! tests bit-stable through the per-agent refactor (PR #118).
 //!
 //! # Population growth & cost
 //!
@@ -721,8 +723,8 @@ where
         // Run `br_train_steps_per_iteration` rollout/update cycles.
         let active_mask: Vec<bool> = (0..2).map(|i| i == active_agent).collect::<Vec<_>>();
         let mut env = (self.env_factory)();
-        let initial = env.reset_joint(Some(self.config.seed.wrapping_add(active_agent as u64)));
-        let mut last_obs = initial[0].clone();
+        let mut last_obs =
+            env.reset_joint(Some(self.config.seed.wrapping_add(active_agent as u64)));
 
         let mut last_stats = JointStats::zeros(2);
         for _ in 0..self.config.br_train_steps_per_iteration {
@@ -759,22 +761,31 @@ where
         let episodes = self.config.payoff_eval_episodes.max(1);
         for ep in 0..episodes {
             let seed = self.config.seed.wrapping_add(((row * 31 + col) * 53 + ep) as u64);
-            let obs_init = env.reset_joint(Some(seed));
-            let mut last_obs = obs_init[0].clone();
+            // Per-agent observation: each policy sees its own view of
+            // the env. The PR #118 refactor purges the shared-obs
+            // assumption from this evaluator so PR 2's N-player envs
+            // (which expose distinct per-agent views) drop in without
+            // further changes here.
+            let mut last_obs = env.reset_joint(Some(seed));
             let mut ep_return = 0.0_f64;
             // We don't expose rollout length on the env; cap at a
             // generous step bound and rely on the env's own `done` flag.
             for _ in 0..1024 {
-                let obs_t = burn::tensor::Tensor::<B, 2>::from_data(
-                    burn::tensor::TensorData::new(last_obs.clone(), [1, last_obs.len()]),
+                let obs_dim = last_obs[0].len();
+                let obs_t_row = burn::tensor::Tensor::<B, 2>::from_data(
+                    burn::tensor::TensorData::new(last_obs[0].clone(), [1, obs_dim]),
+                    &self.device,
+                );
+                let obs_t_col = burn::tensor::Tensor::<B, 2>::from_data(
+                    burn::tensor::TensorData::new(last_obs[1].clone(), [1, obs_dim]),
                     &self.device,
                 );
                 // Seeded sampling: thread the trainer-owned `StdRng`
                 // through both policies' `get_action_host_seeded` so
                 // `PsroConfig::seed` produces bit-identical
                 // exploitability curves across runs (issue #114).
-                let (a_row_host, _, _) = p_row.get_action_host_seeded(obs_t.clone(), &mut self.rng);
-                let (a_col_host, _, _) = p_col.get_action_host_seeded(obs_t, &mut self.rng);
+                let (a_row_host, _, _) = p_row.get_action_host_seeded(obs_t_row, &mut self.rng);
+                let (a_col_host, _, _) = p_col.get_action_host_seeded(obs_t_col, &mut self.rng);
                 let num_dims_row = p_row.action_dims_joint().len();
                 let num_dims_col = p_col.action_dims_joint().len();
                 let a_row = a_row_host[..num_dims_row].to_vec();
@@ -784,7 +795,8 @@ where
                 if res.done {
                     break;
                 }
-                last_obs = res.observations[0].clone();
+                last_obs[0] = res.observations[0].clone();
+                last_obs[1] = res.observations[1].clone();
             }
             total += ep_return;
         }
@@ -1169,8 +1181,7 @@ mod tests {
         let active_before = read_policy_weight(trainer.policy(1));
 
         let mut env = MatchingPennies::new();
-        let initial = env.reset_joint(None);
-        let mut last_obs = initial[0].clone();
+        let mut last_obs = env.reset_joint(None);
         let mut rng = StdRng::seed_from_u64(0);
         let rollout = trainer.collect_rollout(&mut env, &mut last_obs, &mut rng);
 


### PR DESCRIPTION
## Summary

Foundation PR (1/4) of the architect decomposition in #117. Replaces the globally-shared `JointRollout.observations: Vec<f32>` with per-agent buffers `observations_per_agent: Vec<Vec<f32>>`, so envs with distinct per-agent views (partial observability, asymmetric information) drop into `JointMultiAgentTrainer`, `NfspTrainer`, and `PsroTrainer` without pre-concatenation. This is the prerequisite refactor that unblocks #115 (bucket-brigade integration).

Internal refactor only; no public algorithmic changes, no new envs, no new training behavior on matching pennies (where all per-agent obs are identical -> bit-stable no-op).

Closes #118.

## Scope expansion (Curator finding)

The architect's proposal claimed the change was internal to `joint.rs` only. The Curator (see https://github.com/rjwalters/thrust/issues/118) caught **two additional sites** that re-implement the same shared-obs pattern and must be refactored in this PR for consistency:

1. **`src/multi_agent/nfsp.rs` `collect_anticipatory_rollout`** — NFSP's own rollout collector (interleaves eta-BR/AP mixing per step). Mirrors the per-agent obs handling. The reservoir push at the eta-BR path now records agent `i`'s observation instead of agent 0's — load-bearing for partial-observability envs in PR 3 (bucket-brigade adapter).
2. **`src/multi_agent/psro.rs` `evaluate_payoff`** — empirical-payoff matrix evaluator. Each policy now reads its own observation rather than sharing agent 0's view between row and column players.

Including these in PR 1 prevents a divergent per-agent-obs story across the trainers that PR 2/3 would otherwise have to fix. The scope expansion adds roughly 80 LOC beyond the joint.rs-only path.

## LOC delta vs architect's 600-800 estimate

```
 src/multi_agent/joint.rs | 199 +++++++++++++++++++++++++++++++++++++----------
 src/multi_agent/nfsp.rs  |  51 +++++++-----
 src/multi_agent/psro.rs  |  45 +++++++----
 3 files changed, 219 insertions(+), 76 deletions(-)
```

Total: **~295 LOC delta**, well under the architect's 600-800 estimate. The new regression test accounts for ~90 of the joint.rs insertions.

## Acceptance criteria (Curator-tightened, 11 items)

- [x] `JointRollout.observations: Vec<f32>` -> `observations_per_agent: Vec<Vec<f32>>` at `src/multi_agent/joint.rs`. Doc updated.
- [x] `collect_rollout` signature: `last_obs: &mut Vec<f32>` -> `last_obs: &mut [Vec<f32>]` (length = `num_agents`); per-agent obs read at fresh-rollout AND steady-state branches.
- [x] `update_with_active_agents` builds per-agent `obs_mb_per_agent[i]` and feeds it (not a shared `obs_mb`) into each policy's `evaluate_actions_joint` / `encoder_features_joint`.
- [x] `nfsp.rs collect_anticipatory_rollout` mirrors per-agent obs handling; reservoir push uses agent `i`'s obs, not agent 0's.
- [x] `psro.rs evaluate_pair` (a.k.a. `evaluate_payoff`) feeds per-policy obs tensors built from `last_obs[0]` / `last_obs[1]`.
- [x] `MatchingPennies` unchanged (already returns per-agent shape).
- [x] Existing integration tests pass unchanged: `test_psro_matching_pennies` (5/5 release runs, 2/2 tests each), `test_nfsp_matching_pennies` (5/5 release runs, 3/3 tests each).
- [x] Four internal joint.rs unit tests updated to pass the full `Vec<Vec<f32>>` from `env.reset_joint(None)`.
- [x] NEW regression test `test_collect_rollout_reads_per_agent_observations` constructs an env whose per-agent observations are distinct one-hots (agent `i` sees slot `i = 1.0`) and asserts the trainer reads agent `i`'s view for agent `i` at every timestep.
- [x] No public API changes beyond the documented internal-plumbing field/signature renames. `gh pr diff` shows only the JointRollout field rename, `collect_rollout` signature change, and the per-agent reads in nfsp.rs/psro.rs.
- [x] `cargo clippy --all-targets --features training -- -D warnings`: no new warnings in `multi_agent/` (pre-existing warnings on `main` in `env/games/`, `policy/inference.rs`, `buffer/`, `inference/` are unchanged).

## Regression evidence (5+ release-mode runs of each integration test)

Built once with `cargo build --release --features training --test test_psro_matching_pennies --test test_nfsp_matching_pennies`, then ran each 5x:

**PSRO** (`cargo test --release --features training --test test_psro_matching_pennies`):
```
=== Run 1 === 2 passed; 0 failed; finished in 16.72s
=== Run 2 === 2 passed; 0 failed; finished in 17.29s
=== Run 3 === 2 passed; 0 failed; finished in 17.90s
=== Run 4 === 2 passed; 0 failed; finished in 19.42s
=== Run 5 === 2 passed; 0 failed; finished in 19.01s
```

**NFSP** (`cargo test --release --features training --test test_nfsp_matching_pennies`):
```
=== Run 1 === 3 passed; 0 failed; finished in 13.74s
=== Run 2 === 3 passed; 0 failed; finished in 12.96s
=== Run 3 === 3 passed; 0 failed; finished in 11.14s
=== Run 4 === 3 passed; 0 failed; finished in 14.63s
=== Run 5 === 3 passed; 0 failed; finished in 15.23s
```

All 25 integration-test executions pass. No flakiness introduced — exactly as expected for matching pennies (all per-agent obs are equal so per-agent reads return the same values the shared read used to).

## Out of scope (deferred to PR 2/3/4)

- Algorithmic changes to PSRO or NFSP (PR 2's territory).
- Adding `NPlayerMatchingPennies` (PR 2).
- Bucket-brigade env adapter (PR 3).
- Removing the `num_agents == 2` guards in PSRO/NFSP (PR 2).

## Test plan

- [ ] Reviewer: read the per-agent obs slicing in `joint.rs:collect_rollout` and confirm the `last_obs[i]` / `result.observations[i]` reads are correct at both fresh-rollout reset and steady-state branches.
- [ ] Reviewer: read the reservoir push at `nfsp.rs:670` and confirm agent `i`'s reservoir receives `agent_obs.clone()` (agent `i`'s view), not the previous `last_obs.clone()` shared-view.
- [ ] Reviewer: read `psro.rs:evaluate_payoff` and confirm `obs_t_row` is built from `last_obs[0]` and `obs_t_col` from `last_obs[1]`.
- [ ] Optionally re-run `cargo test --release --features training --test test_psro_matching_pennies --test test_nfsp_matching_pennies` locally to confirm.

Closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)