### PR TITLE
Generalize NFSP reservoir to multi-discrete actions (closes #127)

### DIFF
--- a/examples/games/bucket_brigade/train_nfsp.rs
+++ b/examples/games/bucket_brigade/train_nfsp.rs
@@ -1,7 +1,7 @@
 //! NFSP bucket-brigade trainer on the no-convergence cells.
 //!
 //! Long-form training driver wired against `NfspTrainer` +
-//! `MlpBurnPolicy` (single-discrete) for the workshop-paper
+//! `MultiDiscreteMlpBurnPolicy` for the workshop-paper
 //! no-convergence regime. Default cell is canonical
 //! `(β=0.5, κ=0.1, c=0.5)`; override via `CELL=beta01|beta05|beta09`.
 //!
@@ -11,24 +11,17 @@
 //! Sibling of `examples/games/bucket_brigade/train_psro.rs`. PR 4/4
 //! of issue #117's bucket-brigade integration chain (closes #115).
 //!
-//! # Why a Cartesian-product single-discrete adapter
+//! # Factored multi-discrete policy (post-#127)
 //!
-//! `MultiDiscreteMlpBurnPolicy` is the natural fit for bucket-brigade's
-//! factored `[house, mode, signal]` action space — and PSRO uses that
-//! shape directly (see `train_psro.rs`). However, the post-#106 NFSP
-//! trainer's per-agent reservoir stores `(Vec<f32>, i64)` — a single
-//! scalar action — and its supervised AP-update path reshapes that
-//! scalar as a `[mb, 1]` int tensor before calling
-//! `policy.evaluate_actions_joint`. For a multi-discrete policy with
-//! `action_dims = [10, 2, 2]`, that shape causes a Burn `Squeeze` panic
-//! at the second per-dim slice.
-//!
-//! Until #127 (multi-discrete reservoirs) lands, this example
-//! Cartesian-product-flattens the action space into `Discrete(40)`
-//! (`= NUM_HOUSES * 2 * 2`) via the `SingleDiscreteBucketBrigade`
-//! wrapper — exactly the same shape `tests/test_nfsp_bucket_brigade.rs`
-//! (PR #126) uses. Once #127 ships, this example should switch back to
-//! the factored policy, matching the `train_psro.rs` shape.
+//! Per issue #127, NFSP's per-agent reservoir now stores
+//! `(Vec<f32>, Vec<i64>)` with one action entry per factored dim, and
+//! the supervised AP-update step builds an `[mb, num_action_dims]` int
+//! tensor before calling `policy.evaluate_actions_joint`. That lets
+//! this example drive bucket-brigade's factored
+//! `[house, mode, signal]` action space natively, matching the shape
+//! `train_psro.rs` already uses. Pre-#127 this example went through a
+//! Cartesian-product `Discrete(40)` wrapper (`= NUM_HOUSES * 2 * 2`) +
+//! `MlpBurnPolicy`; that workaround is removed.
 //!
 //! # Usage
 //!
@@ -74,10 +67,10 @@ use burn::{
 use thrust_rl::{
     env::games::bucket_brigade::{BucketBrigadeMaEnv, NUM_HOUSES, registry},
     multi_agent::{
-        JointEnv, JointStepResult, JointTrainerConfig, NfspConfig, NfspTrainer,
-        bucket_brigade_metrics::gap_closed,
+        JointTrainerConfig, NfspConfig, NfspTrainer, bucket_brigade_metrics::gap_closed,
+        joint::JointEnv,
     },
-    policy::mlp::MlpBurnPolicy,
+    policy::multi_discrete_mlp::MultiDiscreteMlpBurnPolicy,
     train::optimizer::BurnOptimizer,
 };
 
@@ -98,14 +91,14 @@ const SEED: u64 = 42;
 const DEFAULT_TOTAL_ITERATIONS: usize = 50;
 const DEFAULT_ROLLOUT_STEPS: usize = 2048;
 const DEFAULT_CELL: &str = "beta05";
-/// Cartesian-product cardinality `NUM_HOUSES * 2 (mode) * 2 (signal)`.
-/// Wrapping into a single-discrete dim lets us use `MlpBurnPolicy`
-/// instead of `MultiDiscreteMlpBurnPolicy`, sidestepping the NFSP
-/// multi-discrete reservoir gap (#127).
-const FLAT_ACTION_DIM: usize = NUM_HOUSES * 2 * 2;
 /// Length of the post-iteration deterministic eval rollout used to log
 /// running per-step team estimates.
 const EVAL_STEPS: usize = 200;
+
+/// Per-agent factored action cardinalities `[house, mode, signal]`.
+fn action_dims() -> Vec<usize> {
+    vec![NUM_HOUSES, 2, 2]
+}
 
 fn cell_params(cell: &str) -> (f32, f32, f32) {
     match cell {
@@ -125,57 +118,11 @@ fn make_cell_env(beta: f32, kappa: f32, cost: f32, seed: Option<u64>) -> BucketB
     BucketBrigadeMaEnv::new(scenario, NUM_AGENTS, seed)
 }
 
-/// Cartesian-product single-discrete adapter over [`BucketBrigadeMaEnv`].
-///
-/// Each per-agent action is a single scalar in `0..FLAT_ACTION_DIM`
-/// (`= NUM_HOUSES * 2 * 2 = 40`); the adapter decodes it as
-/// `house = a / 4`, `mode = (a / 2) % 2`, `signal = a % 2` and forwards
-/// the factored `[house, mode, signal]` triple to
-/// [`BucketBrigadeMaEnv::step_joint`]. Mirrors the wrapper inlined in
-/// `tests/test_nfsp_bucket_brigade.rs` (PR #126); kept inline here per
-/// the Curator's "examples self-contained at slight cost of duplication"
-/// guidance.
-struct SingleDiscreteBucketBrigade {
-    inner: BucketBrigadeMaEnv,
-}
-
-impl SingleDiscreteBucketBrigade {
-    fn new(inner: BucketBrigadeMaEnv) -> Self {
-        Self { inner }
-    }
-}
-
-impl JointEnv for SingleDiscreteBucketBrigade {
-    fn reset_joint(&mut self, seed: Option<u64>) -> Vec<Vec<f32>> {
-        self.inner.reset_joint(seed)
-    }
-
-    fn step_joint(&mut self, actions: &[Vec<i64>]) -> JointStepResult {
-        let factored: Vec<Vec<i64>> = actions
-            .iter()
-            .map(|a| {
-                assert_eq!(
-                    a.len(),
-                    1,
-                    "single-discrete adapter expects length-1 actions, got {}",
-                    a.len()
-                );
-                let v = a[0];
-                let signal = v % 2;
-                let mode = (v / 2) % 2;
-                let house = (v / 4) % NUM_HOUSES as i64;
-                vec![house, mode, signal]
-            })
-            .collect();
-        self.inner.step_joint(&factored)
-    }
-}
-
 /// Deterministic eval rollout on a fresh env using the supplied
 /// policies (one per agent). Returns mean per-step team reward over
 /// `EVAL_STEPS` steps.
 fn eval_per_step_team_reward(
-    policies: &[MlpBurnPolicy<B>],
+    policies: &[MultiDiscreteMlpBurnPolicy<B>],
     device: &burn::tensor::Device<InnerBackend>,
     obs_dim: usize,
     beta: f32,
@@ -184,8 +131,7 @@ fn eval_per_step_team_reward(
     seed_xor: u64,
 ) -> f32 {
     use rand::SeedableRng;
-    let mut env =
-        SingleDiscreteBucketBrigade::new(make_cell_env(beta, kappa, cost, Some(SEED ^ seed_xor)));
+    let mut env = make_cell_env(beta, kappa, cost, Some(SEED ^ seed_xor));
     let mut last_obs = env.reset_joint(Some(SEED ^ seed_xor));
     let mut total_team_reward: f32 = 0.0;
     let mut steps: usize = 0;
@@ -231,7 +177,10 @@ fn main() -> Result<()> {
     tracing::info!("  rollout_steps    = {rollout_steps}");
     tracing::info!("  num_agents       = {NUM_AGENTS}");
     tracing::info!("  hidden_dim       = {HIDDEN_DIM}");
-    tracing::info!("  flat_action_dim  = {FLAT_ACTION_DIM} (Cartesian-product wrapper; #127)");
+    tracing::info!(
+        "  action_dims      = {:?} (factored multi-discrete, native shape)",
+        action_dims()
+    );
 
     let device: burn::tensor::Device<InnerBackend> = Default::default();
 
@@ -259,20 +208,19 @@ fn main() -> Result<()> {
     };
 
     let policy_factory = move |dev: &burn::tensor::Device<InnerBackend>| {
-        MlpBurnPolicy::<B>::new(obs_dim, FLAT_ACTION_DIM, HIDDEN_DIM, dev)
+        MultiDiscreteMlpBurnPolicy::<B>::new(obs_dim, action_dims(), HIDDEN_DIM, dev)
     };
     let optimizer_factory = || {
         let inner = AdamConfig::new().init();
         BurnOptimizer::new(inner, 3e-4)
     };
-    let env_factory =
-        move || SingleDiscreteBucketBrigade::new(make_cell_env(beta, kappa, cost, Some(SEED)));
+    let env_factory = move || make_cell_env(beta, kappa, cost, Some(SEED));
 
     let mut trainer = NfspTrainer::<
         B,
-        MlpBurnPolicy<B>,
-        burn::optim::adaptor::OptimizerAdaptor<burn::optim::Adam, MlpBurnPolicy<B>, B>,
-        SingleDiscreteBucketBrigade,
+        MultiDiscreteMlpBurnPolicy<B>,
+        burn::optim::adaptor::OptimizerAdaptor<burn::optim::Adam, MultiDiscreteMlpBurnPolicy<B>, B>,
+        BucketBrigadeMaEnv,
         _,
         _,
         _,
@@ -324,9 +272,9 @@ fn main() -> Result<()> {
     let bin_recorder = BinFileRecorder::<FullPrecisionSettings>::new();
     let json_recorder = PrettyJsonFileRecorder::<FullPrecisionSettings>::new();
 
-    let final_brs: Vec<MlpBurnPolicy<B>> =
+    let final_brs: Vec<MultiDiscreteMlpBurnPolicy<B>> =
         (0..NUM_AGENTS).map(|i| trainer.br_policy(i).clone()).collect();
-    let final_aps: Vec<MlpBurnPolicy<B>> =
+    let final_aps: Vec<MultiDiscreteMlpBurnPolicy<B>> =
         (0..NUM_AGENTS).map(|i| trainer.avg_policy(i).clone()).collect();
 
     for (i, br) in final_brs.iter().enumerate() {

--- a/src/multi_agent/nfsp.rs
+++ b/src/multi_agent/nfsp.rs
@@ -377,8 +377,16 @@ where
     avg_policies: Vec<Option<P>>,
     /// Per-agent average-policy optimizer.
     avg_optimizers: Vec<BurnOptimizer<B, P, O>>,
-    /// Per-agent reservoir buffer of `(obs, action)` pairs.
-    reservoirs: Vec<ReservoirBuffer<(Vec<f32>, i64)>>,
+    /// Per-agent reservoir buffer of `(obs, action_vec)` pairs.
+    ///
+    /// `action_vec` is the per-step joint action with one entry per
+    /// action dim — `Vec<i64>` of length `num_action_dims`. For
+    /// single-discrete policies (`MlpBurnPolicy`) this is a length-1 vec
+    /// (equivalent to the pre-#127 scalar form); for multi-discrete
+    /// policies (`MultiDiscreteMlpBurnPolicy` — e.g. bucket-brigade
+    /// `[10, 2, 2]`) it carries one entry per factored head, matching
+    /// what `evaluate_actions_joint` expects (`[mb, num_action_dims]`).
+    reservoirs: Vec<ReservoirBuffer<(Vec<f32>, Vec<i64>)>>,
     /// Internal RNG (η-flips, AP minibatch sampling).
     rng: StdRng,
     /// Cumulative BR pushes across all agents (diagnostic).
@@ -486,7 +494,7 @@ where
     }
 
     /// Borrow agent `i`'s reservoir buffer.
-    pub fn reservoir(&self, i: usize) -> &ReservoirBuffer<(Vec<f32>, i64)> {
+    pub fn reservoir(&self, i: usize) -> &ReservoirBuffer<(Vec<f32>, Vec<i64>)> {
         &self.reservoirs[i]
     }
 
@@ -706,7 +714,17 @@ where
                     // 0's — so partial-observability envs (PR #118
                     // refactor) record the correct supervised target for
                     // the behavior-cloning update.
-                    self.reservoirs[i].push((agent_obs.clone(), row[0]));
+                    //
+                    // Push the full per-dim action vector (length
+                    // `num_action_dims`). For single-discrete policies
+                    // this is a length-1 vec; for multi-discrete
+                    // factored policies (e.g. bucket-brigade
+                    // `[10, 2, 2]`) it preserves the per-head action so
+                    // the supervised CE step in
+                    // `train_average_policies` can feed
+                    // `evaluate_actions_joint` a properly-shaped
+                    // `[mb, num_action_dims]` int tensor (issue #127).
+                    self.reservoirs[i].push((agent_obs.clone(), row.clone()));
                     self.cumulative_br_pushes += 1;
                     row
                 } else {
@@ -789,6 +807,14 @@ where
             if self.reservoirs[i].is_empty() {
                 continue;
             }
+            // Source-of-truth: probe `num_action_dims` from the BR
+            // policy for agent `i`. PR #103 / issue #127: the AP policy
+            // shares the same factored-action shape as the BR policy,
+            // and `evaluate_actions_joint` expects actions of shape
+            // `[mb, num_action_dims]` for both `MlpBurnPolicy`
+            // (length-1 columns) and `MultiDiscreteMlpBurnPolicy`
+            // (length-`num_action_dims` columns).
+            let num_action_dims = self.br_trainer.policy(i).action_dims_joint().len();
             let mut sum_loss = 0.0_f64;
             let mut n_steps_done = 0usize;
             for _ in 0..steps {
@@ -798,31 +824,58 @@ where
                 }
                 let obs_dim = batch[0].0.len();
                 let mb = batch.len();
-                // Flatten obs into [mb, obs_dim], actions into [mb].
+                // Flatten obs into [mb, obs_dim], actions into
+                // [mb, num_action_dims]. Each batch row's action vec
+                // must already have length `num_action_dims` — that
+                // invariant is established at push-time in
+                // `collect_anticipatory_rollout` (#127).
                 let mut obs_flat = Vec::with_capacity(mb * obs_dim);
-                let mut acts = Vec::with_capacity(mb);
+                let mut acts_flat = Vec::with_capacity(mb * num_action_dims);
                 for (o, a) in &batch {
+                    debug_assert_eq!(
+                        a.len(),
+                        num_action_dims,
+                        "reservoir action vec length {} != num_action_dims {} for agent {}",
+                        a.len(),
+                        num_action_dims,
+                        i
+                    );
                     obs_flat.extend_from_slice(o);
-                    acts.push(*a);
+                    acts_flat.extend_from_slice(a);
                 }
                 let obs_t = Tensor::<B, 2>::from_data(
                     TensorData::new(obs_flat, [mb, obs_dim]),
                     &self.device,
                 );
-                let acts_t: Tensor<B, 1, Int> =
-                    Tensor::<B, 1, Int>::from_data(TensorData::new(acts, [mb]), &self.device);
+                // Build the action tensor directly at shape
+                // `[mb, num_action_dims]` — no `unsqueeze_dim` step.
+                // For single-discrete (`MlpBurnPolicy`,
+                // `num_action_dims = 1`) this matches the prior
+                // shape exactly (the JointPolicy impl squeezes the
+                // trailing dim away). For multi-discrete
+                // (`MultiDiscreteMlpBurnPolicy`) this is required for
+                // the per-dim `slice([0..mb, i..i+1])` reads inside
+                // `evaluate_actions` to land in-bounds.
+                let acts_t: Tensor<B, 2, Int> = Tensor::<B, 2, Int>::from_data(
+                    TensorData::new(acts_flat, [mb, num_action_dims]),
+                    &self.device,
+                );
                 // Cross-entropy: -mean( log_softmax(logits)[gather(actions)] )
                 let policy = self.avg_policies[i]
                     .take()
                     .ok_or_else(|| anyhow!("AP policy {} is None mid-update", i))?;
-                let acts_2d = acts_t.unsqueeze_dim::<2>(1);
                 // We don't have a direct logits method on the
                 // JointPolicy trait — but for both
                 // `MlpBurnPolicy` and `MultiDiscreteMlpBurnPolicy` the
                 // evaluate_actions_joint path returns log-probs over
                 // the *taken* actions, which is exactly what
-                // cross-entropy needs. CE loss is the negative mean.
-                let (log_probs_taken, _, _) = policy.evaluate_actions_joint(obs_t, acts_2d);
+                // cross-entropy needs. For multi-discrete the returned
+                // log-prob is already the sum-across-dims (see
+                // `MultiDiscreteMlpBurnPolicy::evaluate_actions`), so
+                // `-mean(log_probs_taken)` IS the sum-of-per-head
+                // cross-entropy of a conditionally-independent factored
+                // distribution. No new `supervised_loss` method needed.
+                let (log_probs_taken, _, _) = policy.evaluate_actions_joint(obs_t, acts_t);
                 // Loss = -mean(log_probs_taken) → minimize.
                 let loss = log_probs_taken.neg().mean();
                 let loss_value = scalar_f64_avg_policy(loss.clone());
@@ -1329,9 +1382,11 @@ mod tests {
         )
         .expect("NfspTrainer::new should succeed");
 
-        // Seed reservoir 0 with a fixed dataset: all `(obs=[0.0], action=0)`.
+        // Seed reservoir 0 with a fixed dataset: all `(obs=[0.0], action=[0])`.
+        // Single-discrete callers wrap their scalar action in a length-1
+        // vec — the post-#127 reservoir contract.
         for _ in 0..64 {
-            trainer.reservoirs[0].push((vec![0.0_f32], 0));
+            trainer.reservoirs[0].push((vec![0.0_f32], vec![0]));
         }
         // Stage the supervised step manually a few times by setting
         // `avg_policy_train_steps_per_iteration` and calling the

--- a/tests/test_nfsp_bucket_brigade.rs
+++ b/tests/test_nfsp_bucket_brigade.rs
@@ -31,40 +31,23 @@
 //! `gap_closed_cell(_, Beta05) >= 0` assertion: any policy that does at
 //! least as well as uniform-random on this cell will satisfy it.
 //!
-//! # Why a Cartesian-product single-discrete adapter
+//! # Factored multi-discrete policy (post-#127)
 //!
-//! `MultiDiscreteMlpBurnPolicy` is the natural fit for bucket-brigade's
-//! factored `[house, mode, signal]` action space. However, the post-#106
-//! NFSP trainer's per-agent reservoir stores `(Vec<f32>, i64)` — a
-//! single scalar action — and its supervised AP-update path reshapes
-//! that scalar as a `[mb, 1]` int tensor before calling
-//! `policy.evaluate_actions_joint`. For a multi-discrete policy with
-//! `action_dims = [10, 2, 2]`, that shape causes a Burn `Squeeze` panic
-//! at the second per-dim slice. Closing that gap (multi-discrete
-//! reservoirs and per-dim AP updates) is a non-trivial extension to
-//! `NfspTrainer` that is out of scope for #120, which is supposed to
-//! deliver the *integration* (env adapter + metric + test wiring), not
-//! a trainer feature.
-//!
-//! The test therefore uses [`SingleDiscreteBucketBrigade`] — a local
-//! wrapper that Cartesian-product-flattens the bucket-brigade action
-//! space into a single-discrete `Discrete(40)` (`= NUM_HOUSES * 2 *
-//! 2`). The wrapper takes a scalar action per agent and decodes it
-//! into the factored `[house, mode, signal]` shape the underlying
-//! [`BucketBrigadeMaEnv`] expects, matching the
-//! `BucketBrigadeMaEnv::step` single-agent fallback at
-//! `src/env/games/bucket_brigade/env.rs:249–266`. This lets us drive
-//! the canonical cell through NFSP today, at the cost of a larger
-//! flat action space (40 vs the factored [10, 2, 2]); since this is a
-//! smoke-grade convergence check the cost is acceptable. Once NFSP
-//! grows multi-discrete reservoirs, this test should switch back to
-//! the factored policy.
+//! Per #127, NFSP's per-agent reservoir now stores `(Vec<f32>, Vec<i64>)`
+//! with one action entry per factored dim, and the supervised AP-update
+//! step builds an `[mb, num_action_dims]` int tensor before calling
+//! `policy.evaluate_actions_joint`. That lets us drive bucket-brigade's
+//! factored `[house, mode, signal]` action space through NFSP using
+//! [`MultiDiscreteMlpBurnPolicy`] directly — the same shape PSRO uses
+//! (see `train_psro.rs`). Pre-#127 this test went through a
+//! Cartesian-product `Discrete(40)` wrapper (`= NUM_HOUSES * 2 * 2`) +
+//! `MlpBurnPolicy`; that workaround is removed.
 //!
 //! # Cost gating
 //!
 //! Estimated wall-clock is ~10 seconds in release mode on the Burn
 //! NdArray (CPU) backend (4 NFSP outer iterations × 512 rollout steps ×
-//! 4 agents on a 47-d obs × `Discrete(40)` action space). The training
+//! 4 agents on a 47-d obs × `[10, 2, 2]` action space). The training
 //! budget is intentionally minimal because the cell is `no_convergence`
 //! by design (see the body of
 //! `test_nfsp_beats_ppo_on_canonical_no_convergence_cell` for the
@@ -83,9 +66,6 @@
 //! - PSRO wiring for the same cell — PR 4 / #121.
 //! - The full 3-cell `(no_convergence, mixed, converged)` sweep — #121.
 //! - `examples/games/bucket_brigade/train_*.rs` — #121.
-//! - NFSP multi-discrete reservoirs and per-dim AP updates — needs its own
-//!   follow-up issue (see "Why a Cartesian-product single-discrete adapter"
-//!   above).
 
 #![cfg(all(feature = "training", feature = "env-bucket-brigade"))]
 
@@ -97,11 +77,12 @@ use burn::{
 use thrust_rl::{
     env::games::bucket_brigade::{BucketBrigadeMaEnv, NUM_HOUSES, registry},
     multi_agent::{
-        JointEnv, JointStepResult, JointTrainerConfig, NfspConfig, NfspTrainer,
+        JointTrainerConfig, NfspConfig, NfspTrainer,
         bucket_brigade_baselines::BucketBrigadeCell,
         bucket_brigade_metrics::{gap_closed, gap_closed_cell},
+        joint::JointEnv,
     },
-    policy::mlp::MlpBurnPolicy,
+    policy::multi_discrete_mlp::MultiDiscreteMlpBurnPolicy,
     train::optimizer::BurnOptimizer,
 };
 
@@ -109,11 +90,6 @@ type B = Autodiff<NdArray<f32>>;
 
 const SEED: u64 = 42;
 const NUM_AGENTS: usize = 4;
-/// Cartesian-product cardinality `NUM_HOUSES * 2 (mode) * 2 (signal)`.
-/// Wrapping into a single-discrete dim lets us use `MlpBurnPolicy`
-/// instead of `MultiDiscreteMlpBurnPolicy`, which sidesteps the NFSP
-/// multi-discrete reservoir gap (see module docstring).
-const FLAT_ACTION_DIM: usize = NUM_HOUSES * 2 * 2;
 /// Number of NFSP outer iterations. Issue body nominally specified 12;
 /// we use 4 here because the cell is `no_convergence` by design and
 /// extra iterations do not change the test's outcome (we're smoke-
@@ -127,6 +103,15 @@ const ROLLOUT_STEPS: usize = 512;
 /// estimate `per_step_team`. The Python `analyze_291.py` uses K=200;
 /// we mirror that here.
 const EVAL_STEPS: usize = 200;
+/// Hidden dim of the multi-discrete MLP trunk.
+const HIDDEN_DIM: usize = 64;
+
+/// Per-agent factored action cardinalities `[house, mode, signal]`. Mirrors
+/// the bucket-brigade native multi-discrete shape (see
+/// `BucketBrigadeMaEnv::step` at `src/env/games/bucket_brigade/env.rs`).
+fn action_dims() -> Vec<usize> {
+    vec![NUM_HOUSES, 2, 2]
+}
 
 /// Build a fresh canonical-cell env. The base scenario is
 /// `minimal_specialization-v1`; we override the three phase-diagram
@@ -144,64 +129,21 @@ fn make_canonical_env(seed: Option<u64>) -> BucketBrigadeMaEnv {
     BucketBrigadeMaEnv::new(scenario, NUM_AGENTS, seed)
 }
 
-/// Cartesian-product single-discrete adapter over [`BucketBrigadeMaEnv`].
-///
-/// Each per-agent action is a single scalar in `0..FLAT_ACTION_DIM`
-/// (`= NUM_HOUSES * 2 * 2 = 40`); the adapter decodes it as
-/// `house = a / 4`, `mode = (a / 2) % 2`, `signal = a % 2` and forwards
-/// the factored `[house, mode, signal]` triple to
-/// [`BucketBrigadeMaEnv::step_joint`]. Mirrors the single-agent
-/// fallback decoding at `src/env/games/bucket_brigade/env.rs:249–266`.
-struct SingleDiscreteBucketBrigade {
-    inner: BucketBrigadeMaEnv,
-}
-
-impl SingleDiscreteBucketBrigade {
-    fn new(inner: BucketBrigadeMaEnv) -> Self {
-        Self { inner }
-    }
-}
-
-impl JointEnv for SingleDiscreteBucketBrigade {
-    fn reset_joint(&mut self, seed: Option<u64>) -> Vec<Vec<f32>> {
-        self.inner.reset_joint(seed)
-    }
-
-    fn step_joint(&mut self, actions: &[Vec<i64>]) -> JointStepResult {
-        let factored: Vec<Vec<i64>> = actions
-            .iter()
-            .map(|a| {
-                assert_eq!(
-                    a.len(),
-                    1,
-                    "single-discrete adapter expects length-1 actions, got {}",
-                    a.len()
-                );
-                let v = a[0];
-                let signal = v % 2;
-                let mode = (v / 2) % 2;
-                let house = (v / 4) % NUM_HOUSES as i64;
-                vec![house, mode, signal]
-            })
-            .collect();
-        self.inner.step_joint(&factored)
-    }
-}
-
 /// Deterministic post-training evaluation rollout: drives the trained
 /// BR policies on a fresh env for `EVAL_STEPS` steps and returns the
 /// mean per-step team reward (sum of per-agent rewards averaged over
 /// steps).
 fn eval_per_step_team_reward<F>(policies: F, device: &NdArrayDevice, obs_dim: usize) -> f32
 where
-    F: Fn(usize) -> MlpBurnPolicy<B>,
+    F: Fn(usize) -> MultiDiscreteMlpBurnPolicy<B>,
 {
     use rand::SeedableRng;
-    let mut env = SingleDiscreteBucketBrigade::new(make_canonical_env(Some(SEED ^ 0xEE1)));
+    let mut env = make_canonical_env(Some(SEED ^ 0xEE1));
     let mut last_obs = env.reset_joint(Some(SEED ^ 0xEE1));
     let mut total_team_reward: f32 = 0.0;
     let mut steps: usize = 0;
     let mut rng = rand::rngs::StdRng::seed_from_u64(SEED ^ 0xEE2);
+    let num_action_dims = action_dims().len();
 
     for _ in 0..EVAL_STEPS {
         // Build per-agent actions by querying each agent's BR policy on
@@ -216,7 +158,7 @@ where
             let obs_tensor =
                 Tensor::<B, 2>::from_data(TensorData::new(obs_row.clone(), [1, obs_dim]), device);
             let (acts, _, _) = policies(i).get_action_host_seeded(obs_tensor, &mut rng);
-            assert_eq!(acts.len(), 1);
+            assert_eq!(acts.len(), num_action_dims);
             joint_actions.push(acts);
         }
         let result = env.step_joint(&joint_actions);
@@ -237,13 +179,14 @@ where
 /// convergence assertion below.
 fn random_policy_per_step_team(seed_xor: u64) -> f32 {
     use rand::{Rng, SeedableRng};
-    let mut env = SingleDiscreteBucketBrigade::new(make_canonical_env(Some(SEED ^ seed_xor)));
+    let mut env = make_canonical_env(Some(SEED ^ seed_xor));
     let _ = env.reset_joint(Some(SEED ^ seed_xor));
     let mut rng = rand::rngs::StdRng::seed_from_u64(SEED ^ seed_xor.wrapping_add(1));
     let mut total_team_reward: f32 = 0.0;
+    let dims = action_dims();
     for _ in 0..EVAL_STEPS {
         let actions: Vec<Vec<i64>> = (0..NUM_AGENTS)
-            .map(|_| vec![rng.random_range(0..FLAT_ACTION_DIM as i64)])
+            .map(|_| dims.iter().map(|&d| rng.random_range(0..d as i64)).collect::<Vec<i64>>())
             .collect();
         let res = env.step_joint(&actions);
         total_team_reward += res.rewards.iter().sum::<f32>();
@@ -317,8 +260,10 @@ fn test_nfsp_beats_ppo_on_canonical_no_convergence_cell() {
     let probe_env = make_canonical_env(Some(SEED));
     let obs_dim = probe_env.obs_dim();
     println!(
-        "bucket-brigade canonical cell: obs_dim = {}, flat_action_dim = {}, num_agents = {}",
-        obs_dim, FLAT_ACTION_DIM, NUM_AGENTS
+        "bucket-brigade canonical cell: obs_dim = {}, action_dims = {:?}, num_agents = {}",
+        obs_dim,
+        action_dims(),
+        NUM_AGENTS
     );
 
     let nfsp_config = NfspConfig {
@@ -339,19 +284,20 @@ fn test_nfsp_beats_ppo_on_canonical_no_convergence_cell() {
         ..Default::default()
     };
 
-    let policy_factory =
-        move |dev: &NdArrayDevice| MlpBurnPolicy::<B>::new(obs_dim, FLAT_ACTION_DIM, 64, dev);
+    let policy_factory = move |dev: &NdArrayDevice| {
+        MultiDiscreteMlpBurnPolicy::<B>::new(obs_dim, action_dims(), HIDDEN_DIM, dev)
+    };
     let optimizer_factory = || {
         let inner = AdamConfig::new().init();
         BurnOptimizer::new(inner, 3e-4)
     };
-    let env_factory = || SingleDiscreteBucketBrigade::new(make_canonical_env(Some(SEED)));
+    let env_factory = || make_canonical_env(Some(SEED));
 
     let mut trainer = NfspTrainer::<
         B,
-        MlpBurnPolicy<B>,
-        burn::optim::adaptor::OptimizerAdaptor<burn::optim::Adam, MlpBurnPolicy<B>, B>,
-        SingleDiscreteBucketBrigade,
+        MultiDiscreteMlpBurnPolicy<B>,
+        burn::optim::adaptor::OptimizerAdaptor<burn::optim::Adam, MultiDiscreteMlpBurnPolicy<B>, B>,
+        BucketBrigadeMaEnv,
         _,
         _,
         _,
@@ -370,7 +316,7 @@ fn test_nfsp_beats_ppo_on_canonical_no_convergence_cell() {
 
     // Post-training evaluation. We clone each BR policy out of the
     // trainer and drive a fresh env for `EVAL_STEPS` steps.
-    let cloned_brs: Vec<MlpBurnPolicy<B>> =
+    let cloned_brs: Vec<MultiDiscreteMlpBurnPolicy<B>> =
         (0..NUM_AGENTS).map(|i| trainer.br_policy(i).clone()).collect();
     let per_step_team = eval_per_step_team_reward(|i| cloned_brs[i].clone(), &device, obs_dim);
     let gc_cell = gap_closed_cell(per_step_team, BucketBrigadeCell::Beta05);

--- a/tests/test_nfsp_multi_discrete_smoke.rs
+++ b/tests/test_nfsp_multi_discrete_smoke.rs
@@ -1,0 +1,244 @@
+//! NFSP multi-discrete smoke test (issue #127).
+//!
+//! Verifies that the post-#127 NFSP trainer can drive a
+//! `MultiDiscreteMlpBurnPolicy` end-to-end on a small factored env
+//! without panicking. The pre-#127 trainer would panic at the
+//! supervised AP-update step because it built the actions tensor at
+//! shape `[mb, 1]` regardless of `num_action_dims`, which caused the
+//! `MultiDiscreteMlpBurnPolicy::evaluate_actions` per-dim slice
+//! `actions.slice([0..mb, i..i+1])` to go out of bounds when
+//! `num_action_dims > 1`.
+//!
+//! # Env
+//!
+//! A minimal 2-agent toy env with `action_dims = [2, 3]` (factored
+//! multi-discrete) and a 1-d agent-index observation. The reward is a
+//! deterministic function of the joint action; the env's only job is to
+//! exercise the multi-discrete reservoir / supervised-loss path through
+//! the trainer.
+//!
+//! # Assertions
+//!
+//! 1. NFSP runs 2 outer iterations without panicking.
+//! 2. Reservoirs grow under non-zero η (≥ 0 entries after the run, and
+//!    `cumulative_br_pushes > 0` at η = 0.5).
+//! 3. Reservoir entries carry length-2 action vectors (`num_action_dims`
+//!    matches `MultiDiscreteMlpBurnPolicy::action_dims_joint`).
+//! 4. Supervised AP losses are finite for every iteration where the reservoir
+//!    was non-empty.
+
+#![cfg(feature = "training")]
+
+use burn::{
+    backend::{Autodiff, NdArray, ndarray::NdArrayDevice},
+    optim::AdamConfig,
+};
+use thrust_rl::{
+    multi_agent::{
+        JointTrainerConfig, NfspConfig, NfspTrainer,
+        joint::{JointEnv, JointPolicy, JointStepResult},
+    },
+    policy::multi_discrete_mlp::MultiDiscreteMlpBurnPolicy,
+    train::optimizer::BurnOptimizer,
+};
+
+type B = Autodiff<NdArray<f32>>;
+
+const OBS_DIM: usize = 1;
+const NUM_AGENTS: usize = 2;
+const HIDDEN_DIM: usize = 8;
+/// Factored action cardinalities. Length > 1 is the regression target —
+/// the pre-#127 trainer panicked for any `num_action_dims > 1`.
+const ACTION_DIMS: [usize; 2] = [2, 3];
+
+/// Minimal 2-agent factored-action env. Each `step_joint` returns a
+/// deterministic per-agent reward derived from the joint action and
+/// terminates after [`EPISODE_LEN`] steps.
+#[derive(Debug, Clone)]
+struct ToyMultiDiscreteEnv {
+    step_idx: usize,
+}
+
+impl ToyMultiDiscreteEnv {
+    const EPISODE_LEN: usize = 8;
+
+    fn new() -> Self {
+        Self { step_idx: 0 }
+    }
+
+    fn per_agent_obs() -> Vec<Vec<f32>> {
+        (0..NUM_AGENTS)
+            .map(|i| vec![i as f32 / (NUM_AGENTS.saturating_sub(1).max(1)) as f32])
+            .collect()
+    }
+}
+
+impl JointEnv for ToyMultiDiscreteEnv {
+    fn reset_joint(&mut self, _seed: Option<u64>) -> Vec<Vec<f32>> {
+        self.step_idx = 0;
+        Self::per_agent_obs()
+    }
+
+    fn step_joint(&mut self, actions: &[Vec<i64>]) -> JointStepResult {
+        debug_assert_eq!(actions.len(), NUM_AGENTS);
+        for (i, a) in actions.iter().enumerate() {
+            debug_assert_eq!(
+                a.len(),
+                ACTION_DIMS.len(),
+                "agent {i} must supply a {}-d action vec, got {}",
+                ACTION_DIMS.len(),
+                a.len()
+            );
+            for (d, &v) in a.iter().enumerate() {
+                debug_assert!(
+                    v >= 0 && (v as usize) < ACTION_DIMS[d],
+                    "agent {i} action dim {d} out of range [0, {})",
+                    ACTION_DIMS[d]
+                );
+            }
+        }
+
+        // Reward: small deterministic function of own action coordinates.
+        let rewards: Vec<f32> = actions
+            .iter()
+            .map(|a| {
+                let head = a[0] as f32;
+                let body = a[1] as f32;
+                // Rewards favor (1, 2) for both agents — a symmetric
+                // optimum. The exact shape doesn't matter for the
+                // smoke test; what matters is that NFSP can complete
+                // its outer loop with a multi-discrete policy.
+                head * 0.5 + body * 0.25
+            })
+            .collect();
+
+        self.step_idx += 1;
+        let done = self.step_idx >= Self::EPISODE_LEN;
+        JointStepResult { rewards, done, observations: Self::per_agent_obs() }
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn build_trainer(
+    eta: f32,
+    max_iterations: usize,
+    seed: u64,
+) -> NfspTrainer<
+    B,
+    MultiDiscreteMlpBurnPolicy<B>,
+    burn::optim::adaptor::OptimizerAdaptor<burn::optim::Adam, MultiDiscreteMlpBurnPolicy<B>, B>,
+    ToyMultiDiscreteEnv,
+    impl Fn(&NdArrayDevice) -> MultiDiscreteMlpBurnPolicy<B>,
+    impl Fn() -> BurnOptimizer<
+        B,
+        MultiDiscreteMlpBurnPolicy<B>,
+        burn::optim::adaptor::OptimizerAdaptor<burn::optim::Adam, MultiDiscreteMlpBurnPolicy<B>, B>,
+    >,
+    impl Fn() -> ToyMultiDiscreteEnv,
+> {
+    let device: NdArrayDevice = Default::default();
+    let nfsp_config = NfspConfig {
+        max_iterations,
+        anticipatory_param: eta,
+        reservoir_capacity: 1_024,
+        br_train_steps_per_iteration: 1,
+        avg_policy_train_steps_per_iteration: 4,
+        avg_policy_minibatch_size: 16,
+        avg_policy_lr: 5e-3,
+        seed,
+    };
+    let joint_config = JointTrainerConfig {
+        num_agents: NUM_AGENTS,
+        rollout_steps: 64,
+        n_epochs: 1,
+        minibatch_size: 32,
+        ..Default::default()
+    };
+    NfspTrainer::new(
+        nfsp_config,
+        joint_config,
+        device,
+        |dev: &NdArrayDevice| {
+            MultiDiscreteMlpBurnPolicy::<B>::new(OBS_DIM, ACTION_DIMS.to_vec(), HIDDEN_DIM, dev)
+        },
+        || {
+            let inner = AdamConfig::new().init();
+            BurnOptimizer::new(inner, 5e-3)
+        },
+        ToyMultiDiscreteEnv::new,
+    )
+    .expect("NfspTrainer::new should succeed for multi-discrete policy")
+}
+
+/// Primary regression: NFSP outer loop with a multi-discrete policy
+/// runs 2 iterations end-to-end without panicking. The pre-#127
+/// trainer panicked inside `train_average_policies` on the very first
+/// non-empty AP step.
+#[test]
+fn test_nfsp_multi_discrete_runs_without_panic() {
+    let mut trainer = build_trainer(0.5, 2, 7);
+    let stats = trainer
+        .run_silent()
+        .expect("NFSP run with multi-discrete policy must not error");
+    assert_eq!(stats.iterations.len(), 2, "expected 2 outer iterations");
+
+    // Reservoirs grew (η = 0.5 → ~50% of rollout steps push).
+    let total_pushes: usize = trainer.cumulative_br_pushes();
+    assert!(
+        total_pushes > 0,
+        "expected non-zero BR pushes at η=0.5 over 2 iter × 64 rollout × {NUM_AGENTS} agents, got 0"
+    );
+
+    // Reservoir entries carry length-`ACTION_DIMS.len()` action vecs.
+    let expected_num_dims = ACTION_DIMS.len();
+    for i in 0..NUM_AGENTS {
+        let reservoir = trainer.reservoir(i);
+        if !reservoir.is_empty() {
+            for (k, (_, a)) in reservoir.items().iter().enumerate() {
+                assert_eq!(
+                    a.len(),
+                    expected_num_dims,
+                    "agent {i} reservoir item {k}: action vec length {} != num_action_dims {}",
+                    a.len(),
+                    expected_num_dims
+                );
+                // Each component must be in-range for its dim.
+                for (d, &v) in a.iter().enumerate() {
+                    assert!(
+                        v >= 0 && (v as usize) < ACTION_DIMS[d],
+                        "agent {i} reservoir item {k} dim {d}: action {} out of range [0, {})",
+                        v,
+                        ACTION_DIMS[d]
+                    );
+                }
+            }
+        }
+    }
+
+    // Supervised AP losses, when present, are finite. (`None` is
+    // allowed for an iteration where the reservoir was empty.)
+    for (k, it) in stats.iterations.iter().enumerate() {
+        for (i, loss) in it.avg_policy_loss.iter().enumerate() {
+            if let Some(l) = loss {
+                assert!(l.is_finite(), "iter {} agent {i} AP loss must be finite, got {l}", k + 1);
+            }
+        }
+    }
+}
+
+/// Probes the BR policy's reported `action_dims_joint()` and confirms
+/// it matches the factored shape passed at construction. This is the
+/// source of truth `train_average_policies` uses to size its actions
+/// tensor.
+#[test]
+fn test_multi_discrete_policy_action_dims_match_construction() {
+    let trainer = build_trainer(0.5, 1, 11);
+    for i in 0..NUM_AGENTS {
+        let dims = trainer.br_policy(i).action_dims_joint();
+        let expected: Vec<i64> = ACTION_DIMS.iter().map(|&d| d as i64).collect();
+        assert_eq!(
+            dims, expected,
+            "agent {i} action_dims_joint mismatch: got {dims:?}, expected {expected:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Generalizes the NFSP trainer's per-agent reservoir from `(Vec<f32>, i64)` to `(Vec<f32>, Vec<i64>)` so it can drive `MultiDiscreteMlpBurnPolicy` end-to-end, then removes the Cartesian-product `Discrete(40)` workarounds in the bucket-brigade test and example.

Closes #127.

## Root cause and fix

Three localized fixes in `src/multi_agent/nfsp.rs`:

1. **Reservoir storage** (`nfsp.rs:381,498`): `(Vec<f32>, i64)` → `(Vec<f32>, Vec<i64>)`. Single-discrete callers pass a length-1 vec (bit-identical to the scalar form).
2. **Rollout push** (`nfsp.rs:709`): `row[0]` → `row.clone()` — push the full per-dim action vec into the reservoir.
3. **AP supervised step** (`nfsp.rs:799-825`): probe `num_action_dims` from `policy.action_dims_joint()` and build the actions tensor directly at shape `[mb, num_action_dims]` — no `unsqueeze_dim` step. For single-discrete (`MlpBurnPolicy`) this matches the prior shape exactly via the existing `JointPolicy` impl's trailing-dim squeeze; for multi-discrete (`MultiDiscreteMlpBurnPolicy`) this is now in-bounds for every per-dim slice.

The existing `-mean(log_probs_taken)` idiom in `train_average_policies` is already sum-of-per-head cross-entropy under multi-discrete's summed-log-prob contract — no new `supervised_loss` method needed.

## Scope removals (Cartesian wrappers)

- `tests/test_nfsp_bucket_brigade.rs`: `SingleDiscreteBucketBrigade` wrapper + `FLAT_ACTION_DIM` constant removed. Test now drives `MultiDiscreteMlpBurnPolicy` with `action_dims = [NUM_HOUSES, 2, 2]` against `BucketBrigadeMaEnv` directly. Soft-loosened convergence assertion preserved.
- `examples/games/bucket_brigade/train_nfsp.rs`: same removal. Example now mirrors `train_psro.rs`'s factored shape.

## New regression test

`tests/test_nfsp_multi_discrete_smoke.rs` — a tiny 2-agent toy env with `action_dims = [2, 3]` exercises the multi-discrete reservoir + supervised-loss path. The pre-#127 trainer panicked here on the first AP step; the post-fix trainer runs 2 outer iterations cleanly with finite AP losses and length-2 reservoir action vecs.

## Test plan

- [x] `cargo test --features training --lib nfsp` — 17/17 pass (380s)
- [x] `cargo test --release --features training --test test_nfsp_matching_pennies` — 3/3 pass (run 3x: 15.2s, 13.4s, 13.3s)
- [x] `cargo test --release --features training --test test_nfsp_n_player_matching_pennies` — 2/2 pass (run 3x: 19.2s, 19.6s, 17.2s)
- [x] `cargo test --release --features training --test test_nfsp_multi_discrete_smoke` — 2/2 pass (run 3x: 0.20s, 0.19s, 0.22s — no flakiness)
- [x] `cargo test --features "training,env-bucket-brigade" --test test_nfsp_bucket_brigade --no-run` — compiles
- [x] `cargo check --release --features "training,env-bucket-brigade" --example train_nfsp` — clean
- [x] `cargo fmt --all -- --check` — clean

### Bit-identity evidence (single-discrete)

`Vec<i64>` of length 1 is the degenerate case of the scalar form: same RNG draws (η-flip seed unchanged), same flatten order (`extend_from_slice(&[a])` ≡ `push(a)`), and the `JointPolicy` impl for `MlpBurnPolicy` squeezes the trailing dim of `[mb, 1]` back to `[mb]` before calling the legacy `evaluate_actions`. The 3× release-mode runs of the single-discrete regression tests above hold both the **convergence bars** (AP marginal TV ≤ 0.05 vs uniform after 10 iters for N=4 majority game; matcher/mismatcher BR-vs-AP oscillation for 2-player) and the **η-mixing-rate concentration bars** that are deterministic functions of the seed only.

### Pre-existing failures (out of scope)

- `cargo clippy --all-targets --features "training,env-bucket-brigade" -- -D warnings` reports 64 errors, but they're all in pre-existing source files I did not touch: `src/env/games/{cartpole,snake}.rs`, `src/env/games/snake/environment.rs`, `src/env/mod.rs`, `src/policy/{inference,mlp}.rs`, `src/buffer/rollout/{sampling,tests}.rs`. None of my modified files (`src/multi_agent/nfsp.rs`, `tests/test_nfsp_*`, `examples/games/bucket_brigade/train_nfsp.rs`) trigger any clippy warnings.

### Acceptance criteria coverage

- AC 1-3 (Group A — reservoir generalization): ✅ `(Vec<f32>, Vec<i64>)` storage; push uses `row.clone()`; existing single-discrete callers store length-1 vecs in lib tests.
- AC 4-6 (Group B — supervised-loss shape): ✅ `acts_t` is now `[mb, num_action_dims]` directly via `Tensor::<B, 2, Int>::from_data(... [mb, num_action_dims])`. Single-discrete bit-identical via `JointPolicy` impl's squeeze (regression bar evidence above).
- AC 7-8 (Group C — Cartesian wrapper removal): ✅ Both removed; `#127` references dropped.
- AC 9 (Group D — new smoke test): ✅ `tests/test_nfsp_multi_discrete_smoke.rs` exercises `[2, 3]` toy env; asserts non-panic + finite losses + correct reservoir action-vec length.
- AC 10-11 (Group E — regression bar): ✅ 3× release-mode runs of both single-discrete tests.
- Group F verification: ✅ tests pass; example + bucket-brigade test compile; fmt clean. (Clippy noise is pre-existing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)