### PR TITLE
Seed policy init end-to-end for bit-exact PSRO/NFSP reproducibility

### DIFF
--- a/examples/games/bucket_brigade/train_nfsp.rs
+++ b/examples/games/bucket_brigade/train_nfsp.rs
@@ -207,8 +207,8 @@ fn main() -> Result<()> {
         ..Default::default()
     };
 
-    let policy_factory = move |dev: &burn::tensor::Device<InnerBackend>| {
-        MultiDiscreteMlpBurnPolicy::<B>::new(obs_dim, action_dims(), HIDDEN_DIM, dev)
+    let policy_factory = move |dev: &burn::tensor::Device<InnerBackend>, seed: u64| {
+        MultiDiscreteMlpBurnPolicy::<B>::new_seeded(obs_dim, action_dims(), HIDDEN_DIM, seed, dev)
     };
     let optimizer_factory = || {
         let inner = AdamConfig::new().init();

--- a/examples/games/bucket_brigade/train_psro.rs
+++ b/examples/games/bucket_brigade/train_psro.rs
@@ -214,8 +214,14 @@ fn main() -> Result<()> {
     };
     let meta_solver: Box<dyn MetaSolver> = Box::new(AlphaRankMetaSolver::default());
 
-    let policy_factory = move |dev: &burn::tensor::Device<InnerBackend>| {
-        MultiDiscreteMlpBurnPolicy::<B>::new(obs_dim, vec![NUM_HOUSES, 2, 2], HIDDEN_DIM, dev)
+    let policy_factory = move |dev: &burn::tensor::Device<InnerBackend>, seed: u64| {
+        MultiDiscreteMlpBurnPolicy::<B>::new_seeded(
+            obs_dim,
+            vec![NUM_HOUSES, 2, 2],
+            HIDDEN_DIM,
+            seed,
+            dev,
+        )
     };
     let optimizer_factory = || {
         let inner = AdamConfig::new().init();

--- a/examples/games/cartpole/train_cartpole_modern.rs
+++ b/examples/games/cartpole/train_cartpole_modern.rs
@@ -104,6 +104,7 @@ fn main() -> Result<()> {
         hidden_dim: HIDDEN_DIM,
         use_orthogonal_init: true,
         activation: BurnActivation::ReLU,
+        seed: None,
     };
     let policy = MlpBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
 

--- a/examples/games/pong/eval_pong.rs
+++ b/examples/games/pong/eval_pong.rs
@@ -111,6 +111,7 @@ fn main() -> Result<()> {
             hidden_dim: HIDDEN_DIM,
             use_orthogonal_init: true,
             activation: BurnActivation::Tanh,
+            seed: None,
         };
         // Construct a blank policy with the same architecture, then load
         // the recorded record into it. `load_file` will append `.bin` so

--- a/examples/games/pong/train_pong_self_play.rs
+++ b/examples/games/pong/train_pong_self_play.rs
@@ -122,6 +122,7 @@ fn main() -> Result<()> {
         hidden_dim: HIDDEN_DIM,
         use_orthogonal_init: true,
         activation: BurnActivation::Tanh,
+        seed: None,
     };
     let policy = MlpBurnPolicy::<B>::with_config(obs_dim, action_dim, policy_config, &device);
 

--- a/src/multi_agent/nfsp.rs
+++ b/src/multi_agent/nfsp.rs
@@ -362,7 +362,7 @@ where
     P: JointPolicy<B>,
     O: Optimizer<P, B>,
     E: JointEnv,
-    FP: Fn(&B::Device) -> P,
+    FP: Fn(&B::Device, u64) -> P,
     FO: Fn() -> BurnOptimizer<B, P, O>,
     FE: Fn() -> E,
 {
@@ -409,7 +409,7 @@ where
     P: JointPolicy<B>,
     O: Optimizer<P, B>,
     E: JointEnv,
-    FP: Fn(&B::Device) -> P,
+    FP: Fn(&B::Device, u64) -> P,
     FO: Fn() -> BurnOptimizer<B, P, O>,
     FE: Fn() -> E,
 {
@@ -442,7 +442,16 @@ where
             ));
         }
         let num_agents = joint_config.num_agents;
-        let br_policies: Vec<P> = (0..num_agents).map(|_| policy_factory(&device)).collect();
+        // Per-construction init seeds (issue #135, Correction 1): every
+        // BR and AP policy gets a distinct, deterministic seed derived
+        // from `config.seed` so they start from different — but
+        // reproducible — weights. A factory closing over a single fixed
+        // seed would otherwise hand every policy identical weights. BR
+        // policies use counter `agent`; AP policies use
+        // `num_agents + agent`, keeping the two banks disjoint.
+        let init_seed = |idx: u64| config.seed.wrapping_add(0x9E37_79B9_u64.wrapping_mul(idx));
+        let br_policies: Vec<P> =
+            (0..num_agents).map(|i| policy_factory(&device, init_seed(i as u64))).collect();
         let br_optimizers: Vec<BurnOptimizer<B, P, O>> =
             (0..num_agents).map(|_| optimizer_factory()).collect();
         let br_trainer = JointMultiAgentTrainer::<B, P, O>::new(
@@ -451,8 +460,9 @@ where
             joint_config.clone(),
             device.clone(),
         )?;
-        let avg_policies: Vec<Option<P>> =
-            (0..num_agents).map(|_| Some(policy_factory(&device))).collect();
+        let avg_policies: Vec<Option<P>> = (0..num_agents)
+            .map(|i| Some(policy_factory(&device, init_seed((num_agents + i) as u64))))
+            .collect();
         let avg_optimizers: Vec<BurnOptimizer<B, P, O>> =
             (0..num_agents).map(|_| optimizer_factory()).collect();
         let reservoirs = (0..num_agents)
@@ -1117,7 +1127,7 @@ mod tests {
         MlpBurnPolicy<B>,
         burn::optim::adaptor::OptimizerAdaptor<burn::optim::Adam, MlpBurnPolicy<B>, B>,
         MatchingPennies,
-        impl Fn(&NdArrayDevice) -> MlpBurnPolicy<B>,
+        impl Fn(&NdArrayDevice, u64) -> MlpBurnPolicy<B>,
         impl Fn() -> BurnOptimizer<
             B,
             MlpBurnPolicy<B>,
@@ -1147,11 +1157,12 @@ mod tests {
             nfsp_config,
             joint_config,
             device,
-            |dev: &NdArrayDevice| {
-                MlpBurnPolicy::<B>::new(
+            |dev: &NdArrayDevice, seed: u64| {
+                MlpBurnPolicy::<B>::new_seeded(
                     MatchingPennies::OBS_DIM,
                     MatchingPennies::ACTION_DIM,
                     16,
+                    seed,
                     dev,
                 )
             },
@@ -1182,7 +1193,7 @@ mod tests {
             nfsp_config,
             joint_config,
             device,
-            |dev: &NdArrayDevice| MlpBurnPolicy::<B>::new(1, 2, 8, dev),
+            |dev: &NdArrayDevice, seed: u64| MlpBurnPolicy::<B>::new_seeded(1, 2, 8, seed, dev),
             || BurnOptimizer::new(AdamConfig::new().init(), 1e-3),
             MatchingPennies::new,
         );
@@ -1210,11 +1221,12 @@ mod tests {
             nfsp_config,
             joint_config,
             device,
-            |dev: &NdArrayDevice| {
-                MlpBurnPolicy::<B>::new(
+            |dev: &NdArrayDevice, seed: u64| {
+                MlpBurnPolicy::<B>::new_seeded(
                     NPlayerMatchingPennies::OBS_DIM,
                     NPlayerMatchingPennies::ACTION_DIM,
                     8,
+                    seed,
                     dev,
                 )
             },
@@ -1244,7 +1256,7 @@ mod tests {
             nfsp_config,
             joint_config,
             device,
-            |dev: &NdArrayDevice| MlpBurnPolicy::<B>::new(1, 2, 8, dev),
+            |dev: &NdArrayDevice, seed: u64| MlpBurnPolicy::<B>::new_seeded(1, 2, 8, seed, dev),
             || BurnOptimizer::new(AdamConfig::new().init(), 1e-3),
             MatchingPennies::new,
         );
@@ -1325,11 +1337,12 @@ mod tests {
             nfsp_config,
             joint_config,
             device,
-            |dev: &NdArrayDevice| {
-                MlpBurnPolicy::<B>::new(
+            |dev: &NdArrayDevice, seed: u64| {
+                MlpBurnPolicy::<B>::new_seeded(
                     MatchingPennies::OBS_DIM,
                     MatchingPennies::ACTION_DIM,
                     16,
+                    seed,
                     dev,
                 )
             },
@@ -1376,7 +1389,7 @@ mod tests {
             nfsp_config,
             joint_config,
             device,
-            |dev: &NdArrayDevice| MlpBurnPolicy::<B>::new(1, 2, 8, dev),
+            |dev: &NdArrayDevice, seed: u64| MlpBurnPolicy::<B>::new_seeded(1, 2, 8, seed, dev),
             || BurnOptimizer::new(AdamConfig::new().init(), 5e-2),
             MatchingPennies::new,
         )

--- a/src/multi_agent/psro.rs
+++ b/src/multi_agent/psro.rs
@@ -1112,14 +1112,13 @@ impl PayoffCache {
 /// The trainer doesn't know how to construct a Burn module of the
 /// caller's chosen architecture, so we take closures:
 ///
-/// - `policy_factory: Fn(&B::Device, u64) -> P` — fresh policy. The
-///   `u64` is a **per-construction seed** the trainer derives from
-///   `PsroConfig::seed` via a monotonic init-counter. A
-///   reproducibility-aware factory threads it into
-///   `MlpBurnPolicy::new_seeded` / `MlpBurnConfig::with_seed` so that
-///   every agent's initial policy and every per-iteration best-response
-///   gets *distinct but deterministic* weights (issue #135). Factories
-///   that don't care about reproducibility may ignore the argument.
+/// - `policy_factory: Fn(&B::Device, u64) -> P` — fresh policy. The `u64` is a
+///   **per-construction seed** the trainer derives from `PsroConfig::seed` via
+///   a monotonic init-counter. A reproducibility-aware factory threads it into
+///   `MlpBurnPolicy::new_seeded` / `MlpBurnConfig::with_seed` so that every
+///   agent's initial policy and every per-iteration best-response gets
+///   *distinct but deterministic* weights (issue #135). Factories that don't
+///   care about reproducibility may ignore the argument.
 /// - `optimizer_factory: Fn() -> BurnOptimizer<B, P, O>` — fresh optimizer.
 /// - `env_factory: Fn() -> E` — fresh env instance.
 ///

--- a/src/multi_agent/psro.rs
+++ b/src/multi_agent/psro.rs
@@ -1112,7 +1112,14 @@ impl PayoffCache {
 /// The trainer doesn't know how to construct a Burn module of the
 /// caller's chosen architecture, so we take closures:
 ///
-/// - `policy_factory: Fn(&B::Device) -> P` — fresh randomly-initialized policy.
+/// - `policy_factory: Fn(&B::Device, u64) -> P` — fresh policy. The
+///   `u64` is a **per-construction seed** the trainer derives from
+///   `PsroConfig::seed` via a monotonic init-counter. A
+///   reproducibility-aware factory threads it into
+///   `MlpBurnPolicy::new_seeded` / `MlpBurnConfig::with_seed` so that
+///   every agent's initial policy and every per-iteration best-response
+///   gets *distinct but deterministic* weights (issue #135). Factories
+///   that don't care about reproducibility may ignore the argument.
 /// - `optimizer_factory: Fn() -> BurnOptimizer<B, P, O>` — fresh optimizer.
 /// - `env_factory: Fn() -> E` — fresh env instance.
 ///
@@ -1134,7 +1141,7 @@ where
     P: JointPolicy<B>,
     O: Optimizer<P, B>,
     E: JointEnv,
-    FP: Fn(&B::Device) -> P,
+    FP: Fn(&B::Device, u64) -> P,
     FO: Fn() -> BurnOptimizer<B, P, O>,
     FE: Fn() -> E,
 {
@@ -1152,6 +1159,17 @@ where
     env_factory: FE,
     payoff_cache: PayoffCache,
     rng: StdRng,
+    /// Monotonic counter feeding the per-construction policy-init seed.
+    ///
+    /// Incremented on every `policy_factory` call (once per agent at
+    /// construction, once per best-response per outer iteration). Each
+    /// call derives `config.seed.wrapping_add(0x9E37_79B9 *
+    /// init_counter)` so distinct constructions get distinct — but
+    /// fully deterministic — initial weights. Without this, a factory
+    /// closing over a single fixed seed would hand every agent and every
+    /// iteration *identical* weights, a regression (issue #135,
+    /// Correction 1).
+    init_counter: u64,
 }
 
 impl<B, P, O, E, FP, FO, FE> PsroTrainer<B, P, O, E, FP, FO, FE>
@@ -1160,7 +1178,7 @@ where
     P: JointPolicy<B>,
     O: Optimizer<P, B>,
     E: JointEnv,
-    FP: Fn(&B::Device) -> P,
+    FP: Fn(&B::Device, u64) -> P,
     FO: Fn() -> BurnOptimizer<B, P, O>,
     FE: Fn() -> E,
 {
@@ -1189,7 +1207,16 @@ where
             ));
         }
         let n = joint_config.num_agents;
-        let populations: Vec<Vec<P>> = (0..n).map(|_| vec![policy_factory(&device)]).collect();
+        // Derive a distinct init seed per agent at construction time.
+        // We advance the counter inline here (the trainer isn't built
+        // yet) using the same derivation as `next_init_seed`.
+        let base_seed = config.seed;
+        let populations: Vec<Vec<P>> = (0..n)
+            .map(|i| {
+                let s = base_seed.wrapping_add(0x9E37_79B9_u64.wrapping_mul(i as u64));
+                vec![policy_factory(&device, s)]
+            })
+            .collect();
         let rng = StdRng::seed_from_u64(config.seed);
         Ok(Self {
             populations,
@@ -1202,7 +1229,23 @@ where
             env_factory,
             payoff_cache: PayoffCache::with_num_agents(n),
             rng,
+            // Start the running counter past the `n` seeds consumed by
+            // the initial per-agent constructions above.
+            init_counter: n as u64,
         })
+    }
+
+    /// Derive and consume the next per-construction policy-init seed.
+    ///
+    /// Returns `config.seed.wrapping_add(0x9E37_79B9 * init_counter)`
+    /// and advances the counter so the next call gets a fresh,
+    /// non-colliding stream. The multiplier is the 32-bit golden-ratio
+    /// constant — any odd large constant works; this one keeps adjacent
+    /// counters well-separated in the `StdRng` seed space.
+    fn next_init_seed(&mut self) -> u64 {
+        let s = self.config.seed.wrapping_add(0x9E37_79B9_u64.wrapping_mul(self.init_counter));
+        self.init_counter = self.init_counter.wrapping_add(1);
+        s
     }
 
     /// Borrow agent `agent`'s policy population.
@@ -1498,7 +1541,8 @@ where
         let mut policies: Vec<P> = Vec::with_capacity(num_agents);
         for (a, marginal) in per_agent_marginals.iter().enumerate().take(num_agents) {
             if a == active_agent {
-                policies.push((self.policy_factory)(&self.device));
+                let init_seed = self.next_init_seed();
+                policies.push((self.policy_factory)(&self.device, init_seed));
             } else {
                 let opp_index = sample_from_mixture(&mut self.rng, marginal);
                 policies.push(self.populations[a][opp_index].clone());
@@ -2056,7 +2100,7 @@ mod tests {
         MlpBurnPolicy<B>,
         burn::optim::adaptor::OptimizerAdaptor<burn::optim::Adam, MlpBurnPolicy<B>, B>,
         MatchingPennies,
-        impl Fn(&NdArrayDevice) -> MlpBurnPolicy<B>,
+        impl Fn(&NdArrayDevice, u64) -> MlpBurnPolicy<B>,
         impl Fn() -> BurnOptimizer<
             B,
             MlpBurnPolicy<B>,
@@ -2084,12 +2128,13 @@ mod tests {
             joint_config,
             meta_solver,
             device,
-            |dev: &NdArrayDevice| {
+            |dev: &NdArrayDevice, seed: u64| {
                 // 1 obs dim, 2 actions, small hidden.
-                MlpBurnPolicy::<B>::new(
+                MlpBurnPolicy::<B>::new_seeded(
                     MatchingPennies::OBS_DIM,
                     MatchingPennies::ACTION_DIM,
                     16,
+                    seed,
                     dev,
                 )
             },

--- a/src/policy/mlp.rs
+++ b/src/policy/mlp.rs
@@ -22,7 +22,7 @@
 
 use burn::{
     module::{Module, Param},
-    nn::{Initializer, Linear, LinearConfig},
+    nn::{Initializer, Linear},
     tensor::{Int, Tensor, activation, backend::Backend},
 };
 
@@ -61,6 +61,73 @@ pub(crate) fn linear_with_init<B: Backend>(
     Linear::<B> { weight, bias: Some(Param::from_tensor(bias_tensor)) }
 }
 
+/// Build a [`Linear`] layer from a pre-computed, row-major
+/// `[d_input, d_output]` weight buffer (and a zeroed bias).
+///
+/// This is the seeded counterpart to [`linear_with_init`]: instead of
+/// routing through Burn's unseedable [`Initializer`], the caller
+/// supplies weights produced by
+/// [`crate::policy::seeded_init`] (driven by `StdRng::seed_from_u64`),
+/// so two constructions with the same seed yield bit-identical layers.
+/// Used by the `with_config` seeded path on both
+/// [`MlpBurnPolicy`] and
+/// [`crate::policy::multi_discrete_mlp::MultiDiscreteMlpBurnPolicy`]
+/// (issue #135).
+pub(crate) fn linear_from_weights<B: Backend>(
+    d_input: usize,
+    d_output: usize,
+    weights: &[f32],
+    device: &B::Device,
+) -> Linear<B> {
+    debug_assert_eq!(weights.len(), d_input * d_output, "weight buffer must be d_input * d_output");
+    let weight_tensor = Tensor::<B, 2>::from_data(
+        burn::tensor::TensorData::new(weights.to_vec(), [d_input, d_output]),
+        device,
+    );
+    let bias_tensor = Tensor::<B, 1>::zeros([d_output], device);
+    Linear::<B> {
+        weight: Param::from_tensor(weight_tensor),
+        bias: Some(Param::from_tensor(bias_tensor)),
+    }
+}
+
+/// Produce a seeded weight buffer for one layer, honoring the
+/// orthogonal-vs-Kaiming recipe shared by both MLP policies.
+///
+/// Mirrors the gains used on the unseeded [`Initializer`] path:
+/// orthogonal trunk `sqrt(2)` / head `0.01`; Kaiming `1/sqrt(3)` for
+/// both heads and trunk (Burn's `KaimingUniform` default gain).
+pub(crate) fn seeded_layer_weights(
+    seed: u64,
+    d_in: usize,
+    d_out: usize,
+    use_orthogonal: bool,
+    is_head: bool,
+) -> Vec<f32> {
+    use crate::policy::seeded_init::{seeded_kaiming_uniform, seeded_orthogonal};
+    if use_orthogonal {
+        let gain = if is_head { 0.01_f32 } else { 2.0_f32.sqrt() };
+        seeded_orthogonal(seed, d_in, d_out, gain)
+    } else {
+        let gain = 1.0_f32 / 3.0_f32.sqrt();
+        seeded_kaiming_uniform(seed, d_in, d_out, gain)
+    }
+}
+
+/// Derive a distinct per-layer seed from a base construction seed.
+///
+/// Each `Linear` layer in a policy must draw from a *different* RNG
+/// stream — otherwise every layer of the same shape would get identical
+/// weights. We mix the base seed with a small per-layer index using a
+/// SplitMix64-style finalizer so the streams are decorrelated yet fully
+/// determined by `(base_seed, layer_index)`.
+pub(crate) fn derive_layer_seed(base_seed: u64, layer_index: u64) -> u64 {
+    let mut z = base_seed.wrapping_add(layer_index.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
 /// Activation function applied between hidden layers in
 /// [`MlpBurnPolicy`] (and its multi-discrete sibling).
 ///
@@ -94,6 +161,19 @@ pub struct MlpBurnConfig {
     pub use_orthogonal_init: bool,
     /// Activation applied between hidden layers.
     pub activation: BurnActivation,
+    /// Optional construction seed. When `Some`, `with_config` builds
+    /// every layer from a deterministic, [`StdRng`](rand::rngs::StdRng)-
+    /// driven weight buffer (see [`crate::policy::seeded_init`]) instead
+    /// of Burn's unseedable [`Initializer`], so two constructions with
+    /// the same seed produce **bit-identical** policies. When `None`
+    /// (the default) the behavior is unchanged — Burn's `Initializer`
+    /// path is used verbatim. This is the load-bearing knob behind the
+    /// end-to-end `PsroConfig::seed` / `NfspConfig::seed` reproducibility
+    /// contract (issue #135). The seeded path covers **both** the
+    /// orthogonal and Kaiming-uniform recipes (selected by
+    /// `use_orthogonal_init`), so seeding works regardless of which init
+    /// the caller picks.
+    pub seed: Option<u64>,
 }
 
 impl Default for MlpBurnConfig {
@@ -103,7 +183,20 @@ impl Default for MlpBurnConfig {
             hidden_dim: 64,
             use_orthogonal_init: true,
             activation: BurnActivation::Tanh,
+            seed: None,
         }
+    }
+}
+
+impl MlpBurnConfig {
+    /// Set the construction seed, enabling the deterministic
+    /// host-side init path in `with_config`.
+    ///
+    /// Builder-style; returns `self` for chaining:
+    /// `MlpBurnConfig::default().with_seed(42)`.
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 }
 
@@ -153,6 +246,33 @@ impl<B: Backend> MlpBurnPolicy<B> {
             // PPO orthogonal recipe.
             use_orthogonal_init: false,
             activation: BurnActivation::Tanh,
+            seed: None,
+        };
+        Self::with_config(obs_dim, action_dim, config, device)
+    }
+
+    /// Seeded variant of [`new`](Self::new): same 2-layer Kaiming
+    /// architecture, but constructed deterministically from `seed` so
+    /// two calls with the same seed produce bit-identical weights.
+    ///
+    /// Convenience wrapper for callers (and the PSRO/NFSP policy
+    /// factories) that want reproducible policies without assembling a
+    /// full [`MlpBurnConfig`]. Equivalent to
+    /// `with_config(.., MlpBurnConfig { use_orthogonal_init: false,
+    /// .., seed: Some(seed) }, ..)`.
+    pub fn new_seeded(
+        obs_dim: usize,
+        action_dim: usize,
+        hidden_dim: usize,
+        seed: u64,
+        device: &B::Device,
+    ) -> Self {
+        let config = MlpBurnConfig {
+            num_layers: 2,
+            hidden_dim,
+            use_orthogonal_init: false,
+            activation: BurnActivation::Tanh,
+            seed: Some(seed),
         };
         Self::with_config(obs_dim, action_dim, config, device)
     }
@@ -167,6 +287,31 @@ impl<B: Backend> MlpBurnPolicy<B> {
         config: MlpBurnConfig,
         device: &B::Device,
     ) -> Self {
+        // Seeded path (issue #135): when `config.seed` is set, build
+        // every layer from a deterministic `StdRng`-driven weight buffer
+        // so two constructions with the same seed are bit-identical.
+        // Each layer gets a distinct derived seed so layers of the same
+        // shape don't collide. Layer indices are fixed:
+        // 0=fc1, 1=fc2, 2=fc3, 3=policy_head, 4=value_head.
+        if let Some(seed) = config.seed {
+            let orth = config.use_orthogonal_init;
+            let mk = |idx: u64, d_in: usize, d_out: usize, is_head: bool| {
+                let s = derive_layer_seed(seed, idx);
+                let w = seeded_layer_weights(s, d_in, d_out, orth, is_head);
+                linear_from_weights::<B>(d_in, d_out, &w, device)
+            };
+            let fc1 = mk(0, obs_dim, config.hidden_dim, false);
+            let fc2 = mk(1, config.hidden_dim, config.hidden_dim, false);
+            let fc3 = if config.num_layers >= 3 {
+                Some(mk(2, config.hidden_dim, config.hidden_dim, false))
+            } else {
+                None
+            };
+            let policy_head = mk(3, config.hidden_dim, action_dim, true);
+            let value_head = mk(4, config.hidden_dim, 1, true);
+            return Self { fc1, fc2, fc3, policy_head, value_head, activation: config.activation };
+        }
+
         let hidden_init = if config.use_orthogonal_init {
             Initializer::Orthogonal { gain: 2.0_f64.sqrt() }
         } else {
@@ -507,5 +652,86 @@ mod tests {
         // of accidental match) — but at least the call must succeed
         // and produce a 2-row response.
         assert_eq!(a_c.len(), 2, "two-row batch returns two actions");
+    }
+
+    /// Flatten every weight + bias of a policy into one comparison
+    /// vector (test helper for the bit-identity assertions below).
+    fn collect_params(p: &MlpBurnPolicy<B>) -> Vec<f32> {
+        let mut out = Vec::new();
+        let mut push = |lin: &Linear<B>| {
+            out.extend::<Vec<f32>>(lin.weight.val().into_data().to_vec().unwrap());
+            if let Some(b) = &lin.bias {
+                out.extend::<Vec<f32>>(b.val().into_data().to_vec().unwrap());
+            }
+        };
+        push(&p.fc1);
+        push(&p.fc2);
+        if let Some(fc3) = &p.fc3 {
+            push(fc3);
+        }
+        push(&p.policy_head);
+        push(&p.value_head);
+        out
+    }
+
+    /// Two seeded constructions (orthogonal init) with the same seed
+    /// produce bit-identical weights; a different seed differs. This is
+    /// the core guarantee behind end-to-end `PsroConfig::seed` /
+    /// `NfspConfig::seed` reproducibility (issue #135).
+    #[test]
+    fn test_with_seed_is_bit_identical_orthogonal() {
+        let device = Default::default();
+        let cfg = MlpBurnConfig { num_layers: 3, ..Default::default() }.with_seed(42);
+        let a = MlpBurnPolicy::<B>::with_config(4, 2, cfg, &device);
+        let b = MlpBurnPolicy::<B>::with_config(4, 2, cfg, &device);
+        assert_eq!(collect_params(&a), collect_params(&b), "same seed must be bit-identical");
+
+        let cfg_diff = MlpBurnConfig { num_layers: 3, ..Default::default() }.with_seed(43);
+        let c = MlpBurnPolicy::<B>::with_config(4, 2, cfg_diff, &device);
+        assert_ne!(collect_params(&a), collect_params(&c), "different seed must differ");
+    }
+
+    /// Same as above but for the Kaiming-uniform path (`new_seeded`
+    /// uses `use_orthogonal_init = false`). This is the path the
+    /// matching-pennies tests exercise (issue #135, Correction 2).
+    #[test]
+    fn test_new_seeded_is_bit_identical_kaiming() {
+        let device = Default::default();
+        let a = MlpBurnPolicy::<B>::new_seeded(4, 2, 16, 7, &device);
+        let b = MlpBurnPolicy::<B>::new_seeded(4, 2, 16, 7, &device);
+        assert_eq!(collect_params(&a), collect_params(&b), "same seed must be bit-identical");
+        let c = MlpBurnPolicy::<B>::new_seeded(4, 2, 16, 8, &device);
+        assert_ne!(collect_params(&a), collect_params(&c), "different seed must differ");
+    }
+
+    /// Distinct layers within one policy must not share weights even
+    /// when they have the same shape (the per-layer seed derivation
+    /// must decorrelate them). fc2 and fc3 are both
+    /// `[hidden, hidden]`; assert they differ.
+    #[test]
+    fn test_seeded_layers_are_decorrelated() {
+        let device = Default::default();
+        let cfg = MlpBurnConfig { num_layers: 3, hidden_dim: 8, ..Default::default() }.with_seed(1);
+        let p = MlpBurnPolicy::<B>::with_config(8, 2, cfg, &device);
+        let fc2: Vec<f32> = p.fc2.weight.val().into_data().to_vec().unwrap();
+        let fc3: Vec<f32> = p.fc3.as_ref().unwrap().weight.val().into_data().to_vec().unwrap();
+        assert_ne!(fc2, fc3, "same-shape trunk layers must get distinct seeded weights");
+    }
+
+    /// The unseeded path (`seed: None`) is unchanged — two
+    /// constructions are *not* required to match (Burn's unseeded
+    /// init), and the seeded path must not accidentally fire. We just
+    /// assert construction succeeds and produces the right shapes, i.e.
+    /// the `None` branch is still wired to Burn's `Initializer`.
+    #[test]
+    fn test_unseeded_path_still_constructs() {
+        let device = Default::default();
+        let cfg = MlpBurnConfig::default(); // seed: None
+        assert!(cfg.seed.is_none());
+        let p = MlpBurnPolicy::<B>::with_config(4, 2, cfg, &device);
+        let obs = Tensor::<B, 2>::zeros([3, 4], &device);
+        let (logits, values) = p.forward(obs);
+        assert_eq!(logits.dims(), [3, 2]);
+        assert_eq!(values.dims(), [3]);
     }
 }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -18,6 +18,13 @@ pub mod mlp;
 #[cfg(feature = "training")]
 pub mod multi_discrete_mlp;
 
+/// Seeded, host-side weight-initialization helpers that make policy
+/// construction bit-exact under `PsroConfig::seed` / `NfspConfig::seed`
+/// (issue #135). Burn 0.21's `Initializer` has no seed parameter, so we
+/// pre-compute the trunk + head weights from an `StdRng` instead.
+#[cfg(feature = "training")]
+pub mod seeded_init;
+
 /// DQN Q-network with the same MLP backbone as `MlpPolicy` but with a
 /// single Q-head.
 #[cfg(feature = "training")]

--- a/src/policy/multi_discrete_mlp.rs
+++ b/src/policy/multi_discrete_mlp.rs
@@ -100,14 +100,7 @@ impl<B: Backend> MultiDiscreteMlpBurnPolicy<B> {
                 .enumerate()
                 .map(|(i, &dim)| mk(100 + i as u64, config.hidden_dim, dim, true))
                 .collect();
-            return Self {
-                fc1,
-                fc2,
-                fc3,
-                action_heads,
-                value_head,
-                activation: config.activation,
-            };
+            return Self { fc1, fc2, fc3, action_heads, value_head, activation: config.activation };
         }
 
         let hidden_init = if config.use_orthogonal_init {

--- a/src/policy/multi_discrete_mlp.rs
+++ b/src/policy/multi_discrete_mlp.rs
@@ -11,7 +11,10 @@ use burn::{
     tensor::{Int, Tensor, activation, backend::Backend},
 };
 
-use super::mlp::{BurnActivation, MlpBurnConfig, linear_with_init};
+use super::mlp::{
+    BurnActivation, MlpBurnConfig, derive_layer_seed, linear_from_weights, linear_with_init,
+    seeded_layer_weights,
+};
 
 /// Multi-discrete MLP actor-critic policy on Burn.
 ///
@@ -44,6 +47,22 @@ impl<B: Backend> MultiDiscreteMlpBurnPolicy<B> {
         Self::with_config(obs_dim, action_dims, config, device)
     }
 
+    /// Seeded variant of [`new`](Self::new): same default architecture
+    /// (orthogonal init), but constructed deterministically from `seed`
+    /// so two calls with the same seed produce bit-identical weights
+    /// (issue #135). Convenience wrapper for PSRO/NFSP policy factories
+    /// over the multi-discrete policy.
+    pub fn new_seeded(
+        obs_dim: usize,
+        action_dims: Vec<usize>,
+        hidden_dim: usize,
+        seed: u64,
+        device: &B::Device,
+    ) -> Self {
+        let config = MlpBurnConfig { hidden_dim, ..Default::default() }.with_seed(seed);
+        Self::with_config(obs_dim, action_dims, config, device)
+    }
+
     /// Build a fresh multi-discrete policy with custom configuration.
     pub fn with_config(
         obs_dim: usize,
@@ -54,6 +73,41 @@ impl<B: Backend> MultiDiscreteMlpBurnPolicy<B> {
         assert!(!action_dims.is_empty(), "action_dims must have at least one element");
         for (i, d) in action_dims.iter().enumerate() {
             assert!(*d >= 1, "action_dims[{i}] = {d}; must be >= 1");
+        }
+
+        // Seeded path (issue #135): mirror the single-action policy's
+        // deterministic construction per-head. Layer indices are fixed:
+        // 0=fc1, 1=fc2, 2=fc3, 3=value_head, then 100+i for action
+        // head i (offset keeps action-head streams distinct from the
+        // trunk/value streams regardless of head count).
+        if let Some(seed) = config.seed {
+            let orth = config.use_orthogonal_init;
+            let mk = |idx: u64, d_in: usize, d_out: usize, is_head: bool| {
+                let s = derive_layer_seed(seed, idx);
+                let w = seeded_layer_weights(s, d_in, d_out, orth, is_head);
+                linear_from_weights::<B>(d_in, d_out, &w, device)
+            };
+            let fc1 = mk(0, obs_dim, config.hidden_dim, false);
+            let fc2 = mk(1, config.hidden_dim, config.hidden_dim, false);
+            let fc3 = if config.num_layers >= 3 {
+                Some(mk(2, config.hidden_dim, config.hidden_dim, false))
+            } else {
+                None
+            };
+            let value_head = mk(3, config.hidden_dim, 1, true);
+            let action_heads: Vec<Linear<B>> = action_dims
+                .iter()
+                .enumerate()
+                .map(|(i, &dim)| mk(100 + i as u64, config.hidden_dim, dim, true))
+                .collect();
+            return Self {
+                fc1,
+                fc2,
+                fc3,
+                action_heads,
+                value_head,
+                activation: config.activation,
+            };
         }
 
         let hidden_init = if config.use_orthogonal_init {
@@ -381,5 +435,52 @@ mod tests {
         assert_eq!(a_a, a_b, "same-seed actions must be bit-identical");
         assert_eq!(lp_a, lp_b, "same-seed log_probs must be bit-identical");
         assert_eq!(v_a, v_b, "same-seed values must be bit-identical");
+    }
+
+    /// Flatten every weight + bias (trunk, value head, all action
+    /// heads) into one comparison vector.
+    fn collect_params(p: &MultiDiscreteMlpBurnPolicy<B>) -> Vec<f32> {
+        let mut out = Vec::new();
+        let mut push = |lin: &Linear<B>| {
+            out.extend::<Vec<f32>>(lin.weight.val().into_data().to_vec().unwrap());
+            if let Some(b) = &lin.bias {
+                out.extend::<Vec<f32>>(b.val().into_data().to_vec().unwrap());
+            }
+        };
+        push(&p.fc1);
+        push(&p.fc2);
+        if let Some(fc3) = &p.fc3 {
+            push(fc3);
+        }
+        push(&p.value_head);
+        for h in &p.action_heads {
+            push(h);
+        }
+        out
+    }
+
+    /// Two `new_seeded` constructions with the same seed produce
+    /// bit-identical weights across the trunk and every per-head; a
+    /// different seed differs (issue #135).
+    #[test]
+    fn test_new_seeded_is_bit_identical() {
+        let device = Default::default();
+        let a = MultiDiscreteMlpBurnPolicy::<B>::new_seeded(4, vec![3, 4, 2], 16, 42, &device);
+        let b = MultiDiscreteMlpBurnPolicy::<B>::new_seeded(4, vec![3, 4, 2], 16, 42, &device);
+        assert_eq!(collect_params(&a), collect_params(&b), "same seed must be bit-identical");
+        let c = MultiDiscreteMlpBurnPolicy::<B>::new_seeded(4, vec![3, 4, 2], 16, 43, &device);
+        assert_ne!(collect_params(&a), collect_params(&c), "different seed must differ");
+    }
+
+    /// Action heads of the same cardinality must get distinct seeded
+    /// weights (per-head seed derivation decorrelates them).
+    #[test]
+    fn test_seeded_action_heads_are_distinct() {
+        let device = Default::default();
+        // Two heads of identical cardinality (2) — must differ.
+        let p = MultiDiscreteMlpBurnPolicy::<B>::new_seeded(4, vec![2, 2], 8, 5, &device);
+        let h0: Vec<f32> = p.action_heads[0].weight.val().into_data().to_vec().unwrap();
+        let h1: Vec<f32> = p.action_heads[1].weight.val().into_data().to_vec().unwrap();
+        assert_ne!(h0, h1, "same-cardinality action heads must get distinct seeded weights");
     }
 }

--- a/src/policy/seeded_init.rs
+++ b/src/policy/seeded_init.rs
@@ -8,10 +8,11 @@
 //! `burn-core-0.21.0/src/module/initializer.rs`) take **no seed
 //! parameter** — they route through a backend-internal
 //! `Tensor::random` that draws from an unseeded, thread-local
-//! generator. That makes [`Initializer::Orthogonal`] and
-//! [`Initializer::KaimingUniform`] the last non-reproducible site in
-//! the PSRO/NFSP determinism contract advertised by
-//! [`crate::multi_agent::psro::PsroConfig::seed`] /
+//! generator. That makes
+//! [`Initializer::Orthogonal`](burn::nn::Initializer::Orthogonal) and
+//! [`Initializer::KaimingUniform`](burn::nn::Initializer::KaimingUniform) the
+//! last non-reproducible site in the PSRO/NFSP determinism contract advertised
+//! by [`crate::multi_agent::psro::PsroConfig::seed`] /
 //! [`crate::multi_agent::nfsp::NfspConfig::seed`] (every rollout/
 //! training RNG site was plumbed through `StdRng::seed_from_u64` in
 //! PRs #113/#116/#122/#123/#125; this closes the policy-init gap —
@@ -19,12 +20,13 @@
 //!
 //! # What it does
 //!
-//! Provides pure-Rust, [`StdRng`]-driven ports of the two init recipes
-//! the MLP policies use:
+//! Provides pure-Rust, [`StdRng`](rand::rngs::StdRng)-driven ports of the two
+//! init recipes the MLP policies use:
 //!
-//! - [`seeded_orthogonal`] — orthogonal init via Householder QR of a Gaussian
-//!   matrix, scaled by `gain` (PPO recipe: `sqrt(2)` trunk, `0.01` heads).
-//! - [`seeded_kaiming_uniform`] — Kaiming-uniform init matching Burn's
+//! - [`seeded_orthogonal`](crate::policy::seeded_init::seeded_orthogonal) —
+//!   orthogonal init via Householder QR of a Gaussian matrix, scaled by `gain`
+//!   (PPO recipe: `sqrt(2)` trunk, `0.01` heads).
+//! - [`seeded_kaiming_uniform`](crate::policy::seeded_init::seeded_kaiming_uniform) — Kaiming-uniform init matching Burn's
 //!   `KaimingUniform { gain, fan_out_only: false }` formula (`bound = gain *
 //!   sqrt(3 / fan_in)`), the path [`crate::policy::mlp::MlpBurnPolicy::new`]
 //!   exercises.

--- a/src/policy/seeded_init.rs
+++ b/src/policy/seeded_init.rs
@@ -1,0 +1,261 @@
+//! Seeded, host-side weight-initialization helpers for bit-exact
+//! policy construction.
+//!
+//! # Why this module exists
+//!
+//! Burn 0.21's [`burn::nn::Initializer::init_with`] /
+//! `init_tensor` (see
+//! `burn-core-0.21.0/src/module/initializer.rs`) take **no seed
+//! parameter** — they route through a backend-internal
+//! `Tensor::random` that draws from an unseeded, thread-local
+//! generator. That makes [`Initializer::Orthogonal`] and
+//! [`Initializer::KaimingUniform`] the last non-reproducible site in
+//! the PSRO/NFSP determinism contract advertised by
+//! [`crate::multi_agent::psro::PsroConfig::seed`] /
+//! [`crate::multi_agent::nfsp::NfspConfig::seed`] (every rollout/
+//! training RNG site was plumbed through `StdRng::seed_from_u64` in
+//! PRs #113/#116/#122/#123/#125; this closes the policy-init gap —
+//! issue #135).
+//!
+//! # What it does
+//!
+//! Provides pure-Rust, [`StdRng`]-driven ports of the two init recipes
+//! the MLP policies use:
+//!
+//! - [`seeded_orthogonal`] — orthogonal init via Householder QR of a
+//!   Gaussian matrix, scaled by `gain` (PPO recipe: `sqrt(2)` trunk,
+//!   `0.01` heads).
+//! - [`seeded_kaiming_uniform`] — Kaiming-uniform init matching Burn's
+//!   `KaimingUniform { gain, fan_out_only: false }` formula
+//!   (`bound = gain * sqrt(3 / fan_in)`), the path
+//!   [`crate::policy::mlp::MlpBurnPolicy::new`] exercises.
+//!
+//! # Bit-parity caveat
+//!
+//! These are **not** byte-identical to Burn's unseeded output — we are
+//! *replacing* the distribution with a reproducible one, not mirroring
+//! Burn's internal sampler. The only contract is: same `seed` (and
+//! same shape/gain) ⇒ same `Vec<f32>`, every run, every machine.
+
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+/// Draw a single `N(0, 1)` sample from `rng` via the Box–Muller
+/// transform.
+///
+/// We hand-roll the normal sampler (rather than pulling in
+/// `rand_distr`) so the only RNG draws are `f32` uniforms — keeping the
+/// per-construction consumption order trivial to reason about and the
+/// dependency surface unchanged. Two `StdRng`s seeded identically
+/// therefore yield identical draw sequences and identical matrices.
+fn standard_normal(rng: &mut StdRng) -> f32 {
+    // Guard u1 away from 0 so ln() is finite.
+    let u1: f32 = {
+        let x: f32 = rng.random();
+        if x <= f32::MIN_POSITIVE { f32::MIN_POSITIVE } else { x }
+    };
+    let u2: f32 = rng.random();
+    let r = (-2.0_f32 * u1.ln()).sqrt();
+    let theta = 2.0_f32 * std::f32::consts::PI * u2;
+    r * theta.cos()
+}
+
+/// Generate a seeded orthogonal weight matrix of shape `[d_in, d_out]`
+/// flattened in **row-major** order (row index over `d_in`, column
+/// index over `d_out`) — matching Burn's `Linear` weight layout
+/// (`weight: Param<Tensor<B, 2>>` with dims `[d_input, d_output]`).
+///
+/// Algorithm (a faithful, seeded port of the orthogonal recipe):
+/// 1. Sample an `[rows, cols]` matrix `A` from `N(0, 1)`.
+/// 2. Compute a (thin) QR factorization `A = Q R` via Householder
+///    reflections, with the sign convention `sign(diag(R)) >= 0` so the
+///    result is deterministic.
+/// 3. Return `gain * Q`.
+///
+/// `Q` has orthonormal columns when `rows >= cols`, and orthonormal
+/// rows when `rows < cols` (we QR the taller orientation internally and
+/// transpose back), matching the behavior of standard orthogonal init.
+pub fn seeded_orthogonal(seed: u64, d_in: usize, d_out: usize, gain: f32) -> Vec<f32> {
+    let mut rng = StdRng::seed_from_u64(seed);
+
+    // We want an [d_in, d_out] result with orthonormal rows or columns.
+    // QR is cleanest when the matrix is tall (rows >= cols). If
+    // d_in < d_out we QR the transpose ([d_out, d_in]) and transpose
+    // the resulting Q back.
+    let (rows, cols, transposed) =
+        if d_in >= d_out { (d_in, d_out, false) } else { (d_out, d_in, true) };
+
+    // Sample the tall Gaussian matrix in column-major working storage:
+    // a[c] is the c-th column (length `rows`). Column-major makes the
+    // Householder loop's column access contiguous.
+    let mut cols_data: Vec<Vec<f32>> = Vec::with_capacity(cols);
+    for _ in 0..cols {
+        let mut col = Vec::with_capacity(rows);
+        for _ in 0..rows {
+            col.push(standard_normal(&mut rng));
+        }
+        cols_data.push(col);
+    }
+
+    // Modified Gram–Schmidt orthonormalization (numerically adequate
+    // for the small matrices used here, and trivially deterministic).
+    // Equivalent in outcome to a Householder QR's Q for full-rank
+    // Gaussian input; we additionally fix the sign so the diagonal of
+    // the implied R is non-negative.
+    let mut q: Vec<Vec<f32>> = Vec::with_capacity(cols);
+    for j in 0..cols {
+        let mut v = cols_data[j].clone();
+        // Subtract projections onto the previously-fixed orthonormal
+        // columns.
+        for qi in q.iter() {
+            let dot: f32 = (0..rows).map(|r| v[r] * qi[r]).sum();
+            for r in 0..rows {
+                v[r] -= dot * qi[r];
+            }
+        }
+        // Normalize.
+        let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let norm = if norm <= f32::MIN_POSITIVE { 1.0 } else { norm };
+        for slot in v.iter_mut() {
+            *slot /= norm;
+        }
+        // Sign fix: make the leading nonzero-ish entry positive so the
+        // result is a deterministic function of the seed regardless of
+        // platform float associativity in the projection sums.
+        if v[j] < 0.0 {
+            for slot in v.iter_mut() {
+                *slot = -*slot;
+            }
+        }
+        q.push(v);
+    }
+
+    // q[c][r] = Q[r, c] for the tall orientation [rows, cols].
+    // Emit row-major [d_in, d_out] * gain.
+    let mut out = vec![0.0_f32; d_in * d_out];
+    for i in 0..d_in {
+        for j in 0..d_out {
+            // Map (i, j) in [d_in, d_out] back to (r, c) in [rows, cols].
+            let (r, c) = if transposed { (j, i) } else { (i, j) };
+            out[i * d_out + j] = gain * q[c][r];
+        }
+    }
+    out
+}
+
+/// Generate a seeded Kaiming-uniform weight matrix of shape
+/// `[d_in, d_out]` flattened in **row-major** order.
+///
+/// Matches Burn's `Initializer::KaimingUniform { gain, fan_out_only:
+/// false }` formula: each entry is drawn uniformly from
+/// `[-bound, bound]` where `bound = gain * sqrt(3 / fan_in)` and
+/// `fan_in = d_in`. This is the path
+/// [`crate::policy::mlp::MlpBurnPolicy::new`] uses
+/// (`use_orthogonal_init = false`), so seeding it is required to make
+/// the matching-pennies tests (which build policies via `new`)
+/// reproducible — see issue #135's Correction 2.
+pub fn seeded_kaiming_uniform(seed: u64, d_in: usize, d_out: usize, gain: f32) -> Vec<f32> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let fan_in = d_in.max(1) as f32;
+    let bound = gain * (3.0_f32 / fan_in).sqrt();
+    let mut out = vec![0.0_f32; d_in * d_out];
+    for slot in out.iter_mut() {
+        // Uniform in [-bound, bound]: rng.random() is [0, 1).
+        let u: f32 = rng.random();
+        *slot = (u * 2.0 - 1.0) * bound;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two calls with the same seed/shape/gain produce bit-identical
+    /// orthogonal matrices; a different seed differs.
+    #[test]
+    fn orthogonal_is_deterministic_in_seed() {
+        let a = seeded_orthogonal(42, 6, 4, 2.0_f32.sqrt());
+        let b = seeded_orthogonal(42, 6, 4, 2.0_f32.sqrt());
+        assert_eq!(a, b, "same seed must be bit-identical");
+        let c = seeded_orthogonal(43, 6, 4, 2.0_f32.sqrt());
+        assert_ne!(a, c, "different seed must differ");
+        assert_eq!(a.len(), 24);
+    }
+
+    /// Columns of the [d_in, d_out] result (d_in >= d_out) are
+    /// orthonormal up to the gain factor.
+    #[test]
+    fn orthogonal_columns_are_orthonormal_tall() {
+        let d_in = 8;
+        let d_out = 3;
+        let gain = 1.0;
+        let w = seeded_orthogonal(7, d_in, d_out, gain);
+        // Column dot products: col j . col k should be ~delta_{jk}.
+        for j in 0..d_out {
+            for k in 0..d_out {
+                let mut dot = 0.0_f32;
+                for r in 0..d_in {
+                    dot += w[r * d_out + j] * w[r * d_out + k];
+                }
+                let expected = if j == k { 1.0 } else { 0.0 };
+                assert!(
+                    (dot - expected).abs() < 1e-4,
+                    "col {j}.col {k} = {dot}, expected {expected}"
+                );
+            }
+        }
+    }
+
+    /// Rows of the [d_in, d_out] result (d_in < d_out) are orthonormal
+    /// up to the gain factor.
+    #[test]
+    fn orthogonal_rows_are_orthonormal_wide() {
+        let d_in = 3;
+        let d_out = 8;
+        let gain = 1.0;
+        let w = seeded_orthogonal(11, d_in, d_out, gain);
+        for i in 0..d_in {
+            for k in 0..d_in {
+                let mut dot = 0.0_f32;
+                for c in 0..d_out {
+                    dot += w[i * d_out + c] * w[k * d_out + c];
+                }
+                let expected = if i == k { 1.0 } else { 0.0 };
+                assert!(
+                    (dot - expected).abs() < 1e-4,
+                    "row {i}.row {k} = {dot}, expected {expected}"
+                );
+            }
+        }
+    }
+
+    /// Gain scales the matrix linearly.
+    #[test]
+    fn orthogonal_gain_scales() {
+        let w1 = seeded_orthogonal(5, 6, 4, 1.0);
+        let w2 = seeded_orthogonal(5, 6, 4, 3.0);
+        for (a, b) in w1.iter().zip(w2.iter()) {
+            assert!((b - a * 3.0).abs() < 1e-5, "gain should scale: {a} vs {b}");
+        }
+    }
+
+    /// Kaiming-uniform is deterministic in seed and respects the
+    /// `gain * sqrt(3 / fan_in)` bound.
+    #[test]
+    fn kaiming_is_deterministic_and_bounded() {
+        let d_in = 16;
+        let d_out = 8;
+        let gain = 1.0_f32 / 3.0_f32.sqrt();
+        let a = seeded_kaiming_uniform(99, d_in, d_out, gain);
+        let b = seeded_kaiming_uniform(99, d_in, d_out, gain);
+        assert_eq!(a, b, "same seed must be bit-identical");
+        let c = seeded_kaiming_uniform(100, d_in, d_out, gain);
+        assert_ne!(a, c, "different seed must differ");
+
+        let bound = gain * (3.0_f32 / d_in as f32).sqrt();
+        for &x in &a {
+            assert!(x.abs() <= bound + 1e-6, "{x} exceeds bound {bound}");
+        }
+        assert_eq!(a.len(), d_in * d_out);
+    }
+}

--- a/src/policy/seeded_init.rs
+++ b/src/policy/seeded_init.rs
@@ -22,13 +22,12 @@
 //! Provides pure-Rust, [`StdRng`]-driven ports of the two init recipes
 //! the MLP policies use:
 //!
-//! - [`seeded_orthogonal`] — orthogonal init via Householder QR of a
-//!   Gaussian matrix, scaled by `gain` (PPO recipe: `sqrt(2)` trunk,
-//!   `0.01` heads).
+//! - [`seeded_orthogonal`] — orthogonal init via Householder QR of a Gaussian
+//!   matrix, scaled by `gain` (PPO recipe: `sqrt(2)` trunk, `0.01` heads).
 //! - [`seeded_kaiming_uniform`] — Kaiming-uniform init matching Burn's
-//!   `KaimingUniform { gain, fan_out_only: false }` formula
-//!   (`bound = gain * sqrt(3 / fan_in)`), the path
-//!   [`crate::policy::mlp::MlpBurnPolicy::new`] exercises.
+//!   `KaimingUniform { gain, fan_out_only: false }` formula (`bound = gain *
+//!   sqrt(3 / fan_in)`), the path [`crate::policy::mlp::MlpBurnPolicy::new`]
+//!   exercises.
 //!
 //! # Bit-parity caveat
 //!
@@ -51,7 +50,11 @@ fn standard_normal(rng: &mut StdRng) -> f32 {
     // Guard u1 away from 0 so ln() is finite.
     let u1: f32 = {
         let x: f32 = rng.random();
-        if x <= f32::MIN_POSITIVE { f32::MIN_POSITIVE } else { x }
+        if x <= f32::MIN_POSITIVE {
+            f32::MIN_POSITIVE
+        } else {
+            x
+        }
     };
     let u2: f32 = rng.random();
     let r = (-2.0_f32 * u1.ln()).sqrt();
@@ -66,9 +69,9 @@ fn standard_normal(rng: &mut StdRng) -> f32 {
 ///
 /// Algorithm (a faithful, seeded port of the orthogonal recipe):
 /// 1. Sample an `[rows, cols]` matrix `A` from `N(0, 1)`.
-/// 2. Compute a (thin) QR factorization `A = Q R` via Householder
-///    reflections, with the sign convention `sign(diag(R)) >= 0` so the
-///    result is deterministic.
+/// 2. Compute a (thin) QR factorization `A = Q R` via Householder reflections,
+///    with the sign convention `sign(diag(R)) >= 0` so the result is
+///    deterministic.
 /// 3. Return `gain * Q`.
 ///
 /// `Q` has orthonormal columns when `rows >= cols`, and orthonormal
@@ -81,8 +84,11 @@ pub fn seeded_orthogonal(seed: u64, d_in: usize, d_out: usize, gain: f32) -> Vec
     // QR is cleanest when the matrix is tall (rows >= cols). If
     // d_in < d_out we QR the transpose ([d_out, d_in]) and transpose
     // the resulting Q back.
-    let (rows, cols, transposed) =
-        if d_in >= d_out { (d_in, d_out, false) } else { (d_out, d_in, true) };
+    let (rows, cols, transposed) = if d_in >= d_out {
+        (d_in, d_out, false)
+    } else {
+        (d_out, d_in, true)
+    };
 
     // Sample the tall Gaussian matrix in column-major working storage:
     // a[c] is the c-th column (length `rows`). Column-major makes the

--- a/tests/test_nfsp_bucket_brigade.rs
+++ b/tests/test_nfsp_bucket_brigade.rs
@@ -284,8 +284,8 @@ fn test_nfsp_beats_ppo_on_canonical_no_convergence_cell() {
         ..Default::default()
     };
 
-    let policy_factory = move |dev: &NdArrayDevice| {
-        MultiDiscreteMlpBurnPolicy::<B>::new(obs_dim, action_dims(), HIDDEN_DIM, dev)
+    let policy_factory = move |dev: &NdArrayDevice, seed: u64| {
+        MultiDiscreteMlpBurnPolicy::<B>::new_seeded(obs_dim, action_dims(), HIDDEN_DIM, seed, dev)
     };
     let optimizer_factory = || {
         let inner = AdamConfig::new().init();

--- a/tests/test_nfsp_matching_pennies.rs
+++ b/tests/test_nfsp_matching_pennies.rs
@@ -53,7 +53,7 @@ fn build_trainer(
     MlpBurnPolicy<B>,
     burn::optim::adaptor::OptimizerAdaptor<burn::optim::Adam, MlpBurnPolicy<B>, B>,
     MatchingPennies,
-    impl Fn(&NdArrayDevice) -> MlpBurnPolicy<B>,
+    impl Fn(&NdArrayDevice, u64) -> MlpBurnPolicy<B>,
     impl Fn() -> BurnOptimizer<
         B,
         MlpBurnPolicy<B>,
@@ -83,8 +83,14 @@ fn build_trainer(
         nfsp_config,
         joint_config,
         device,
-        |dev: &NdArrayDevice| {
-            MlpBurnPolicy::<B>::new(MatchingPennies::OBS_DIM, MatchingPennies::ACTION_DIM, 16, dev)
+        |dev: &NdArrayDevice, seed: u64| {
+            MlpBurnPolicy::<B>::new_seeded(
+                MatchingPennies::OBS_DIM,
+                MatchingPennies::ACTION_DIM,
+                16,
+                seed,
+                dev,
+            )
         },
         || {
             let inner = AdamConfig::new().init();

--- a/tests/test_nfsp_multi_discrete_smoke.rs
+++ b/tests/test_nfsp_multi_discrete_smoke.rs
@@ -128,7 +128,7 @@ fn build_trainer(
     MultiDiscreteMlpBurnPolicy<B>,
     burn::optim::adaptor::OptimizerAdaptor<burn::optim::Adam, MultiDiscreteMlpBurnPolicy<B>, B>,
     ToyMultiDiscreteEnv,
-    impl Fn(&NdArrayDevice) -> MultiDiscreteMlpBurnPolicy<B>,
+    impl Fn(&NdArrayDevice, u64) -> MultiDiscreteMlpBurnPolicy<B>,
     impl Fn() -> BurnOptimizer<
         B,
         MultiDiscreteMlpBurnPolicy<B>,
@@ -158,8 +158,14 @@ fn build_trainer(
         nfsp_config,
         joint_config,
         device,
-        |dev: &NdArrayDevice| {
-            MultiDiscreteMlpBurnPolicy::<B>::new(OBS_DIM, ACTION_DIMS.to_vec(), HIDDEN_DIM, dev)
+        |dev: &NdArrayDevice, seed: u64| {
+            MultiDiscreteMlpBurnPolicy::<B>::new_seeded(
+                OBS_DIM,
+                ACTION_DIMS.to_vec(),
+                HIDDEN_DIM,
+                seed,
+                dev,
+            )
         },
         || {
             let inner = AdamConfig::new().init();

--- a/tests/test_nfsp_n_player_matching_pennies.rs
+++ b/tests/test_nfsp_n_player_matching_pennies.rs
@@ -51,7 +51,7 @@ fn build_n_player_trainer(
     MlpBurnPolicy<B>,
     burn::optim::adaptor::OptimizerAdaptor<burn::optim::Adam, MlpBurnPolicy<B>, B>,
     NPlayerMatchingPennies,
-    impl Fn(&NdArrayDevice) -> MlpBurnPolicy<B>,
+    impl Fn(&NdArrayDevice, u64) -> MlpBurnPolicy<B>,
     impl Fn() -> BurnOptimizer<
         B,
         MlpBurnPolicy<B>,
@@ -81,11 +81,12 @@ fn build_n_player_trainer(
         nfsp_config,
         joint_config,
         device,
-        |dev: &NdArrayDevice| {
-            MlpBurnPolicy::<B>::new(
+        |dev: &NdArrayDevice, seed: u64| {
+            MlpBurnPolicy::<B>::new_seeded(
                 NPlayerMatchingPennies::OBS_DIM,
                 NPlayerMatchingPennies::ACTION_DIM,
                 16,
+                seed,
                 dev,
             )
         },

--- a/tests/test_psro_bucket_brigade.rs
+++ b/tests/test_psro_bucket_brigade.rs
@@ -388,8 +388,14 @@ fn test_psro_beats_ppo_on_no_convergence_cells() {
         let beta_c = *beta;
         let kappa_c = *kappa;
         let cost_c = *cost;
-        let policy_factory = move |dev: &NdArrayDevice| {
-            MultiDiscreteMlpBurnPolicy::<B>::new(obs_dim, vec![NUM_HOUSES, 2, 2], HIDDEN_DIM, dev)
+        let policy_factory = move |dev: &NdArrayDevice, seed: u64| {
+            MultiDiscreteMlpBurnPolicy::<B>::new_seeded(
+                obs_dim,
+                vec![NUM_HOUSES, 2, 2],
+                HIDDEN_DIM,
+                seed,
+                dev,
+            )
         };
         let optimizer_factory = || {
             let inner = AdamConfig::new().init();

--- a/tests/test_psro_matching_pennies.rs
+++ b/tests/test_psro_matching_pennies.rs
@@ -96,8 +96,14 @@ fn test_psro_converges_to_uniform_on_matching_pennies() {
         joint_config,
         meta_solver,
         device,
-        |dev: &NdArrayDevice| {
-            MlpBurnPolicy::<B>::new(MatchingPennies::OBS_DIM, MatchingPennies::ACTION_DIM, 16, dev)
+        |dev: &NdArrayDevice, seed: u64| {
+            MlpBurnPolicy::<B>::new_seeded(
+                MatchingPennies::OBS_DIM,
+                MatchingPennies::ACTION_DIM,
+                16,
+                seed,
+                dev,
+            )
         },
         || {
             let inner = AdamConfig::new().init();
@@ -165,19 +171,24 @@ fn test_psro_converges_to_uniform_on_matching_pennies() {
 /// Tightened from `+1.2` to `+1.0` after issue #114 plumbed the
 /// seeded `StdRng` through `get_action_host_seeded`. A 10-run release-
 /// mode sweep on this seed triple observed `(second - first)`
-/// deltas in `[0.71, 0.88]` (mean ≈ 0.81). The new `+1.0` bound
-/// gives ~14% headroom over the worst observed delta while halving
-/// the previous slack.
+/// deltas in `[0.71, 0.88]` (mean ≈ 0.81). The `+1.0` bound gave
+/// ~14% headroom over the worst observed delta while halving the
+/// previous slack.
 ///
-/// **Why not bit-exact / +0.2?** Bit-identical exploitability curves
-/// across runs of the same `PsroConfig::seed` would additionally
-/// require seeding the policy *initialization* RNG — Burn 0.21's
-/// `Initializer::Orthogonal` uses an unseeded thread-local generator
-/// internally, with no exposed API to inject a custom RNG. Per-
-/// iteration `policy_factory` calls therefore inject ~0.1 of
-/// (second − first) variance that can't be eliminated by seeding the
-/// rollout-time action sampler alone. Bit-exact PSRO is tracked as a
-/// follow-up Burn-upstream concern, not part of #114.
+/// **Now bit-exact (issue #135).** The last unseeded RNG site —
+/// policy *initialization* — has been plumbed through a seeded host-
+/// side init shim (`MlpBurnPolicy::new_seeded` →
+/// `crate::policy::seeded_init`, driven by `StdRng::seed_from_u64`),
+/// and the PSRO factory now receives a distinct per-construction seed
+/// derived from `PsroConfig::seed`. As a result this curve is fully
+/// **deterministic**: across 10 release-mode runs the averaged
+/// `(second - first)` delta is identically `0.7655` (first-half mean
+/// `0.9686`, second-half mean `1.7341`) — zero run-to-run variance.
+/// The band is therefore tightened from `+1.0` to `+0.85`, ~11%
+/// headroom over the now-exact observed delta. (We do *not* assert a
+/// literal trace equality here because that belongs in
+/// `tests/test_seeded_reproducibility.rs`, which checks bit-identity
+/// directly; this test keeps its trend-monotonicity contract.)
 #[test]
 fn test_psro_exploitability_non_increasing_trend_on_matching_pennies() {
     let device: NdArrayDevice = Default::default();
@@ -205,11 +216,12 @@ fn test_psro_exploitability_non_increasing_trend_on_matching_pennies() {
             joint_config.clone(),
             Box::new(FictitiousPlayMetaSolver::new(500)) as Box<dyn MetaSolver>,
             device,
-            |dev: &NdArrayDevice| {
-                MlpBurnPolicy::<B>::new(
+            |dev: &NdArrayDevice, seed: u64| {
+                MlpBurnPolicy::<B>::new_seeded(
                     MatchingPennies::OBS_DIM,
                     MatchingPennies::ACTION_DIM,
                     16,
+                    seed,
                     dev,
                 )
             },
@@ -249,7 +261,7 @@ fn test_psro_exploitability_non_increasing_trend_on_matching_pennies() {
         first_half_mean, second_half_mean
     );
     assert!(
-        second_half_mean <= first_half_mean + 1.0,
-        "averaged exploitability second-half mean exceeded first-half mean + 1.0;          first={first_half_mean}, second={second_half_mean}.          The asserted band was tightened from +1.2 to +1.0 after #114 plumbed the          seeded `StdRng` through `get_action_host_seeded`; see test docs for the          calibration rationale and the residual policy-init nondeterminism.",
+        second_half_mean <= first_half_mean + 0.85,
+        "averaged exploitability second-half mean exceeded first-half mean + 0.85;          first={first_half_mean}, second={second_half_mean}.          The band was tightened from +1.0 to +0.85 after issue #135 made the          curve bit-exact by seeding policy init; the deterministic delta is          0.7655. See test docs for the calibration rationale.",
     );
 }

--- a/tests/test_psro_n_player_matching_pennies.rs
+++ b/tests/test_psro_n_player_matching_pennies.rs
@@ -132,11 +132,12 @@ fn test_psro_n4_converges_to_uniform_on_majority_game() {
         joint_config,
         meta_solver,
         device,
-        |dev: &NdArrayDevice| {
-            MlpBurnPolicy::<B>::new(
+        |dev: &NdArrayDevice, seed: u64| {
+            MlpBurnPolicy::<B>::new_seeded(
                 NPlayerMatchingPennies::OBS_DIM,
                 NPlayerMatchingPennies::ACTION_DIM,
                 16,
+                seed,
                 dev,
             )
         },
@@ -185,7 +186,18 @@ fn test_psro_n4_converges_to_uniform_on_majority_game() {
 /// reduces to the legacy 2-player exploitability formula for N=2 by
 /// construction; see `compute_nashconv`'s N=2 fast path) is finite,
 /// non-negative, and decreases on average — last-half mean ≤
-/// first-half mean + `0.5` slack.
+/// first-half mean + `0.2` slack.
+///
+/// **Bit-exact since issue #135.** With policy init seeded
+/// (`MlpBurnPolicy::new_seeded` → `crate::policy::seeded_init`) and the
+/// PSRO factory fed a distinct per-construction seed derived from
+/// `PsroConfig::seed`, this curve is fully deterministic. Across
+/// repeated release-mode runs the curve is identically
+/// `[1.0, 3.5556, 1.375, 1.3120, 1.2577]`: first-half mean `2.2778`,
+/// second-half mean `1.3149`, so `(second - first) = -0.963` every
+/// run. The slack is tightened from `+0.5` to `+0.2`; the deterministic
+/// delta sits ~1.16 below the bound, so the assertion fires only on a
+/// genuine blow-up.
 ///
 /// The PSRO N≥3 NashConv is monotonically-decreasing in *expectation*
 /// (each newly-added best response is, by α-rank's response-graph
@@ -223,11 +235,12 @@ fn test_psro_n4_nashconv_trend_does_not_blow_up() {
         joint_config,
         meta_solver,
         device,
-        |dev: &NdArrayDevice| {
-            MlpBurnPolicy::<B>::new(
+        |dev: &NdArrayDevice, seed: u64| {
+            MlpBurnPolicy::<B>::new_seeded(
                 NPlayerMatchingPennies::OBS_DIM,
                 NPlayerMatchingPennies::ACTION_DIM,
                 16,
+                seed,
                 dev,
             )
         },
@@ -252,7 +265,7 @@ fn test_psro_n4_nashconv_trend_does_not_blow_up() {
     let second_mean: f32 = expls[half..].iter().copied().sum::<f32>() / (n - half) as f32;
     println!("N=4 NashConv first-half mean = {first_mean:.4}, second-half mean = {second_mean:.4}");
     assert!(
-        second_mean <= first_mean + 0.5,
-        "NashConv blew up: first-half mean {first_mean}, second-half mean {second_mean}"
+        second_mean <= first_mean + 0.2,
+        "NashConv blew up: first-half mean {first_mean}, second-half mean {second_mean}.          Band tightened from +0.5 to +0.2 after issue #135 made the curve          bit-exact (deterministic delta -0.963); see test docs."
     );
 }

--- a/tests/test_seeded_reproducibility.rs
+++ b/tests/test_seeded_reproducibility.rs
@@ -1,0 +1,157 @@
+//! End-to-end bit-exact reproducibility tests for PSRO and NFSP under
+//! a fixed `PsroConfig::seed` / `NfspConfig::seed` (issue #135).
+//!
+//! These close the last determinism gap: with the seeded host-side
+//! policy-init shim (`MlpBurnPolicy::new_seeded` /
+//! `MlpBurnConfig::with_seed`, routed through
+//! `crate::policy::seeded_init`) plumbed into the trainers' per-
+//! construction seed derivation, two runs with the same seed must
+//! produce **bit-identical** trajectories — not merely a bounded trend.
+//!
+//! The rollout/training RNG sites were already seeded in PRs
+//! #113/#116/#122/#123/#125; before this PR the policy-init RNG (Burn
+//! 0.21's unseedable `Initializer`) injected residual nondeterminism
+//! that forced the matching-pennies tolerance bands to stay loose. With
+//! init seeded the curves are reproducible to the last bit.
+
+#![cfg(feature = "training")]
+
+use burn::{
+    backend::{Autodiff, NdArray, ndarray::NdArrayDevice},
+    optim::AdamConfig,
+};
+use thrust_rl::{
+    env::games::matching_pennies::MatchingPennies,
+    multi_agent::{
+        FictitiousPlayMetaSolver, JointTrainerConfig, MetaSolver, NfspConfig, NfspTrainer,
+        PsroConfig, PsroTrainer,
+    },
+    policy::mlp::MlpBurnPolicy,
+    train::optimizer::BurnOptimizer,
+};
+
+type B = Autodiff<NdArray<f32>>;
+
+/// Run PSRO on matching pennies with the given seed and return the
+/// per-iteration exploitability trace.
+fn psro_exploitability_trace(seed: u64) -> Vec<f32> {
+    let device: NdArrayDevice = Default::default();
+    let psro_config = PsroConfig {
+        max_iterations: 6,
+        max_population_size: 50,
+        br_train_steps_per_iteration: 2,
+        payoff_eval_episodes: 4,
+        seed,
+    };
+    let joint_config = JointTrainerConfig {
+        num_agents: 2,
+        rollout_steps: 32,
+        n_epochs: 1,
+        minibatch_size: 32,
+        ..Default::default()
+    };
+    let mut trainer = PsroTrainer::new(
+        psro_config,
+        joint_config,
+        Box::new(FictitiousPlayMetaSolver::new(500)) as Box<dyn MetaSolver>,
+        device,
+        |dev: &NdArrayDevice, s: u64| {
+            MlpBurnPolicy::<B>::new_seeded(
+                MatchingPennies::OBS_DIM,
+                MatchingPennies::ACTION_DIM,
+                16,
+                s,
+                dev,
+            )
+        },
+        || BurnOptimizer::new(AdamConfig::new().init(), 1e-3),
+        MatchingPennies::new,
+    )
+    .expect("PsroTrainer::new should succeed");
+    let stats = trainer.run().expect("PSRO run should not error");
+    stats.iterations.iter().map(|it| it.exploitability).collect()
+}
+
+/// Two PSRO runs with the same seed produce a bit-identical
+/// exploitability trace; a different seed produces a different trace.
+#[test]
+fn test_psro_exploitability_trace_is_bit_identical() {
+    let a = psro_exploitability_trace(42);
+    let b = psro_exploitability_trace(42);
+    assert_eq!(a.len(), 6);
+    assert_eq!(a, b, "same PsroConfig::seed must yield a bit-identical exploitability trace");
+
+    let c = psro_exploitability_trace(43);
+    assert_ne!(a, c, "different seed should change the trace");
+}
+
+/// Run NFSP on matching pennies with the given seed and return the
+/// per-iteration average-policy action marginals (agent 0) as a flat
+/// trace.
+#[allow(clippy::type_complexity)]
+fn nfsp_avg_marginal_trace(seed: u64) -> Vec<f32> {
+    let device: NdArrayDevice = Default::default();
+    let nfsp_config = NfspConfig {
+        max_iterations: 6,
+        anticipatory_param: 0.1,
+        reservoir_capacity: 4_096,
+        br_train_steps_per_iteration: 1,
+        avg_policy_train_steps_per_iteration: 4,
+        avg_policy_minibatch_size: 32,
+        avg_policy_lr: 5e-3,
+        seed,
+    };
+    let joint_config = JointTrainerConfig {
+        num_agents: 2,
+        rollout_steps: 64,
+        n_epochs: 1,
+        minibatch_size: 32,
+        ..Default::default()
+    };
+    let mut trainer: NfspTrainer<
+        B,
+        MlpBurnPolicy<B>,
+        burn::optim::adaptor::OptimizerAdaptor<burn::optim::Adam, MlpBurnPolicy<B>, B>,
+        MatchingPennies,
+        _,
+        _,
+        _,
+    > = NfspTrainer::new(
+        nfsp_config,
+        joint_config,
+        device,
+        |dev: &NdArrayDevice, s: u64| {
+            MlpBurnPolicy::<B>::new_seeded(
+                MatchingPennies::OBS_DIM,
+                MatchingPennies::ACTION_DIM,
+                16,
+                s,
+                dev,
+            )
+        },
+        || BurnOptimizer::new(AdamConfig::new().init(), 5e-3),
+        MatchingPennies::new,
+    )
+    .expect("NfspTrainer::new should succeed");
+    let stats = trainer.run_silent().expect("NFSP run should not error");
+    let mut trace = Vec::new();
+    for it in &stats.iterations {
+        if let Some(Some(m)) = it.avg_action_marginal.first() {
+            trace.extend_from_slice(m);
+        }
+    }
+    trace
+}
+
+/// Two NFSP runs with the same seed produce a bit-identical
+/// average-policy marginal trace; a different seed differs.
+#[test]
+fn test_nfsp_avg_marginal_trace_is_bit_identical() {
+    let a = nfsp_avg_marginal_trace(7);
+    let b = nfsp_avg_marginal_trace(7);
+    assert!(!a.is_empty(), "trace should be non-empty");
+    assert_eq!(a, b, "same NfspConfig::seed must yield a bit-identical marginal trace");
+
+    let c = nfsp_avg_marginal_trace(8);
+    assert_ne!(a, c, "different seed should change the trace");
+}


### PR DESCRIPTION
Closes #135.

## What this does

Closes the last unseeded RNG site in the PSRO/NFSP determinism contract advertised by `PsroConfig::seed` / `NfspConfig::seed`: **policy weight initialization**. Burn 0.21's `Initializer::{Orthogonal,KaimingUniform}` take no seed parameter and route through an unseeded thread-local generator, so two runs with the same seed previously diverged at init. This implements **Option B** (in-tree seeded shim).

## Design decisions (the two BLOCKING curator corrections)

**Correction 1 — per-construction seed derivation.** The policy factory enters via a closure called once per agent at construction and once per best-response per outer iteration. A single fixed seed would make every construction produce *identical* weights — a regression. The factory signature is therefore extended from `Fn(&Device) -> P` to **`Fn(&Device, u64) -> P`**, and each trainer owns a monotonic init-counter derived from `config.seed` (`PsroTrainer::next_init_seed`, NFSP's per-bank `init_seed` closure). Every agent's initial policy and every per-iteration BR gets a distinct, deterministic seed. Blast radius: `PsroTrainer`/`NfspTrainer` bounds + 8 test call sites + 2 examples, all updated.

**Correction 2 — Kaiming-path coverage.** The matching-pennies tests build policies via `MlpBurnPolicy::new()` → `use_orthogonal_init = false` → **Kaiming-uniform**, not Orthogonal. The seeded shim covers **both** recipes (selected by `use_orthogonal_init`), so seeding works on the path the tests actually use. The tests now construct via `new_seeded(..)`.

## Implementation

- **`src/policy/seeded_init.rs` (NEW):** `seeded_orthogonal` (hand-rolled modified-Gram-Schmidt QR of a seeded Gaussian with a deterministic sign fix — no `nalgebra`) and `seeded_kaiming_uniform` (`bound = gain * sqrt(3/fan_in)`). Both driven by `StdRng::seed_from_u64`; normals via Box-Muller over `rng.random::<f32>()`. Bit-parity with Burn's unseeded output is **not** a goal — we replace the distribution with a reproducible one.
- **`src/policy/mlp.rs`:** `MlpBurnConfig.seed: Option<u64>` + `with_seed`; `with_config` routes through the seeded path when `Some`, preserves the `Initializer` path verbatim when `None`; `new_seeded` convenience ctor; `linear_from_weights` / `derive_layer_seed` / `seeded_layer_weights` helpers. Per-layer seeds are derived (splitmix64) so same-shape layers don't collide.
- **`src/policy/multi_discrete_mlp.rs`:** same per-head, with distinct seed streams per action head.
- **`src/multi_agent/{psro,nfsp}.rs`:** factory signature + per-construction seed plumbing.

## Tests

**New reproducibility tests** (`tests/test_seeded_reproducibility.rs`): two PSRO runs with the same seed produce a **bit-identical** exploitability trace; two NFSP runs produce a bit-identical avg-policy-marginal trace; different seeds differ. Plus bit-identical-weights unit tests on both policies and layer-decorrelation tests.

**Tolerance recalibration** (curves are now fully deterministic — verified by repeated release-mode runs producing identical values):
- `test_psro_matching_pennies` trend: `+1.0` → **`+0.85`**. Deterministic delta is `0.7655` every run (first-half mean `0.9686`, second-half `1.7341`); +0.85 gives ~11% headroom.
- `test_psro_n_player_matching_pennies` NashConv slack: `+0.5` → **`+0.2`**. Deterministic curve `[1.0, 3.5556, 1.375, 1.3120, 1.2577]`, delta `-0.963` every run; the bound sits ~1.16 above.
- `test_nfsp_matching_pennies` (`0.10`) and `test_nfsp_n_player_matching_pennies` (`0.05`) TV bounds: **unchanged**, confirmed still green.

## Quality gate

- All affected suites green in release mode (PSRO/NFSP matching-pennies x2, n-player x2, multi-discrete smoke, bucket-brigade, new reproducibility tests, 50 trainer-module unit tests, 36 policy unit tests).
- `cargo clippy --all-targets --features training -- -D warnings`: **zero errors in any file this PR touches.** The repo has 64 pre-existing clippy errors in untouched files (`buffer/rollout/tests.rs`, `policy/{inference,universal_inference}.rs`, snake/pong envs, etc.) that predate this branch; this PR introduces none and additionally removes one (`mlp.rs`'s pre-existing unused `LinearConfig` import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)