### PR TITLE
SAC PR A: ContinuousReplayBuffer for off-policy continuous-action storage

### DIFF
--- a/src/buffer/replay.rs
+++ b/src/buffer/replay.rs
@@ -8,8 +8,12 @@
 //! 2. [`PrioritizedReplayBuffer`] — a sum-tree backed buffer with proportional
 //!    priority sampling and importance-sampling correction weights (Schaul et
 //!    al. 2015).
+//! 3. [`ContinuousReplayBuffer`] — the continuous-action sibling of
+//!    [`ReplayBuffer`], storing `Vec<f32>` actions of width `action_dim` for
+//!    off-policy continuous control (SAC / TD3 / DDPG). Same ring/FIFO design
+//!    and flat-`Vec` storage; sample it via [`sample_continuous`].
 //!
-//! Both store transitions as flat CPU-side `Vec`s rather than Burn tensors
+//! All store transitions as flat CPU-side `Vec`s rather than Burn tensors
 //! so the buffer stays WASM-compatible if it ever needs to be exposed
 //! there. Tensor materialization happens via `to_burn_tensors` on the
 //! batch types when the trainer pushes them to a device.
@@ -52,11 +56,17 @@
 //! }
 //! ```
 
+pub use continuous_sampling::{
+    ContinuousReplayBatch, ContinuousReplayBurnTensors, sample as sample_continuous,
+};
+pub use continuous_storage::ContinuousReplayBuffer;
 pub use prioritized::{PrioritizedBatch, PrioritizedBurnTensors, PrioritizedReplayBuffer};
 pub use sampling::{ReplayBatch, ReplayBurnTensors, sample};
 pub use storage::ReplayBuffer;
 pub use sum_tree::SumTree;
 
+mod continuous_sampling;
+mod continuous_storage;
 mod prioritized;
 mod sampling;
 mod storage;

--- a/src/buffer/replay/continuous_sampling.rs
+++ b/src/buffer/replay/continuous_sampling.rs
@@ -1,0 +1,303 @@
+//! Uniform random sampling and tensor conversion for the continuous-action
+//! replay buffer.
+//!
+//! `sample` draws `batch_size` independent uniform indices from the filled
+//! portion of a [`super::continuous_storage::ContinuousReplayBuffer`] and
+//! copies the transitions into flat CPU-side vectors.
+//! [`ContinuousReplayBatch::to_burn_tensors`] then stacks those vectors into
+//! Burn tensors on the requested device so the trainer can run actor/critic
+//! forward passes.
+//!
+//! This mirrors [`super::sampling`] but with continuous `f32` actions of
+//! width `action_dim` (shape `[batch, action_dim]`) rather than discrete
+//! `i64` actions.
+
+use burn::tensor::{Tensor as BurnTensor, TensorData, backend::Backend};
+use rand::Rng;
+
+use super::continuous_storage::ContinuousReplayBuffer;
+
+/// One minibatch sampled from the continuous replay buffer.
+///
+/// All fields are CPU-side primitive vectors; convert to Burn tensors via
+/// [`ContinuousReplayBatch::to_burn_tensors`] when handing them to the
+/// trainer.
+#[derive(Debug, Clone)]
+pub struct ContinuousReplayBatch {
+    /// Flattened current observations, shape `[batch_size * obs_dim]`.
+    pub observations: Vec<f32>,
+    /// Flattened actions taken, shape `[batch_size * action_dim]`.
+    pub actions: Vec<f32>,
+    /// Rewards received, length `batch_size`.
+    pub rewards: Vec<f32>,
+    /// Flattened next observations, shape `[batch_size * obs_dim]`.
+    pub next_observations: Vec<f32>,
+    /// Episode-end mask, length `batch_size`. `true` means the transition
+    /// terminated the episode (so the TD target drops the bootstrap term).
+    pub dones: Vec<bool>,
+    /// Length of one observation slice (so `to_burn_tensors` can reshape).
+    pub obs_dim: usize,
+    /// Length of one action slice (so `to_burn_tensors` can reshape).
+    pub action_dim: usize,
+}
+
+impl ContinuousReplayBatch {
+    /// Number of transitions in the batch.
+    pub fn len(&self) -> usize {
+        self.rewards.len()
+    }
+
+    /// `true` if the batch is empty.
+    pub fn is_empty(&self) -> bool {
+        self.rewards.is_empty()
+    }
+
+    /// Stack the batch into Burn tensors on `device`.
+    ///
+    /// Returns a named [`ContinuousReplayBurnTensors`] struct so trainers can
+    /// pattern-match named fields rather than positional tuple elements.
+    ///
+    /// Shapes (all on `device`):
+    /// - `observations`: `[batch, obs_dim]`, `f32`
+    /// - `actions`: `[batch, action_dim]`, `f32`
+    /// - `rewards`: `[batch]`, `f32`
+    /// - `next_observations`: `[batch, obs_dim]`, `f32`
+    /// - `dones`: `[batch]`, `f32` (0.0 / 1.0; the TD-target formula `(1 -
+    ///   done)` consumes it directly as a float mask).
+    pub fn to_burn_tensors<B: Backend>(
+        &self,
+        device: &B::Device,
+    ) -> ContinuousReplayBurnTensors<B> {
+        let batch = self.len();
+        let obs_dim = self.obs_dim;
+        let action_dim = self.action_dim;
+
+        // Direct rank-2 construction (vs. rank-1 + reshape) to keep the
+        // empty-batch case panic-free; the reshape path trips an internal
+        // shape assertion in cubecl-zspace when both dims are zero.
+        let observations = BurnTensor::<B, 2>::from_data(
+            TensorData::new(self.observations.clone(), [batch, obs_dim]),
+            device,
+        );
+        let next_observations = BurnTensor::<B, 2>::from_data(
+            TensorData::new(self.next_observations.clone(), [batch, obs_dim]),
+            device,
+        );
+        let actions = BurnTensor::<B, 2>::from_data(
+            TensorData::new(self.actions.clone(), [batch, action_dim]),
+            device,
+        );
+        let rewards =
+            BurnTensor::<B, 1>::from_data(TensorData::new(self.rewards.clone(), [batch]), device);
+        let dones_f: Vec<f32> = self.dones.iter().map(|&d| if d { 1.0 } else { 0.0 }).collect();
+        let dones = BurnTensor::<B, 1>::from_data(TensorData::new(dones_f, [batch]), device);
+
+        ContinuousReplayBurnTensors { observations, actions, rewards, next_observations, dones }
+    }
+}
+
+/// Bundle of Burn tensors produced by
+/// [`ContinuousReplayBatch::to_burn_tensors`].
+///
+/// Fields are in the order off-policy continuous-control trainers consume
+/// them: state and action first, then the reward signal, then the bootstrap
+/// state and terminal mask used to build the TD target. Fields are named so
+/// downstream patches that add fields stay source-compatible.
+#[derive(Debug)]
+pub struct ContinuousReplayBurnTensors<B: Backend> {
+    /// Observations, shape `[batch, obs_dim]`, dtype `f32`.
+    pub observations: BurnTensor<B, 2>,
+    /// Continuous actions, shape `[batch, action_dim]`, dtype `f32`.
+    pub actions: BurnTensor<B, 2>,
+    /// Rewards, shape `[batch]`, dtype `f32`.
+    pub rewards: BurnTensor<B, 1>,
+    /// Bootstrap-state observations, shape `[batch, obs_dim]`, dtype `f32`.
+    pub next_observations: BurnTensor<B, 2>,
+    /// Episode-terminal mask (0.0 or 1.0), shape `[batch]`, dtype `f32`.
+    /// Kept as `f32` so the TD-target formula `(1 - done)` works directly.
+    pub dones: BurnTensor<B, 1>,
+}
+
+/// Sample `batch_size` transitions uniformly with replacement from the
+/// filled portion of `buffer`.
+///
+/// Uniform with-replacement matches the canonical off-policy recipe and is
+/// what makes the sampler O(1) per draw. For small batches relative to
+/// buffer size the difference vs without-replacement is negligible.
+///
+/// # Panics
+/// Panics if `buffer.is_empty()` or `batch_size == 0`.
+pub fn sample<R: Rng>(
+    buffer: &ContinuousReplayBuffer,
+    batch_size: usize,
+    rng: &mut R,
+) -> ContinuousReplayBatch {
+    assert!(!buffer.is_empty(), "ContinuousReplayBuffer is empty; cannot sample");
+    assert!(batch_size > 0, "batch_size must be > 0");
+
+    let obs_dim = buffer.obs_dim();
+    let action_dim = buffer.action_dim();
+    let len = buffer.len();
+
+    let mut observations = vec![0.0f32; batch_size * obs_dim];
+    let mut next_observations = vec![0.0f32; batch_size * obs_dim];
+    let mut actions = vec![0.0f32; batch_size * action_dim];
+    let mut rewards = Vec::with_capacity(batch_size);
+    let mut dones = Vec::with_capacity(batch_size);
+
+    for k in 0..batch_size {
+        let idx = rng.random_range(0..len);
+        let obs_slice = &mut observations[k * obs_dim..(k + 1) * obs_dim];
+        let next_slice = &mut next_observations[k * obs_dim..(k + 1) * obs_dim];
+        let action_slice = &mut actions[k * action_dim..(k + 1) * action_dim];
+        let (r, d) = buffer.read_into(idx, obs_slice, action_slice, next_slice);
+        rewards.push(r);
+        dones.push(d);
+    }
+
+    ContinuousReplayBatch {
+        observations,
+        actions,
+        rewards,
+        next_observations,
+        dones,
+        obs_dim,
+        action_dim,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{SeedableRng, rngs::StdRng};
+
+    use super::*;
+
+    #[test]
+    fn test_sample_returns_correct_count() {
+        let mut buf = ContinuousReplayBuffer::new(16, 3, 2);
+        for i in 0..10 {
+            buf.push(
+                &[i as f32, i as f32 + 0.1, i as f32 + 0.2],
+                &[i as f32, -(i as f32)],
+                i as f32,
+                &[(i + 1) as f32, (i + 1) as f32 + 0.1, (i + 1) as f32 + 0.2],
+                false,
+            );
+        }
+        let mut rng = StdRng::seed_from_u64(42);
+        let batch = sample(&buf, 5, &mut rng);
+        assert_eq!(batch.len(), 5);
+        assert_eq!(batch.rewards.len(), 5);
+        assert_eq!(batch.dones.len(), 5);
+        assert_eq!(batch.observations.len(), 5 * 3);
+        assert_eq!(batch.next_observations.len(), 5 * 3);
+        assert_eq!(batch.actions.len(), 5 * 2);
+        assert_eq!(batch.obs_dim, 3);
+        assert_eq!(batch.action_dim, 2);
+    }
+
+    #[test]
+    fn test_sampled_values_match_pushed_values() {
+        // Push a single transition; every sample must return it.
+        let mut buf = ContinuousReplayBuffer::new(8, 2, 3);
+        buf.push(&[7.0, 8.0], &[0.1, 0.2, 0.3], 42.0, &[9.0, 10.0], true);
+
+        let mut rng = StdRng::seed_from_u64(0);
+        let batch = sample(&buf, 4, &mut rng);
+        for k in 0..4 {
+            assert_eq!(batch.rewards[k], 42.0);
+            assert!(batch.dones[k]);
+            assert_eq!(&batch.observations[k * 2..(k + 1) * 2], &[7.0, 8.0]);
+            assert_eq!(&batch.next_observations[k * 2..(k + 1) * 2], &[9.0, 10.0]);
+            assert_eq!(&batch.actions[k * 3..(k + 1) * 3], &[0.1, 0.2, 0.3]);
+        }
+    }
+
+    mod burn_tests {
+        use burn::backend::NdArray;
+
+        use super::*;
+
+        type B = NdArray<f32>;
+
+        #[test]
+        fn test_to_burn_tensors_shapes_and_roundtrip() {
+            let mut buf = ContinuousReplayBuffer::new(8, 4, 2);
+            for i in 0..6 {
+                buf.push(
+                    &[i as f32; 4],
+                    &[i as f32, i as f32 + 0.5],
+                    i as f32,
+                    &[i as f32 + 1.0; 4],
+                    i == 5,
+                );
+            }
+            let mut rng = StdRng::seed_from_u64(1);
+            let batch = sample(&buf, 3, &mut rng);
+            let device = crate::utils::cuda::default_burn_device::<B>();
+            let t = batch.to_burn_tensors::<B>(&device);
+
+            // Shapes.
+            assert_eq!(t.observations.dims(), [3, 4]);
+            assert_eq!(t.next_observations.dims(), [3, 4]);
+            assert_eq!(t.actions.dims(), [3, 2]);
+            assert_eq!(t.rewards.dims(), [3]);
+            assert_eq!(t.dones.dims(), [3]);
+
+            // Round-trip: copying out the host data should match the
+            // CPU-side `Vec`s the batch was built from.
+            let obs_flat: Vec<f32> = t.observations.into_data().to_vec().unwrap();
+            assert_eq!(obs_flat, batch.observations);
+            let next_flat: Vec<f32> = t.next_observations.into_data().to_vec().unwrap();
+            assert_eq!(next_flat, batch.next_observations);
+            let acts: Vec<f32> = t.actions.into_data().to_vec().unwrap();
+            assert_eq!(acts, batch.actions);
+            let rews: Vec<f32> = t.rewards.into_data().to_vec().unwrap();
+            assert_eq!(rews, batch.rewards);
+            let dones_f: Vec<f32> = t.dones.into_data().to_vec().unwrap();
+            let expected_dones: Vec<f32> =
+                batch.dones.iter().map(|&d| if d { 1.0 } else { 0.0 }).collect();
+            assert_eq!(dones_f, expected_dones);
+        }
+
+        #[test]
+        fn test_to_burn_tensors_empty_batch_does_not_panic() {
+            // A 0-row batch must produce well-formed zero-element tensors.
+            // The buffer-side `sample` API doesn't accept batch_size == 0,
+            // so build the batch by hand to exercise the edge case.
+            let batch = ContinuousReplayBatch {
+                observations: vec![],
+                actions: vec![],
+                rewards: vec![],
+                next_observations: vec![],
+                dones: vec![],
+                obs_dim: 4,
+                action_dim: 2,
+            };
+            let device = crate::utils::cuda::default_burn_device::<B>();
+            let t = batch.to_burn_tensors::<B>(&device);
+            assert_eq!(t.observations.dims(), [0, 4]);
+            assert_eq!(t.next_observations.dims(), [0, 4]);
+            assert_eq!(t.actions.dims(), [0, 2]);
+            assert_eq!(t.rewards.dims(), [0]);
+            assert_eq!(t.dones.dims(), [0]);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "ContinuousReplayBuffer is empty")]
+    fn test_sample_empty_panics() {
+        let buf = ContinuousReplayBuffer::new(4, 2, 1);
+        let mut rng = StdRng::seed_from_u64(0);
+        let _ = sample(&buf, 2, &mut rng);
+    }
+
+    #[test]
+    #[should_panic(expected = "batch_size must be > 0")]
+    fn test_zero_batch_size_panics() {
+        let mut buf = ContinuousReplayBuffer::new(4, 2, 1);
+        buf.push(&[0.0, 0.0], &[0.0], 0.0, &[0.0, 0.0], false);
+        let mut rng = StdRng::seed_from_u64(0);
+        let _ = sample(&buf, 0, &mut rng);
+    }
+}

--- a/src/buffer/replay/continuous_storage.rs
+++ b/src/buffer/replay/continuous_storage.rs
@@ -1,0 +1,328 @@
+//! Continuous-action replay buffer storage for off-policy training.
+//!
+//! This module mirrors [`super::storage::ReplayBuffer`] but stores
+//! **continuous** `Vec<f32>` actions of width `action_dim` (e.g. for SAC /
+//! TD3 / DDPG) instead of a single discrete `i64` action. Like the discrete
+//! buffer, transitions are stored as plain CPU-side primitive vectors rather
+//! than Burn tensors so the buffer stays WASM-compatible if it's ever exposed
+//! there, and so the same code path can serve `--no-default-features` builds.
+//!
+//! # Layout
+//!
+//! For a buffer of capacity `C`, observation dimension `D`, and action
+//! dimension `A`:
+//! - `observations`: `Vec<f32>` of length `C * D` (flattened)
+//! - `actions`: `Vec<f32>` of length `C * A` (flattened)
+//! - `rewards`: `Vec<f32>` of length `C`
+//! - `next_observations`: `Vec<f32>` of length `C * D` (flattened)
+//! - `dones`: `Vec<bool>` of length `C`
+//!
+//! Position `i` in the buffer is the slice
+//! `observations[i*D .. (i+1)*D]` paired with `actions[i*A .. (i+1)*A]`,
+//! `rewards[i]`, `next_observations[i*D .. (i+1)*D]`, and `dones[i]`.
+//!
+//! # Ring semantics
+//!
+//! `push` writes at `write_idx`, increments `write_idx` modulo `capacity`,
+//! and grows `len` up to (but not past) `capacity`. Once the buffer is
+//! full, additional pushes overwrite the oldest transition (FIFO eviction).
+
+/// Fixed-capacity FIFO replay buffer for off-policy continuous-action
+/// training.
+///
+/// Stores `(obs, action, reward, next_obs, done)` transitions with
+/// continuous `Vec<f32>` actions of width `action_dim`, and supports uniform
+/// random sampling via [`super::continuous_sampling::sample`]. The buffer is
+/// allocated once at construction (`vec![0.0; capacity * obs_dim]` etc.); no
+/// further allocations occur during `push`.
+///
+/// This is the continuous-action sibling of
+/// [`ReplayBuffer`](super::storage::ReplayBuffer); the discrete DQN buffer is
+/// left untouched.
+#[derive(Debug, Clone)]
+pub struct ContinuousReplayBuffer {
+    obs_dim: usize,
+    action_dim: usize,
+    capacity: usize,
+    len: usize,
+    write_idx: usize,
+
+    observations: Vec<f32>,
+    actions: Vec<f32>,
+    rewards: Vec<f32>,
+    next_observations: Vec<f32>,
+    dones: Vec<bool>,
+}
+
+impl ContinuousReplayBuffer {
+    /// Create a new continuous replay buffer with the given capacity,
+    /// observation dimensionality, and action dimensionality.
+    ///
+    /// # Arguments
+    /// * `capacity` - Maximum number of transitions stored. Must be > 0.
+    /// * `obs_dim` - Length of one observation vector. Must be > 0.
+    /// * `action_dim` - Length of one action vector. Must be > 0.
+    ///
+    /// # Panics
+    /// Panics if `capacity == 0`, `obs_dim == 0`, or `action_dim == 0`.
+    pub fn new(capacity: usize, obs_dim: usize, action_dim: usize) -> Self {
+        assert!(capacity > 0, "ContinuousReplayBuffer capacity must be > 0");
+        assert!(obs_dim > 0, "ContinuousReplayBuffer obs_dim must be > 0");
+        assert!(action_dim > 0, "ContinuousReplayBuffer action_dim must be > 0");
+
+        Self {
+            obs_dim,
+            action_dim,
+            capacity,
+            len: 0,
+            write_idx: 0,
+            observations: vec![0.0; capacity * obs_dim],
+            actions: vec![0.0; capacity * action_dim],
+            rewards: vec![0.0; capacity],
+            next_observations: vec![0.0; capacity * obs_dim],
+            dones: vec![false; capacity],
+        }
+    }
+
+    /// Push a single transition into the buffer.
+    ///
+    /// When the buffer is at capacity, this overwrites the oldest
+    /// transition (FIFO eviction).
+    ///
+    /// # Arguments
+    /// * `obs` - Current observation; must have length `obs_dim`.
+    /// * `action` - Continuous action taken; must have length `action_dim`.
+    /// * `reward` - Reward received.
+    /// * `next_obs` - Resulting observation; must have length `obs_dim`.
+    /// * `done` - `true` if the episode terminated (used to mask the bootstrap
+    ///   term in the TD target).
+    ///
+    /// # Panics
+    /// Panics in debug builds if `obs.len() != obs_dim`,
+    /// `next_obs.len() != obs_dim`, or `action.len() != action_dim`.
+    pub fn push(&mut self, obs: &[f32], action: &[f32], reward: f32, next_obs: &[f32], done: bool) {
+        debug_assert_eq!(
+            obs.len(),
+            self.obs_dim,
+            "ContinuousReplayBuffer::push: obs.len() ({}) != obs_dim ({})",
+            obs.len(),
+            self.obs_dim
+        );
+        debug_assert_eq!(
+            next_obs.len(),
+            self.obs_dim,
+            "ContinuousReplayBuffer::push: next_obs.len() ({}) != obs_dim ({})",
+            next_obs.len(),
+            self.obs_dim
+        );
+        debug_assert_eq!(
+            action.len(),
+            self.action_dim,
+            "ContinuousReplayBuffer::push: action.len() ({}) != action_dim ({})",
+            action.len(),
+            self.action_dim
+        );
+
+        let obs_start = self.write_idx * self.obs_dim;
+        let obs_end = obs_start + self.obs_dim;
+        self.observations[obs_start..obs_end].copy_from_slice(obs);
+        self.next_observations[obs_start..obs_end].copy_from_slice(next_obs);
+
+        let act_start = self.write_idx * self.action_dim;
+        let act_end = act_start + self.action_dim;
+        self.actions[act_start..act_end].copy_from_slice(action);
+
+        self.rewards[self.write_idx] = reward;
+        self.dones[self.write_idx] = done;
+
+        self.write_idx = (self.write_idx + 1) % self.capacity;
+        if self.len < self.capacity {
+            self.len += 1;
+        }
+    }
+
+    /// Number of transitions currently in the buffer.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// `true` if the buffer holds no transitions.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Maximum number of transitions the buffer can hold.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Observation dimension (length of one obs slice).
+    pub fn obs_dim(&self) -> usize {
+        self.obs_dim
+    }
+
+    /// Action dimension (length of one action slice).
+    pub fn action_dim(&self) -> usize {
+        self.action_dim
+    }
+
+    /// `true` if the buffer holds at least `min_size` transitions.
+    ///
+    /// Used by the trainer to decide whether to start sampling /
+    /// performing gradient updates: SAC normally collects a few thousand
+    /// transitions before the first update.
+    pub fn is_ready(&self, min_size: usize) -> bool {
+        self.len >= min_size
+    }
+
+    /// Read the transition at logical index `i` (0..len) into the provided
+    /// scratch slices. Used by [`super::continuous_sampling`] to build
+    /// batches.
+    ///
+    /// # Panics
+    /// Panics if `i >= len`, if `obs_out`/`next_obs_out` aren't sized
+    /// `obs_dim`, or if `action_out` isn't sized `action_dim`.
+    pub(super) fn read_into(
+        &self,
+        i: usize,
+        obs_out: &mut [f32],
+        action_out: &mut [f32],
+        next_obs_out: &mut [f32],
+    ) -> (f32, bool) {
+        assert!(
+            i < self.len,
+            "ContinuousReplayBuffer::read_into: i ({}) >= len ({})",
+            i,
+            self.len
+        );
+        assert_eq!(obs_out.len(), self.obs_dim);
+        assert_eq!(next_obs_out.len(), self.obs_dim);
+        assert_eq!(action_out.len(), self.action_dim);
+
+        let obs_start = i * self.obs_dim;
+        let obs_end = obs_start + self.obs_dim;
+        obs_out.copy_from_slice(&self.observations[obs_start..obs_end]);
+        next_obs_out.copy_from_slice(&self.next_observations[obs_start..obs_end]);
+
+        let act_start = i * self.action_dim;
+        let act_end = act_start + self.action_dim;
+        action_out.copy_from_slice(&self.actions[act_start..act_end]);
+
+        (self.rewards[i], self.dones[i])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_push_and_len() {
+        let mut buf = ContinuousReplayBuffer::new(8, 3, 2);
+        assert!(buf.is_empty());
+        assert_eq!(buf.capacity(), 8);
+        assert_eq!(buf.obs_dim(), 3);
+        assert_eq!(buf.action_dim(), 2);
+
+        buf.push(&[1.0, 2.0, 3.0], &[0.1, 0.2], 0.5, &[4.0, 5.0, 6.0], false);
+        assert_eq!(buf.len(), 1);
+        assert!(!buf.is_empty());
+
+        for i in 0..5 {
+            buf.push(
+                &[i as f32; 3],
+                &[i as f32, i as f32 + 0.5],
+                i as f32,
+                &[(i + 1) as f32; 3],
+                false,
+            );
+        }
+        assert_eq!(buf.len(), 6);
+    }
+
+    #[test]
+    fn test_roundtrip_values() {
+        // Push known values, then read them back through read_into.
+        let mut buf = ContinuousReplayBuffer::new(4, 2, 3);
+        buf.push(&[1.0, 2.0], &[0.1, 0.2, 0.3], 10.0, &[3.0, 4.0], false);
+        buf.push(&[5.0, 6.0], &[0.4, 0.5, 0.6], 20.0, &[7.0, 8.0], true);
+
+        let mut obs = [0.0f32; 2];
+        let mut action = [0.0f32; 3];
+        let mut next_obs = [0.0f32; 2];
+        let (r, d) = buf.read_into(0, &mut obs, &mut action, &mut next_obs);
+        assert_eq!(obs, [1.0, 2.0]);
+        assert_eq!(action, [0.1, 0.2, 0.3]);
+        assert_eq!(next_obs, [3.0, 4.0]);
+        assert_eq!(r, 10.0);
+        assert!(!d);
+
+        let (r, d) = buf.read_into(1, &mut obs, &mut action, &mut next_obs);
+        assert_eq!(obs, [5.0, 6.0]);
+        assert_eq!(action, [0.4, 0.5, 0.6]);
+        assert_eq!(next_obs, [7.0, 8.0]);
+        assert_eq!(r, 20.0);
+        assert!(d);
+    }
+
+    #[test]
+    fn test_ring_wraparound_evicts_oldest() {
+        // Capacity 4: push 6 → first 2 should be gone, slots should hold
+        // transitions 2,3,4,5. We tag each transition by its reward value.
+        let mut buf = ContinuousReplayBuffer::new(4, 1, 2);
+        for i in 0..6 {
+            buf.push(&[i as f32], &[i as f32, -(i as f32)], i as f32, &[(i + 100) as f32], false);
+        }
+        assert_eq!(buf.len(), 4, "len must saturate at capacity");
+
+        // Collect all transitions in slot order, keyed by reward (== i).
+        let mut found_rewards = std::collections::HashSet::new();
+        let mut obs_scratch = [0.0f32; 1];
+        let mut action_scratch = [0.0f32; 2];
+        let mut next_scratch = [0.0f32; 1];
+        for i in 0..buf.len() {
+            let (r, _) = buf.read_into(i, &mut obs_scratch, &mut action_scratch, &mut next_scratch);
+            // Action width carries the same tag, sanity-check it survived.
+            assert_eq!(action_scratch, [r, -r]);
+            found_rewards.insert(r as i64);
+        }
+
+        // After 6 pushes into capacity 4, transitions 0 and 1 must be gone
+        // and transitions 2,3,4,5 must remain.
+        assert!(!found_rewards.contains(&0), "oldest transition 0 not evicted");
+        assert!(!found_rewards.contains(&1), "oldest transition 1 not evicted");
+        assert!(found_rewards.contains(&2));
+        assert!(found_rewards.contains(&3));
+        assert!(found_rewards.contains(&4));
+        assert!(found_rewards.contains(&5));
+    }
+
+    #[test]
+    fn test_is_ready() {
+        let mut buf = ContinuousReplayBuffer::new(8, 2, 1);
+        assert!(!buf.is_ready(1));
+        for _ in 0..4 {
+            buf.push(&[0.0, 0.0], &[0.0], 0.0, &[0.0, 0.0], false);
+        }
+        assert!(buf.is_ready(4));
+        assert!(!buf.is_ready(5));
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity must be > 0")]
+    fn test_zero_capacity_panics() {
+        let _ = ContinuousReplayBuffer::new(0, 4, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "obs_dim must be > 0")]
+    fn test_zero_obs_dim_panics() {
+        let _ = ContinuousReplayBuffer::new(4, 0, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "action_dim must be > 0")]
+    fn test_zero_action_dim_panics() {
+        let _ = ContinuousReplayBuffer::new(4, 2, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Implements PR A of the SAC decomposition (#136): a continuous-action replay buffer for off-policy continuous control (SAC / TD3 / DDPG). Per the architect's decision, this is an additive **sibling** of the discrete `ReplayBuffer` that reuses the proven ring/FIFO + flat-`Vec<f32>` WASM-compatible design — NOT a generic `Buffer<S: Strategy>`.

Closes #138

## What changed

- **`src/buffer/replay/continuous_storage.rs`** (new): `ContinuousReplayBuffer` with `actions: Vec<f32>` of length `capacity * action_dim`. API mirrors `ReplayBuffer`: `new(capacity, obs_dim, action_dim)` (with `> 0` asserts on all three), `push(&[f32] obs, &[f32] action, f32 reward, &[f32] next_obs, bool done)` with debug-assert length checks, and `len()/is_empty()/capacity()/obs_dim()/action_dim()/is_ready(min_size)` plus a `pub(super) read_into` helper.
- **`src/buffer/replay/continuous_sampling.rs`** (new): `ContinuousReplayBatch`, `ContinuousReplayBurnTensors`, and `sample(&buffer, batch_size, &mut rng)`. `to_burn_tensors::<B>(&device)` produces obs `[batch, obs_dim]`, actions `[batch, action_dim]`, rewards `[batch]`, next_obs `[batch, obs_dim]`, dones `[batch]` (f32 0/1 mask). Empty-batch path uses direct rank-2 construction (same panic-free trick as the discrete sampler).
- **`src/buffer/replay.rs`**: declares the two modules and re-exports `ContinuousReplayBuffer`, `ContinuousReplayBatch`, `ContinuousReplayBurnTensors`, and the sampler as `sample_continuous` (renamed to avoid colliding with the discrete `sample`).

The discrete `ReplayBuffer` / `PrioritizedReplayBuffer` and the DQN path are entirely untouched.

## Tests

12 new unit tests mirroring the discrete `storage.rs` + `sampling.rs` suites: push/len, value round-trip, ring wraparound evicts oldest, `is_ready`, zero-capacity / zero-obs-dim / zero-action-dim panics, sample count + value match, `to_burn_tensors` shape + round-trip, empty-batch no-panic, and empty-buffer / zero-batch-size panics.

## Verification

- `cargo test --features training --lib continuous`: 12/12 new tests pass.
- `cargo fmt --check`: passes.
- `cargo clippy --all-targets --features training -- -D warnings`: zero new errors from the touched files (the repo has ~64 pre-existing clippy errors in untouched files, left as-is).
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: passes (intra-doc links resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)