### PR TITLE
docs: refresh for Burn backend + current algorithm set

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,8 +353,9 @@ cargo valgrind --bin your-binary
 
 ### Related Projects
 - [PufferLib](https://github.com/PufferAI/PufferLib) - Python RL library
-- [tch-rs](https://github.com/LaurentMazare/tch-rs) - PyTorch bindings
+- [Burn](https://burn.dev) - Pure-Rust deep learning framework (Thrust's tensor backend)
 - [Border](https://github.com/laboroai/border) - Rust RL library
+- [tch-rs](https://github.com/LaurentMazare/tch-rs) - PyTorch bindings (Thrust's pre-v0.1.0 backend; since replaced by Burn)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,12 @@ See [ROADMAP.md](ROADMAP.md) for detailed development schedule.
 - [x] Snake environment (multi-agent support)
 - [x] SimpleBandit environment (contextual bandits)
 
-### Phase 2: Multi-Agent & WASM (In Progress - 60%)
+### Phase 2: Multi-Agent & WASM (In Progress)
 - [x] Multi-agent training infrastructure (`multi_agent::PolicyLearner` is experimental — API may change)
 - [x] Population-based training design
+- [x] PSRO with α-rank meta-solver (N-player)
+- [x] NFSP (approximate, N-player, multi-discrete)
+- [x] Bucket Brigade cooperative-MARL integration
 - [x] Pure Rust inference (Burn backend or hand-rolled WASM path)
 - [x] Universal inference system (JSON model format)
 - [ ] Complete WASM bindings
@@ -64,6 +67,10 @@ See [ROADMAP.md](ROADMAP.md) for detailed development schedule.
 - [ ] Multi-agent communication channels
 
 ### Phase 3: Features
+- [x] SAC for continuous control (twin critics, auto-entropy, Polyak targets)
+- [x] Continuous-control environments (PendulumSwingUp, ContinuousLqr)
+- [ ] A2C (Advantage Actor-Critic)
+- [ ] Behavioral cloning / imitation learning
 - [ ] LSTM policy support
 - [ ] Prioritized experience replay
 - [ ] V-trace importance sampling
@@ -90,7 +97,8 @@ See [ROADMAP.md](ROADMAP.md) for detailed development schedule.
 │  │ Buffers      │  │ (Pure Rust)          │    │
 │  └──────────────┘  └──────────────────────┘    │
 │  ┌─────────────────────────────────────────┐   │
-│  │   PPO / DQN trainers (Burn autodiff)    │   │
+│  │ PPO / DQN / SAC + PSRO / NFSP trainers   │   │
+│  │            (Burn autodiff)               │   │
 │  └─────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────┘
 ```
@@ -98,16 +106,23 @@ See [ROADMAP.md](ROADMAP.md) for detailed development schedule.
 ## 🎮 Environments
 
 - **CartPole** ✅ - Classic control benchmark (solved: 301.6 avg reward)
+- **PendulumSwingUp** ✅ - Continuous-control benchmark (Gym `Pendulum-v1`; SAC's reference env)
+- **ContinuousLqr** ✅ - Linear-quadratic regulator (continuous-action trait existence proof)
 - **Snake** ✅ - Multi-agent grid world with torus wrapping
+- **Pong** ✅ - Two-player competitive self-play
 - **SimpleBandit** ✅ - Contextual multi-armed bandits
-- **Bucket Brigade** 🚧 - Cooperative multi-agent coordination
+- **Matching Pennies** ✅ - Two-player and N-player zero-sum (PSRO/NFSP smoke tests)
+- **Bucket Brigade** ✅ - Cooperative multi-agent coordination (Slepian-Wolf MARL adapter)
 - More coming soon!
 
 ## 🧠 Algorithms
 
-- **PPO** ✅ - Proximal Policy Optimization (on-policy, actor-critic)
+- **PPO** ✅ - Proximal Policy Optimization (on-policy, actor-critic; single- and multi-agent)
 - **DQN** ✅ - Deep Q-Network (off-policy, replay buffer + target network), including **Double-DQN** target computation and optional **Polyak (soft) target updates**
-- More coming soon (prioritized replay, dueling heads — see [ROADMAP.md](ROADMAP.md))
+- **SAC** ✅ - Soft Actor-Critic (off-policy, continuous control; twin critics, automatic entropy tuning, Polyak target updates)
+- **PSRO** ✅ - Policy-Space Response Oracles with **α-rank** meta-solver (multi-agent, N-player)
+- **NFSP** ✅ - Neural Fictitious Self-Play (approximate, N-player, multi-discrete actions)
+- More coming soon (A2C, behavioral cloning — see [ROADMAP.md](ROADMAP.md))
 
 ## 📚 Inspiration
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,57 +1,60 @@
 # Thrust Development Roadmap
 
-**Last Updated**: 2025-11-06
+**Last Updated**: 2026-06-17
 
 ## Vision
 
 Thrust aims to be the **first production-ready RL library in pure Rust** with:
-- 🚀 GPU-accelerated training (tch-rs + PyTorch)
+- 🚀 GPU-accelerated training via [Burn](https://burn.dev) (CUDA / wgpu) — no libtorch FFI
 - 🎮 Multi-agent population training (cooperative & competitive)
 - 🌐 WASM inference for web demos
 - ⚡ High-performance Rust environments
 
+> **Backend note.** Thrust runs entirely on the [Burn](https://burn.dev) tensor
+> framework (pure Rust, autodiff). The pre-v0.1.0 `tch`/libtorch path has been
+> fully removed (see `docs/BURN_BACKENDS.md`). The default build uses Burn's
+> NdArray CPU backend with **no external system libraries**; GPU is opt-in via
+> the `wgpu` (cross-platform) or `cuda` (Linux/NVIDIA) features.
+
 ## Current Status
 
-### ✅ Completed (Phase 1)
+### ✅ Completed Foundation
 
 **Core Infrastructure**
-- [x] Environment trait and CartPole implementation
+- [x] `Environment` trait (discrete + continuous actions) with CartPole, Pendulum, LQR, Snake, Pong, bandit, matching-pennies
 - [x] EnvPool for parallel environments
-- [x] RolloutBuffer with GAE
-- [x] MlpPolicy with tch-rs
-- [x] PPO trainer with clipping
-- [x] GPU training pipeline (NVIDIA L4, ~1000 steps/sec)
-- [x] Version management (local: tch 0.22, GPU: tch 0.15)
-- [x] Training scripts for remote GPU
+- [x] RolloutBuffer with GAE (on-policy) + ReplayBuffer / ContinuousReplayBuffer (off-policy)
+- [x] Burn-backed policy networks (`MlpBurnPolicy`, multi-discrete, Q-networks, SAC actor/critics)
+- [x] Seeded, bit-exact-reproducible network init (`seeded_init`)
+- [x] PPO trainer with clipping (single- and multi-agent)
+- [x] Burn NdArray CPU backend by default; `wgpu` / `cuda` GPU backends opt-in
 - [x] CartPole solved: 301.6 avg steps/episode (target: 195+)
 
+**Algorithms** (see the Algorithms section below)
+- [x] PPO, DQN (Double-DQN + Polyak), SAC (continuous control)
+- [x] PSRO with α-rank meta-solver (N-player), NFSP (N-player, multi-discrete)
+
 **WASM Infrastructure (Partial)**
-- [x] Pure Rust inference module (no PyTorch deps)
+- [x] Pure Rust inference module (no external deps)
 - [x] ExportedModel with JSON serialization
 - [x] Forward pass implementation (softmax, linear layers)
-- [x] 5 passing inference tests
 
-**Multi-Agent Infrastructure (Partial)**
-- [x] MultiAgentEnvironment trait
-- [x] Population and Agent structs
-- [x] 4 matchmaking strategies (Random, RoundRobin, Fitness, SelfPlay)
-- [x] GameSimulator skeleton
-- [x] PolicyLearner skeleton
-- [x] 15 passing multi-agent tests
+**Multi-Agent Infrastructure**
+- [x] MultiAgentEnvironment trait + `JointMultiAgentTrainer` (per-agent observations)
+- [x] Population and Agent structs, 4 matchmaking strategies
+- [x] Bucket Brigade cooperative-MARL adapter + PSRO/NFSP integration
 
 ## Active Work
 
 ### 🚧 In Progress
 
-1. **Multi-Agent Training (Phase 2 - 60% complete)**
-   - Status: Core structs done, need communication layer
-   - Next: Crossbeam channels, run loops
-   - Files: `src/multi_agent/simulator.rs`, `src/multi_agent/learner.rs`
+1. **Research validation (operator-gated)** — long-budget PSRO/NFSP training +
+   evaluation on the Bucket Brigade no-convergence cells (issue #134). Needs
+   GPU host time on alc-2; the *infrastructure* is shipped, the multi-hour
+   *runs* are pending an operator.
 
-2. **WASM Visualization (Phase 1 - 40% complete)**
-   - Status: Pure Rust inference ready, need weight export
-   - Blocker: `MlpPolicy::export_for_inference()` tch-rs API
-   - Files: `examples/export_model.rs`, needs `src/wasm.rs`
+2. **WASM Visualization** — pure Rust inference is ready; remaining work is the
+   `wasm-bindgen` bindings and a browser demo. Files: needs `src/wasm.rs`.
 
 ## Roadmap
 
@@ -96,13 +99,11 @@ Thrust aims to be the **first production-ready RL library in pure Rust** with:
 **Goal**: Interactive web demo of trained CartPole policy
 
 **Tasks**:
-- [ ] Solve tch-rs weight extraction (MlpPolicy::export_for_inference)
-  - Option A: Manual tensor access via tch-rs API
-  - Option B: Save to .pt, load with Python, extract to JSON
-  - Option C: Hook into existing save/load mechanism
+- [x] Weight export to JSON (`ExportedModel` / universal inference format) — the
+      pre-Burn `tch` weight-extraction blocker is gone; Burn modules serialize directly
 - [ ] Add wasm-bindgen to Cargo.toml with features
 - [ ] Create src/wasm.rs with WASM bindings
-- [ ] Implement CartPole environment in pure Rust (no tch)
+- [ ] Implement CartPole environment in pure Rust (already env-trait native)
 - [ ] Create web/index.html with Canvas rendering
 - [ ] Create web/cartpole.js for game loop
 - [ ] Build with wasm-pack
@@ -125,16 +126,19 @@ Thrust aims to be the **first production-ready RL library in pure Rust** with:
 - [ ] Nash equilibrium computation
 
 #### Milestone 5: More Environments
+- [x] Multi-agent competitive games (Pong self-play)
+- [x] Continuous-control envs (PendulumSwingUp, ContinuousLqr)
 - [ ] Atari environments (via Rust ALE bindings)
-- [ ] MuJoCo environments (via mujoco-rs)
+- [ ] MuJoCo environments (via mujoco-rs) — now unblocked by SAC
 - [ ] Custom 2D grid worlds
-- [ ] Multi-agent competitive games (Pong, Soccer)
 
 #### Milestone 6: Algorithm Expansion
 - See [`docs/RL_TOYBOX_SURVEY.md`](docs/RL_TOYBOX_SURVEY.md) for ranked port recommendations (replay buffer, DQN, SAC, centralized critic, MCTS) and prioritized follow-up issues.
+- [x] DQN for discrete actions (Double-DQN + Polyak target updates)
+- [x] SAC (Soft Actor-Critic) for continuous control (twin critics, auto-entropy tuning)
+- [x] PSRO with α-rank meta-solver (N-player)
+- [x] NFSP (approximate, N-player, multi-discrete)
 - [ ] A2C (Advantage Actor-Critic)
-- [ ] SAC (Soft Actor-Critic) for continuous control
-- [ ] DQN for discrete actions
 - [ ] Imitation learning (behavioral cloning)
 
 #### Milestone 7: Performance Optimization
@@ -163,40 +167,36 @@ Thrust aims to be the **first production-ready RL library in pure Rust** with:
 - [ ] Evolution strategies
 - [ ] Population-based training (PBT)
 
-## Priority Queue (Next 3 Tasks)
+## Priority Queue (Next Tasks)
 
-1. **Complete Multi-Agent Simulator Run Loop** (1-2 days)
-   - Add crossbeam channels
-   - Implement experience routing
-   - Test with CartPole 4-agent setup
+1. **Research validation on alc-2** (operator-gated, issue #134)
+   - Long-budget PSRO/NFSP training on the Bucket Brigade no-convergence cells
+   - Answers the open research question (do PSRO+α-rank / NFSP beat PPO there?)
+   - Infrastructure is shipped; needs GPU host time + manual artifact promotion
 
-2. **Complete Multi-Agent Learner Training Loop** (1 day)
-   - Implement PPO updates
-   - Add policy synchronization
-   - Benchmark GPU utilization
+2. **A2C trainer** (Milestone 6)
+   - Reuses the existing PPO rollout/GAE path; smaller surface than SAC
+   - Architect → builder decomposition
 
-3. **Create Multi-Agent CartPole Example** (0.5 days)
-   - Simple 4-agent training script
-   - Logging and metrics
-   - Save/load population
+3. **Capitalize on SAC** (Milestone 5)
+   - `train_sac` example + a second continuous env (LunarLanderContinuous, or
+     MuJoCo via `mujoco-rs`) to take SAC from "implemented" to "benchmarked"
+
+4. **WASM demo** — `wasm-bindgen` bindings + browser inference (pure-Rust
+   inference path is already done; no weight-export blocker remains post-Burn)
 
 ## Dependencies & Blockers
 
 ### External Dependencies
-- **tch-rs version compatibility**: Different versions on local vs GPU (acceptable)
-- **PyTorch version**: Must match tch-rs (documented in VERSIONS.md)
-- **WASM target**: Need pure Rust neural net (done)
+- **Burn 0.21**: the sole tensor backend; NdArray (CPU) by default, `wgpu` / `cuda` opt-in
+- **No libtorch / PyTorch**: the pre-v0.1.0 `tch` path was removed (see `docs/BURN_BACKENDS.md`)
+- **WASM target**: pure Rust neural net (done)
 
 ### Known Blockers
-1. **WASM weight export**: tch-rs API unclear for extracting layer weights
-   - Impact: Blocks WASM demo
-   - Workaround: Can use Python script to extract weights
-   - Priority: Medium (not blocking multi-agent work)
-
-2. **BucketBrigade integration**: Need access to Rust environment
-   - Impact: Blocks validation of multi-agent design
-   - Workaround: Use CartPole multi-agent first
-   - Priority: Low (can validate with CartPole)
+1. **Research validation (#134)**: needs operator GPU time on alc-2 (multi-hour
+   runs, manual artifact promotion). Labeled `loom:blocked` — not automatable.
+   - Impact: the headline research question stays unanswered until run
+   - Priority: High value, operator-gated
 
 ## Success Metrics
 

--- a/WASM_ROADMAP.md
+++ b/WASM_ROADMAP.md
@@ -38,11 +38,11 @@ Compile Rust inference code to WASM and run trained policies in the browser with
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│ Training (Native Rust + PyTorch)                            │
+│ Training (Pure Rust + Burn)                                 │
 ├─────────────────────────────────────────────────────────────┤
-│  • GPU training with tch-rs                                 │
-│  • Full PyTorch neural network                              │
-│  • Saves model weights (.pt format)                         │
+│  • GPU/CPU training via Burn (NdArray / wgpu / cuda)        │
+│  • Burn autodiff neural networks                            │
+│  • Saves model weights (Burn record / JSON)                 │
 └─────────────────────────────────────────────────────────────┘
                           │
                           │ Extract weights
@@ -50,9 +50,9 @@ Compile Rust inference code to WASM and run trained policies in the browser with
 ┌─────────────────────────────────────────────────────────────┐
 │ Weight Export (Rust)                                        │
 ├─────────────────────────────────────────────────────────────┤
-│  • Load .pt model                                           │
+│  • Read Burn module params                                  │
 │  • Extract layer weights & biases                           │
-│  • Export to JSON                                           │
+│  • Export to portable JSON (ExportedModel)                  │
 └─────────────────────────────────────────────────────────────┘
                           │
                           │ Portable weights

--- a/docs/ARCHITECTURE_PROPOSAL.md
+++ b/docs/ARCHITECTURE_PROPOSAL.md
@@ -1,5 +1,15 @@
 # Thrust Architecture Proposal
 
+> **⚠️ Historical document (superseded in part).** This is the original
+> pre-v0.1.0 architecture proposal. Its high-level ideas (Rayon-parallel
+> environments, zero-copy buffers, lock-free channels) still hold, but the
+> **tensor-backend decision changed**: Thrust does **not** use `tch-rs` /
+> libtorch / CUDA kernels as proposed here — it runs entirely on the pure-Rust
+> [Burn](https://burn.dev) framework (NdArray default; `wgpu` / `cuda` opt-in).
+> See [`BURN_BACKENDS.md`](BURN_BACKENDS.md) for the migration rationale and
+> [`../ROADMAP.md`](../ROADMAP.md) for current status. Read the `tch`/PyTorch
+> references below as historical context only.
+
 ## Executive Summary
 
 Thrust aims to be the **fastest reinforcement learning library in Rust**, targeting 3-6x speedup over Python implementations like PufferLib through:

--- a/docs/RESEARCH_PAPERS.md
+++ b/docs/RESEARCH_PAPERS.md
@@ -2,6 +2,14 @@
 
 This document catalogs key papers, systems, and insights that should inform Thrust's architecture design.
 
+> **⚠️ Backend note.** The "Architecture Recommendations" sections below predate
+> the Burn migration and recommend `tch-rs` / PyTorch bindings for the GPU path.
+> Thrust has since moved entirely to the pure-Rust [Burn](https://burn.dev)
+> framework (NdArray default; `wgpu` / `cuda` opt-in) — see
+> [`BURN_BACKENDS.md`](BURN_BACKENDS.md). The *algorithm* and *systems* insights
+> here remain valuable; read the `tch`/PyTorch backend recommendations as
+> historical context.
+
 ---
 
 ## Table of Contents


### PR DESCRIPTION
## Summary

The docs had drifted from the codebase after the **tch-rs → Burn** migration and the **DQN / SAC / PSRO / NFSP** additions. This refresh brings the user-facing and roadmap docs back in line with reality. No code changes — docs only.

## Changes

- **ROADMAP.md** — rewrote Vision/Current Status to describe the Burn backend (NdArray default; `wgpu`/`cuda` opt-in, no libtorch); marked DQN, SAC, PSRO+α-rank, and NFSP as done; refreshed Milestones 5/6, the priority queue, and the blockers list (research validation #134 is the live operator-gated item).
- **README.md** — added SAC / PSRO / NFSP to Algorithms; added Pendulum / Pong / ContinuousLqr / matching-pennies / bucket-brigade to Environments; updated the architecture trainer box and the phase checklists.
- **WASM_ROADMAP.md** — updated the architecture diagram from the old PyTorch/`.pt` training stack to Burn.
- **docs/ARCHITECTURE_PROPOSAL.md**, **docs/RESEARCH_PAPERS.md** — added "superseded / historical" banners noting their tch-rs recommendations predate the Burn migration (kept the still-valid algorithm/systems analysis intact).
- **CONTRIBUTING.md** — listed Burn as the actual backend; annotated tch-rs as the since-replaced pre-v0.1.0 backend.

## Deliberately left untouched

- **CHANGELOG.md** — append-only history; its `tch` mentions correctly record when tch was used and removed.
- **docs/BURN_BACKENDS.md** — already the accurate migration explainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)