### PR TITLE
feat: add A2cTrainer and un-clipped A2C loss with smoke tests

### DIFF
--- a/src/train/a2c/loss.rs
+++ b/src/train/a2c/loss.rs
@@ -1,0 +1,161 @@
+//! A2C loss math (Burn backend).
+//!
+//! A2C is the *single-update-per-rollout, no-clipping* special case of
+//! the actor-critic family. Its loss diverges from PPO
+//! ([`crate::train::ppo::loss`]) in exactly two ways:
+//!
+//! 1. **Policy loss** — the plain policy-gradient objective `-mean(log_prob *
+//!    advantage)` with **no importance ratio** and **no clipping**. PPO's
+//!    [`compute_policy_loss`] instead forms the clipped surrogate `min(ratio *
+//!    adv, clip(ratio) * adv)`.
+//! 2. **Value loss** — plain MSE `mean((V(s) - returns)^2)` with **no
+//!    value-clipping**. PPO's [`compute_value_loss`] takes the pessimistic max
+//!    over clipped/unclipped squared errors.
+//!
+//! The entropy bonus is shared verbatim with PPO, so we re-export PPO's
+//! [`compute_entropy_loss`] and host-side [`scalar_f64`] rather than
+//! re-implement them.
+//!
+//! [`compute_policy_loss`]: crate::train::ppo::loss::compute_policy_loss
+//! [`compute_value_loss`]: crate::train::ppo::loss::compute_value_loss
+
+use burn::tensor::{Tensor, backend::Backend};
+
+// Re-export the shared helpers from the PPO loss module so the A2C
+// trainer (and downstream callers) can pull the whole loss surface from
+// `a2c::loss` without reaching into `ppo::loss`.
+pub use crate::train::ppo::loss::{compute_entropy_loss, scalar_f64};
+
+/// Compute the A2C policy-gradient loss.
+///
+/// This is the un-clipped, ratio-free actor objective:
+/// `-mean(log_prob * advantage)`. Because A2C is on-policy and performs a
+/// single gradient step per rollout there is no behaviour/target policy
+/// split, hence no importance ratio and no clipping (the key divergence
+/// from PPO's [`compute_policy_loss`]).
+///
+/// The advantages are treated as constants (detached) — they are the
+/// critic's estimate of the rollout's advantage and must not propagate
+/// gradients back through the value head via the policy term. The caller
+/// passes advantages computed outside the autograd tape (host-side GAE),
+/// so this is naturally satisfied; we additionally detach defensively.
+///
+/// # Arguments
+///
+/// * `log_probs` - Log-probabilities of the taken actions under the current
+///   policy. `[batch]`.
+/// * `advantages` - Per-sample advantage estimates. `[batch]`.
+///
+/// # Returns
+///
+/// A scalar tensor (rank 1, shape `[1]`) carrying the grad-bearing
+/// policy-gradient loss.
+///
+/// [`compute_policy_loss`]: crate::train::ppo::loss::compute_policy_loss
+pub fn compute_a2c_policy_loss<B: Backend>(
+    log_probs: Tensor<B, 1>,
+    advantages: Tensor<B, 1>,
+) -> Tensor<B, 1> {
+    // Advantages are constants w.r.t. the policy/value parameters.
+    let advantages = advantages.detach();
+    (log_probs * advantages).mean().neg()
+}
+
+/// Compute the A2C value-function loss: plain MSE `mean((V(s) - returns)^2)`.
+///
+/// Unlike PPO's [`compute_value_loss`], there is **no value-clipping** and
+/// no pessimistic max — A2C uses the straight regression target. The
+/// `returns` are detached (bootstrap targets are constants w.r.t. the
+/// current value head).
+///
+/// # Arguments
+///
+/// * `values` - Current value-function predictions `V(s_t)`. `[batch]`.
+/// * `returns` - Bootstrap/Monte-Carlo return targets. `[batch]`.
+///
+/// # Returns
+///
+/// A scalar tensor (rank 1, shape `[1]`) carrying the grad-bearing value
+/// loss.
+///
+/// [`compute_value_loss`]: crate::train::ppo::loss::compute_value_loss
+pub fn compute_a2c_value_loss<B: Backend>(
+    values: Tensor<B, 1>,
+    returns: Tensor<B, 1>,
+) -> Tensor<B, 1> {
+    let returns = returns.detach();
+    (values - returns).powf_scalar(2.0_f32).mean()
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::{
+        backend::{Autodiff, NdArray},
+        tensor::{Tensor, TensorData},
+    };
+
+    use super::*;
+
+    type B = Autodiff<NdArray<f32>>;
+
+    fn tensor1d(data: &[f32]) -> Tensor<B, 1> {
+        let device = Default::default();
+        Tensor::<B, 1>::from_data(TensorData::new(data.to_vec(), [data.len()]), &device)
+    }
+
+    #[test]
+    fn a2c_policy_loss_is_scalar() {
+        let log_probs = tensor1d(&[-0.5, -1.0, -0.2]);
+        let advantages = tensor1d(&[1.0, -1.0, 0.5]);
+        let loss = compute_a2c_policy_loss(log_probs, advantages);
+        assert_eq!(loss.dims(), [1]);
+        assert!(scalar_f64(loss).is_finite());
+    }
+
+    /// Sign sanity: with all-positive advantages and all-negative
+    /// log-probs (the usual regime — `log p <= 0`), the PG loss
+    /// `-mean(log_prob * advantage)` is positive.
+    #[test]
+    fn a2c_policy_loss_sign_with_positive_advantage() {
+        let log_probs = tensor1d(&[-0.5, -1.0, -0.2]);
+        let advantages = tensor1d(&[1.0, 2.0, 0.5]);
+        let loss_val = scalar_f64(compute_a2c_policy_loss(log_probs, advantages));
+        // -mean(neg * pos) = -mean(neg) = positive.
+        assert!(loss_val > 0.0, "expected positive PG loss, got {loss_val}");
+    }
+
+    /// Increasing the log-prob of a positively-advantaged action must
+    /// *decrease* the policy-gradient loss (gradient ascent on reward).
+    #[test]
+    fn a2c_policy_loss_decreases_when_good_action_more_likely() {
+        let advantages = tensor1d(&[1.0, 1.0, 1.0]);
+        let low =
+            scalar_f64(compute_a2c_policy_loss(tensor1d(&[-2.0, -2.0, -2.0]), advantages.clone()));
+        let high = scalar_f64(compute_a2c_policy_loss(tensor1d(&[-0.5, -0.5, -0.5]), advantages));
+        assert!(high < low, "higher log-prob on good actions should lower loss: {high} !< {low}");
+    }
+
+    #[test]
+    fn a2c_value_loss_is_plain_mse() {
+        // values - returns = [0.0, 0.5, -0.3] → squares [0, 0.25, 0.09]
+        // mean = 0.34 / 3 = 0.11333...
+        let values = tensor1d(&[1.0, 2.0, 0.5]);
+        let returns = tensor1d(&[1.0, 1.5, 0.8]);
+        let loss = compute_a2c_value_loss(values, returns);
+        assert_eq!(loss.dims(), [1]);
+        let expected = (0.0_f64 + 0.25 + 0.09) / 3.0;
+        let loss_val = scalar_f64(loss);
+        assert!(
+            (loss_val - expected).abs() < 1e-5,
+            "A2C value loss should be plain MSE {expected}, got {loss_val}"
+        );
+    }
+
+    #[test]
+    fn a2c_value_loss_zero_when_perfect() {
+        let values = tensor1d(&[1.0, 2.0, 0.5]);
+        let returns = tensor1d(&[1.0, 2.0, 0.5]);
+        let loss_val = scalar_f64(compute_a2c_value_loss(values, returns));
+        assert!(loss_val.abs() < 1e-6, "perfect predictions should give ~0 loss, got {loss_val}");
+    }
+}

--- a/src/train/a2c/mod.rs
+++ b/src/train/a2c/mod.rs
@@ -10,9 +10,15 @@
 //!
 //! This module is built incrementally by the A2C decomposition (#150):
 //! - [`A2cConfig`] — hyperparameters (builder + `validate()`), mirroring
-//!   [`crate::train::ppo::PPOConfig`] (this PR, #151).
-//! - the A2C trainer + loss math arrive in #152.
+//!   [`crate::train::ppo::PPOConfig`] (#151).
+//! - [`loss`] — the un-clipped policy-gradient + plain-MSE value loss
+//!   ([`compute_a2c_policy_loss`], [`compute_a2c_value_loss`]) and the
+//!   [`A2cTrainer`] single-update-per-rollout loop (#152).
 
 pub mod config;
+pub mod loss;
+pub mod trainer;
 
 pub use config::A2cConfig;
+pub use loss::{compute_a2c_policy_loss, compute_a2c_value_loss};
+pub use trainer::{A2cStats, A2cTrainer};

--- a/src/train/a2c/trainer.rs
+++ b/src/train/a2c/trainer.rs
@@ -1,0 +1,328 @@
+//! Synchronous Advantage Actor-Critic (A2C) trainer (Burn backend).
+//!
+//! Sibling to [`crate::train::ppo::trainer::PPOTrainerBurn`]. A2C reuses
+//! the same policy ([`MlpBurnPolicy`]), optimizer ([`BurnOptimizer`]) and
+//! GAE/advantage path, and shares PPO's `Option<P>` move-through
+//! ownership model (Burn's `Optimizer::step` consumes the module by
+//! value). It diverges from PPO in exactly two places:
+//!
+//! 1. **Loss** — un-clipped policy-gradient loss + plain-MSE value loss (see
+//!    [`crate::train::a2c::loss`]); no importance ratio, no value clipping.
+//! 2. **Loop** — exactly **one** gradient step per rollout: no epoch loop, no
+//!    minibatch shuffle, no KL early-stop. Consequently
+//!    [`A2cTrainer::train_step`] drops the `old_log_probs` / `old_values`
+//!    arguments PPO needs for its importance ratio and value clipping.
+//!
+//! [`MlpBurnPolicy`]: crate::policy::mlp::MlpBurnPolicy
+
+use anyhow::{Result, anyhow};
+use burn::{
+    module::AutodiffModule,
+    optim::{GradientsParams, Optimizer},
+    tensor::{Int, Tensor, backend::AutodiffBackend},
+};
+use rand::{SeedableRng, rngs::StdRng};
+
+use super::{
+    config::A2cConfig,
+    loss::{compute_a2c_policy_loss, compute_a2c_value_loss, compute_entropy_loss, scalar_f64},
+};
+use crate::train::optimizer::{BackendOptimizer, BurnOptimizer};
+
+/// Per-update A2C training statistics.
+///
+/// Purpose-built (rather than reusing PPO's
+/// [`TrainingStats`](crate::train::ppo::TrainingStats)) because A2C has
+/// no clip-fraction / KL / explained-variance diagnostics — the loop
+/// performs a single un-clipped update. All fields are finite host-side
+/// `f64`s pulled off the autograd tape after the gradient step.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct A2cStats {
+    /// Policy-gradient loss `-mean(log_prob * advantage)`.
+    pub policy_loss: f64,
+    /// Plain-MSE value loss `mean((V(s) - returns)^2)`.
+    pub value_loss: f64,
+    /// Mean per-row policy entropy (the bonus, before negation/scaling).
+    pub entropy: f64,
+    /// Total optimized loss
+    /// `policy_loss + value_coef * value_loss + entropy_coef * entropy_loss`.
+    pub total_loss: f64,
+}
+
+/// Burn-backend A2C trainer.
+///
+/// Generic over:
+/// - `B: AutodiffBackend` — the Burn backend (e.g. `Autodiff<NdArray<f32>>`).
+/// - `P: AutodiffModule<B>` — the shared actor-critic policy module.
+/// - `O: Optimizer<P, B>` — the Burn optimizer (typically
+///   `AdamConfig::new().init()`).
+///
+/// The policy is held in `Option<P>` because Burn's `Optimizer::step`
+/// consumes the module by value; we `.take()` it and put back the updated
+/// copy across the single gradient step.
+pub struct A2cTrainer<B, P, O>
+where
+    B: AutodiffBackend,
+    P: AutodiffModule<B>,
+    O: Optimizer<P, B>,
+{
+    config: A2cConfig,
+    policy: Option<P>,
+    optimizer: BurnOptimizer<B, P, O>,
+    total_steps: usize,
+    total_episodes: usize,
+    low_entropy_count: usize,
+    /// Seedable RNG owned by the trainer so any stochastic step (e.g.
+    /// future seeded advantage handling) is reproducible under
+    /// [`A2cConfig::seed`]. Kept for parity with
+    /// [`PPOTrainerBurn`](crate::train::ppo::trainer::PPOTrainerBurn),
+    /// whose minibatch shuffle draws from this RNG.
+    #[allow(dead_code)]
+    rng: StdRng,
+}
+
+impl<B, P, O> A2cTrainer<B, P, O>
+where
+    B: AutodiffBackend,
+    P: AutodiffModule<B> + Clone,
+    O: Optimizer<P, B>,
+{
+    /// Build a new Burn A2C trainer.
+    ///
+    /// Validates the config and stages the global gradient-norm clip
+    /// ([`A2cConfig::max_grad_norm`]) on the optimizer wrapper.
+    pub fn new(
+        config: A2cConfig,
+        policy: P,
+        mut optimizer: BurnOptimizer<B, P, O>,
+    ) -> Result<Self> {
+        config.validate()?;
+        let rng = StdRng::seed_from_u64(config.seed);
+        // Record the global-norm cap on the wrapper. The actual clip is
+        // honored by the Burn optimizer built with
+        // `AdamConfig::with_grad_clipping`; staging it here keeps the
+        // trainer's view of the cap consistent with PPO.
+        optimizer.clip_grad_norm(config.max_grad_norm);
+        Ok(Self {
+            config,
+            policy: Some(policy),
+            optimizer,
+            total_steps: 0,
+            total_episodes: 0,
+            low_entropy_count: 0,
+            rng,
+        })
+    }
+
+    /// Borrow the configuration.
+    pub fn config(&self) -> &A2cConfig {
+        &self.config
+    }
+
+    /// Borrow the policy. Panics if the trainer is mid-step (the policy
+    /// has been moved into the optimizer); only safe to call between
+    /// `train_step` invocations.
+    pub fn policy(&self) -> &P {
+        self.policy.as_ref().expect("policy is None mid-step")
+    }
+
+    /// Total completed gradient updates (one per `train_step`).
+    pub fn total_steps(&self) -> usize {
+        self.total_steps
+    }
+
+    /// Total completed episodes (caller increments).
+    pub fn total_episodes(&self) -> usize {
+        self.total_episodes
+    }
+
+    /// Increment the episode counter.
+    pub fn increment_episodes(&mut self, n: usize) {
+        self.total_episodes += n;
+    }
+
+    /// Train for one A2C update.
+    ///
+    /// Performs exactly **one** gradient step over the whole rollout:
+    /// 1. Optionally normalize advantages to zero-mean/unit-variance when
+    ///    [`A2cConfig::normalize_advantages`] is set.
+    /// 2. Evaluate the policy to get `(log_probs, entropy, values)`.
+    /// 3. `policy_loss = -mean(log_prob * advantage)` (no ratio, no clip).
+    /// 4. `value_loss = mean((V(s) - returns)^2)` (plain MSE, no clip).
+    /// 5. `entropy_loss = -mean(entropy)`.
+    /// 6. `total = policy_loss + value_coef * value_loss
+    ///    + entropy_coef * entropy_loss`.
+    /// 7. Backprop, build `GradientsParams`, step the optimizer once.
+    /// 8. Entropy-collapse guard (shared with PPO).
+    ///
+    /// Note the **absence** of `old_log_probs` / `old_values`: A2C is
+    /// on-policy with a single update, so there is no behaviour policy to
+    /// form an importance ratio against, and no old value baseline to
+    /// clip against.
+    ///
+    /// The `evaluate_fn` closure receives `(&policy, obs, actions)` and
+    /// must return `(log_probs, entropy, values)` — exactly the shape of
+    /// [`MlpBurnPolicy::evaluate_actions`](crate::policy::mlp::MlpBurnPolicy::evaluate_actions).
+    pub fn train_step<F>(
+        &mut self,
+        observations: Tensor<B, 2>,
+        actions: Tensor<B, 1, Int>,
+        advantages: Tensor<B, 1>,
+        returns: Tensor<B, 1>,
+        mut evaluate_fn: F,
+    ) -> Result<A2cStats>
+    where
+        F: FnMut(&P, Tensor<B, 2>, Tensor<B, 1, Int>) -> (Tensor<B, 1>, Tensor<B, 1>, Tensor<B, 1>),
+    {
+        let device = observations.device();
+
+        // Advantage normalization (matches the PPO trainer's host-side
+        // biased normalization). Done on the host so the advantages stay
+        // detached constants w.r.t. the policy parameters.
+        let advantages = if self.config.normalize_advantages {
+            let adv_mean = scalar_f64(advantages.clone().mean());
+            let adv_data: Vec<f32> = advantages.into_data().to_vec().unwrap_or_default();
+            let adv_std = host_std_biased(&adv_data, adv_mean) as f32;
+            let normalized: Vec<f32> =
+                adv_data.iter().map(|&a| (a - adv_mean as f32) / (adv_std + 1e-8)).collect();
+            let n = normalized.len();
+            Tensor::<B, 1>::from_data(burn::tensor::TensorData::new(normalized, [n]), &device)
+        } else {
+            advantages
+        };
+
+        // Take the policy out so we can move it through `step`.
+        let policy = self
+            .policy
+            .take()
+            .ok_or_else(|| anyhow!("policy is None; concurrent train_step calls?"))?;
+
+        let (log_probs, entropy, values) = evaluate_fn(&policy, observations, actions);
+
+        let policy_loss = compute_a2c_policy_loss(log_probs, advantages);
+        let value_loss = compute_a2c_value_loss(values, returns);
+        let entropy_loss = compute_entropy_loss(entropy.clone());
+
+        // Host-side scalars for stat collection.
+        let policy_loss_val = scalar_f64(policy_loss.clone());
+        let value_loss_val = scalar_f64(value_loss.clone());
+        let entropy_val = scalar_f64(entropy.mean());
+
+        // total = policy_loss + value_coef * value_loss + entropy_coef * entropy_loss
+        let total_loss = policy_loss
+            + value_loss.mul_scalar(self.config.value_coef as f32)
+            + entropy_loss.mul_scalar(self.config.entropy_coef as f32);
+        let total_loss_val = scalar_f64(total_loss.clone());
+
+        // Burn gradient flow: backward → GradientsParams → single step.
+        let grads = total_loss.backward();
+        let grads = GradientsParams::from_grads(grads, &policy);
+        let lr = self.optimizer.learning_rate();
+        let policy = self.optimizer.inner_mut().step(lr, policy, grads);
+        self.policy = Some(policy);
+
+        self.total_steps += 1;
+
+        let stats = A2cStats {
+            policy_loss: policy_loss_val,
+            value_loss: value_loss_val,
+            entropy: entropy_val,
+            total_loss: total_loss_val,
+        };
+
+        // Entropy-collapse guard (matches the PPO trainer).
+        const ENTROPY_THRESHOLD: f64 = 0.05;
+        const MAX_LOW_ENTROPY_COUNT: usize = 3;
+        if stats.entropy < ENTROPY_THRESHOLD {
+            self.low_entropy_count += 1;
+            if self.low_entropy_count >= MAX_LOW_ENTROPY_COUNT {
+                return Err(anyhow!(
+                    "Training stopped due to entropy collapse (entropy < {} for {} updates)",
+                    ENTROPY_THRESHOLD,
+                    MAX_LOW_ENTROPY_COUNT
+                ));
+            }
+        } else {
+            self.low_entropy_count = 0;
+        }
+
+        Ok(stats)
+    }
+}
+
+/// Biased standard deviation (denominator `n`). Mirrors the PPO
+/// trainer's host-side advantage-normalization helper.
+fn host_std_biased(xs: &[f32], mean: f64) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    let n = xs.len() as f64;
+    let sq_dev = xs.iter().map(|&x| (x as f64 - mean).powi(2)).sum::<f64>();
+    (sq_dev / n).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::{
+        backend::{Autodiff, NdArray},
+        optim::AdamConfig,
+        tensor::TensorData,
+    };
+
+    use super::*;
+    use crate::{policy::mlp::MlpBurnPolicy, train::optimizer::BurnOptimizer};
+
+    type B = Autodiff<NdArray<f32>>;
+
+    /// Smoke test: an A2C trainer constructs and reports zero steps.
+    #[test]
+    fn a2c_trainer_constructs() {
+        let device = Default::default();
+        let policy = MlpBurnPolicy::<B>::new(4, 2, 32, &device);
+        let inner_opt = AdamConfig::new().init();
+        let burn_opt: BurnOptimizer<B, MlpBurnPolicy<B>, _> = BurnOptimizer::new(inner_opt, 7e-4);
+        let trainer = A2cTrainer::new(A2cConfig::default(), policy, burn_opt).unwrap();
+        assert_eq!(trainer.total_steps(), 0);
+        assert_eq!(trainer.total_episodes(), 0);
+    }
+
+    /// End-to-end: a single `train_step` against a synthetic batch
+    /// completes, performs exactly one update, and yields finite stats.
+    #[test]
+    fn a2c_train_step_runs() {
+        let device = Default::default();
+        let policy = MlpBurnPolicy::<B>::new(4, 2, 16, &device);
+        let inner_opt = AdamConfig::new().init();
+        let burn_opt: BurnOptimizer<B, MlpBurnPolicy<B>, _> = BurnOptimizer::new(inner_opt, 1e-3);
+        let mut trainer = A2cTrainer::new(A2cConfig::default(), policy, burn_opt).unwrap();
+
+        let batch = 8;
+        let obs_dim = 4;
+        let obs_data: Vec<f32> = (0..batch * obs_dim).map(|i| (i as f32) * 0.01).collect();
+        let observations =
+            Tensor::<B, 2>::from_data(TensorData::new(obs_data, [batch, obs_dim]), &device);
+        let actions = Tensor::<B, 1, Int>::from_data(
+            TensorData::new(vec![0i64, 1, 0, 1, 0, 1, 0, 1], [batch]),
+            &device,
+        );
+        let advantages = Tensor::<B, 1>::from_data(
+            TensorData::new(vec![1.0f32, -1.0, 0.5, -0.5, 1.0, -1.0, 0.5, -0.5], [batch]),
+            &device,
+        );
+        let returns =
+            Tensor::<B, 1>::from_data(TensorData::new(vec![1.0f32; batch], [batch]), &device);
+
+        let stats = trainer
+            .train_step(observations, actions, advantages, returns, |p, o, a| {
+                p.evaluate_actions(o, a)
+            })
+            .unwrap();
+
+        // Exactly one gradient step per rollout.
+        assert_eq!(trainer.total_steps(), 1);
+        assert!(stats.policy_loss.is_finite());
+        assert!(stats.value_loss.is_finite());
+        assert!(stats.entropy.is_finite());
+        assert!(stats.total_loss.is_finite());
+    }
+}

--- a/src/train/mod.rs
+++ b/src/train/mod.rs
@@ -13,7 +13,7 @@ pub mod dqn;
 pub mod ppo;
 pub mod sac;
 
-pub use a2c::A2cConfig;
+pub use a2c::{A2cConfig, A2cStats, A2cTrainer, compute_a2c_policy_loss, compute_a2c_value_loss};
 pub use dqn::{DQNConfig, DQNStepStatsBurn, DQNTrainerBurn};
 pub use optimizer::{BackendOptimizer, BurnOptimizer};
 pub use ppo::{


### PR DESCRIPTION
## Summary

Implements PR B of the A2C epic (#150): the `A2cTrainer` and the A2C loss math, landing as a sibling to the PPO Burn trainer. With `A2cConfig` already merged (#151), this PR adds the trainer + loss and fast always-on smoke tests. It reuses PPO infrastructure (`MlpBurnPolicy`, `BurnOptimizer`, the `Option<P>` move-through ownership model, host-side advantage normalization) and only diverges in the loss and the loop.

## Changes

- **NEW `src/train/a2c/loss.rs`**:
  - `compute_a2c_policy_loss(log_probs, advantages) = -mean(log_prob * advantage)` — un-clipped, ratio-free policy gradient. Advantages are detached (constants w.r.t. params).
  - `compute_a2c_value_loss(values, returns) = mean((V(s) - returns)^2)` — plain MSE, no value-clip, no pessimistic max. Returns detached.
  - Re-exports PPO's `compute_entropy_loss` (`-mean(entropy)`) and `scalar_f64` rather than re-implementing.
- **NEW `src/train/a2c/trainer.rs`**:
  - `A2cTrainer<B, P, O>` with the same `Option<P>` move-through ownership as `PPOTrainerBurn`.
  - `new(config, policy, optimizer)` calls `config.validate()`, seeds an internal `StdRng` from `config.seed`, and stages `max_grad_norm` on the optimizer wrapper.
  - `train_step(observations, actions, advantages, returns, evaluate_fn)` — note **no** `old_log_probs`/`old_values`. Optional advantage normalization (`normalize_advantages`), one gradient step per rollout (no epochs, no shuffle, no KL early-stop). Total loss = `policy_loss + value_coef*value_loss + entropy_coef*entropy_loss`. PPO entropy-collapse guard retained.
  - Accessors `config()`, `policy()`, `total_steps()`, `total_episodes()`, `increment_episodes(n)`.
  - Purpose-built `A2cStats { policy_loss, value_loss, entropy, total_loss }` (no clip-fraction/KL/explained-var — A2C has no such diagnostics).
- **Re-exports** wired through `src/train/a2c/mod.rs` and `src/train/mod.rs`.

## Loss math

```
policy_loss  = -mean(log_prob * advantage)            # no ratio, no clip
value_loss   =  mean((V(s) - returns)^2)              # plain MSE, no clip
entropy_loss = -mean(entropy)
total        = policy_loss + value_coef*value_loss + entropy_coef*entropy_loss
```

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `a2c/loss.rs` with unclipped PG loss, plain-MSE value loss, entropy loss + unit tests (shapes `[1]`, PG sign, value=MSE) | ✅ | 5 unit tests pass incl. shape `[1]`, positive-advantage sign, MSE-equals check |
| `a2c/trainer.rs` with `A2cTrainer` per the surface above | ✅ | Full surface implemented; `train_step` drops `old_*` args |
| Two always-on smoke tests pass | ✅ | `a2c_trainer_constructs`, `a2c_train_step_runs` (asserts `total_steps()==1`, all stats finite) |
| `mod.rs` re-exports `A2cTrainer` (+ `A2cStats`); `train/mod.rs` updated | ✅ | Both updated |
| `cargo build --features training` passes | ✅ | Clean build |
| `cargo test --features training` passes | ✅ | 10 a2c lib tests pass (7 new + 3 config) |
| `cargo clippy --features training` clean | ✅ | Zero clippy issues in touched files; pre-existing errors live only in untouched files (snake env, buffer/rollout/sampling.rs) and are out of scope |

## Test Plan

- `cargo build --features training` — clean.
- `cargo test --features training --lib a2c` — 10 passed, 0 failed.
- `cargo fmt --check` — clean.
- `cargo clippy --all-targets --features training -- -D warnings` — no issues in `src/train/a2c/*`; remaining errors are pre-existing in untouched files (verified the `sampling.rs` warning exists at base commit).
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — exit 0, no doc warnings.

Additive only — the PPO trainer is untouched. The slow CartPole convergence test is intentionally out of scope (that is #153).

Closes #152