### PR TITLE
feat: add A2C CartPole example, opt-in learning-curve CSV, convergence test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,15 @@ name = "train_cartpole_dqn"
 path = "examples/games/cartpole/train_cartpole_dqn.rs"
 required-features = ["training"]
 
+# A2C CartPole trainer (issue #153, PR C of the A2C epic #150). Same
+# EnvPool rollout + GAE pattern as train_cartpole_modern but with the
+# single-update-per-rollout A2cTrainer. Emits an opt-in learning-curve
+# CSV via CURVE_CSV for overlay comparison with the PPO example.
+[[example]]
+name = "train_cartpole_a2c"
+path = "examples/games/cartpole/train_cartpole_a2c.rs"
+required-features = ["training"]
+
 # Multi-agent / self-play trainers resurrected from the pre-Burn
 # deletion (PR #98) per issue #101.
 [[example]]

--- a/examples/games/cartpole/train_cartpole_a2c.rs
+++ b/examples/games/cartpole/train_cartpole_a2c.rs
@@ -1,44 +1,56 @@
-//! Modern CartPole PPO training on the Burn backend.
+//! CartPole A2C training on the Burn backend.
 //!
-//! End-to-end PPO trainer for CartPole-v1 using the
+//! End-to-end synchronous Advantage Actor-Critic (A2C) trainer for
+//! CartPole-v1 using the
 //! [`MlpBurnPolicy`](thrust_rl::policy::mlp::MlpBurnPolicy) +
-//! [`PPOTrainerBurn`](thrust_rl::train::ppo::PPOTrainerBurn) stack on
-//! `Autodiff<NdArray<f32>>` (CPU). This is one of the resurrected
-//! trainers from issue #101 (PR #98 deleted the pre-Burn version).
+//! [`A2cTrainer`](thrust_rl::train::a2c::A2cTrainer) stack on
+//! `Autodiff<NdArray<f32>>` (CPU). This is PR C of the A2C epic (#150,
+//! issue #153) and mirrors the PPO example
+//! (`train_cartpole_modern.rs`): same `EnvPool` rollout-collect + GAE
+//! pattern, swapping `PPOTrainerBurn`/`PPOConfig` for
+//! `A2cTrainer`/`A2cConfig`.
+//!
+//! A2C differs from PPO in two places (see
+//! [`thrust_rl::train::a2c::trainer`]): an un-clipped policy-gradient +
+//! plain-MSE value loss, and exactly **one** gradient step per rollout (no
+//! epoch loop, no minibatch shuffle, no importance ratio — hence
+//! `train_step` takes no `old_log_probs` / `old_values`).
 //!
 //! # Architecture
 //!
 //! - 2-layer MLP, 128 hidden units, ReLU activations, orthogonal init.
 //! - `EnvPool` of 16 parallel CartPole envs.
-//! - `n_steps = 256` rollout, `n_epochs = 10`, `batch_size = 128`.
-//! - Total budget: 200k env steps (≈ 50 PPO updates).
+//! - `n_steps = 5` rollout, single update per rollout.
+//! - `learning_rate = 7e-4`, seeded via `A2cConfig::seed`.
+//! - Total budget: 500k env steps by default.
 //!
 //! # Usage
 //!
 //! ```bash
-//! cargo run --example train_cartpole_modern --features training --release
+//! cargo run --example train_cartpole_a2c --features training --release
 //! ```
 //!
 //! Override the total step budget via the `TOTAL_TIMESTEPS` env var:
 //!
 //! ```bash
-//! TOTAL_TIMESTEPS=50000 cargo run --example train_cartpole_modern \
+//! TOTAL_TIMESTEPS=200000 cargo run --example train_cartpole_a2c \
 //!     --features training --release
 //! ```
 //!
 //! Expected: average episode length climbs well above the random
-//! baseline (~22 steps) within ~100k env steps.
+//! baseline (~22 steps).
 //!
 //! # Learning-curve CSV (opt-in)
 //!
 //! Set `CURVE_CSV=<path>` to emit one `env_steps,mean_episode_reward` row
-//! per logging interval (header row first). The run is seeded, so re-runs
-//! reproduce. This is the comparison curve for the A2C benchmark (issue
-//! #153) — A2C and PPO can be overlaid on the same env/seed/budget. When
-//! `CURVE_CSV` is unset, no file is written and behavior is unchanged.
+//! per logging interval (header row first). The policy init is seeded, so
+//! re-runs reproduce. The same opt-in writer lives on the PPO example, so
+//! A2C and PPO curves can be overlaid on the same env/seed/budget for the
+//! benchmark comparison. When `CURVE_CSV` is unset, no file is written and
+//! behavior is unchanged.
 //!
 //! ```bash
-//! CURVE_CSV=/tmp/ppo.csv cargo run --example train_cartpole_modern \
+//! CURVE_CSV=/tmp/a2c.csv cargo run --example train_cartpole_a2c \
 //!     --features training --release
 //! ```
 
@@ -54,15 +66,14 @@ use thrust_rl::{
     env::{Environment, cartpole::CartPole, pool::EnvPool},
     policy::mlp::{BurnActivation, MlpBurnConfig, MlpBurnPolicy},
     train::{
+        a2c::{A2cConfig, A2cTrainer},
         optimizer::BurnOptimizer,
-        ppo::{PPOConfig, PPOTrainerBurn},
     },
 };
 
 // Concrete backend stack — selected at compile time via Cargo features.
 // `--features "training,wgpu"` swaps the CPU NdArray default for Burn's
-// cross-platform GPU backend (Vulkan / Metal / DX12 / WebGPU). See issue
-// #102 for the GPU validation run.
+// cross-platform GPU backend (Vulkan / Metal / DX12 / WebGPU).
 #[cfg(not(feature = "wgpu"))]
 type InnerBackend = burn::backend::NdArray<f32>;
 #[cfg(feature = "wgpu")]
@@ -75,14 +86,15 @@ const BACKEND_LABEL: &str = "NdArray<f32> + Autodiff (CPU)";
 const BACKEND_LABEL: &str = "Wgpu<f32, i32> + Autodiff (GPU: Vulkan/Metal/DX12/WebGPU)";
 
 const NUM_ENVS: usize = 16;
-const NUM_STEPS: usize = 256;
-const DEFAULT_TIMESTEPS: usize = 200_000;
-const LEARNING_RATE: f64 = 3e-4;
+const NUM_STEPS: usize = 5;
+const DEFAULT_TIMESTEPS: usize = 500_000;
+const LEARNING_RATE: f64 = 7e-4;
 const HIDDEN_DIM: usize = 128;
 const GAMMA: f32 = 0.99;
-const GAE_LAMBDA: f32 = 0.95;
-/// Seed for reproducible policy init + env reset, so the opt-in
-/// learning-curve CSV is reproducible and overlay-comparable with A2C.
+// Classic A2C uses full n-step returns (gae_lambda = 1.0).
+const GAE_LAMBDA: f32 = 1.0;
+/// Seed for reproducible policy init, threaded through both the policy
+/// network init and `A2cConfig::seed`.
 const SEED: u64 = 0;
 
 fn main() -> Result<()> {
@@ -93,7 +105,7 @@ fn main() -> Result<()> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_TIMESTEPS);
 
-    tracing::info!("Starting Modern CartPole PPO Training (Burn backend: {})", BACKEND_LABEL);
+    tracing::info!("Starting CartPole A2C Training (Burn backend: {})", BACKEND_LABEL);
 
     let training_start = std::time::Instant::now();
 
@@ -122,9 +134,8 @@ fn main() -> Result<()> {
     // length.
     let mut curve_csv = open_curve_csv()?;
 
-    // Policy: 2-layer ReLU MLP, orthogonal init. Seeded for a reproducible
-    // policy initialization so the learning curve is overlay-comparable
-    // with A2C on the same seed.
+    // Policy: 2-layer ReLU MLP, orthogonal init, seeded for reproducible
+    // initialization.
     let policy_config = MlpBurnConfig {
         num_layers: 2,
         hidden_dim: HIDDEN_DIM,
@@ -138,32 +149,28 @@ fn main() -> Result<()> {
     let burn_opt: BurnOptimizer<Backend, MlpBurnPolicy<Backend>, _> =
         BurnOptimizer::new(inner_opt, LEARNING_RATE);
 
-    let ppo_config = PPOConfig::new()
+    let a2c_config = A2cConfig::new()
         .learning_rate(LEARNING_RATE)
-        .n_epochs(10)
-        .batch_size(128)
         .gamma(GAMMA as f64)
         .gae_lambda(GAE_LAMBDA as f64)
-        .clip_range(0.2)
-        .clip_range_vf(0.2)
-        .vf_coef(0.5)
-        .ent_coef(0.01)
+        .value_coef(0.5)
+        .entropy_coef(0.01)
+        .n_steps(NUM_STEPS)
+        .num_envs(NUM_ENVS)
         .max_grad_norm(0.5)
-        // Disable KL early-stop (the trainer's collapse guard handles
-        // pathology; KL early-stop interferes with small-budget runs).
-        .target_kl(1.0);
+        .normalize_advantages(true)
+        .seed(SEED);
 
-    let mut trainer = PPOTrainerBurn::new(ppo_config, policy, burn_opt)?;
+    let mut trainer = A2cTrainer::new(a2c_config, policy, burn_opt)?;
 
     let num_updates = total_timesteps / (NUM_STEPS * NUM_ENVS);
-    tracing::info!("Planned PPO updates: {}", num_updates);
+    tracing::info!("Planned A2C updates: {}", num_updates);
     tracing::info!("------------------------------------------------------------");
 
     // Rollout buffers (host).
     let cap = NUM_STEPS * NUM_ENVS;
     let mut buf_obs: Vec<f32> = Vec::with_capacity(cap * obs_dim);
     let mut buf_actions: Vec<i64> = Vec::with_capacity(cap);
-    let mut buf_log_probs: Vec<f32> = Vec::with_capacity(cap);
     let mut buf_values: Vec<f32> = Vec::with_capacity(cap);
     let mut buf_rewards: Vec<f32> = Vec::with_capacity(cap);
     let mut buf_dones: Vec<f32> = Vec::with_capacity(cap);
@@ -180,7 +187,6 @@ fn main() -> Result<()> {
     for update in 0..num_updates {
         buf_obs.clear();
         buf_actions.clear();
-        buf_log_probs.clear();
         buf_values.clear();
         buf_rewards.clear();
         buf_dones.clear();
@@ -191,14 +197,13 @@ fn main() -> Result<()> {
             let obs_t: Tensor<Backend, 2> =
                 Tensor::from_data(TensorData::new(obs_flat, [NUM_ENVS, obs_dim]), &device);
 
-            let (actions, log_probs, values) = trainer.policy().get_action_host(obs_t);
+            let (actions, _log_probs, values) = trainer.policy().get_action_host(obs_t);
 
             let results = env_pool.step(&actions);
 
             for env_id in 0..NUM_ENVS {
                 buf_obs.extend_from_slice(&observations[env_id]);
                 buf_actions.push(actions[env_id]);
-                buf_log_probs.push(log_probs[env_id]);
                 buf_values.push(values[env_id]);
                 buf_rewards.push(results[env_id].reward);
 
@@ -242,25 +247,17 @@ fn main() -> Result<()> {
             Tensor::from_data(TensorData::new(buf_obs.clone(), [batch, obs_dim]), &device);
         let actions_b: Tensor<Backend, 1, Int> =
             Tensor::from_data(TensorData::new(buf_actions.clone(), [batch]), &device);
-        let old_log_probs_b: Tensor<Backend, 1> =
-            Tensor::from_data(TensorData::new(buf_log_probs.clone(), [batch]), &device);
-        let old_values_b: Tensor<Backend, 1> =
-            Tensor::from_data(TensorData::new(buf_values.clone(), [batch]), &device);
         let advantages_b: Tensor<Backend, 1> =
             Tensor::from_data(TensorData::new(advantages_host, [batch]), &device);
         let returns_b: Tensor<Backend, 1> =
             Tensor::from_data(TensorData::new(returns_host, [batch]), &device);
 
-        // --- Train step --------------------------------------------
-        let stats = trainer.train_step(
-            obs_b,
-            actions_b,
-            old_log_probs_b,
-            old_values_b,
-            advantages_b,
-            returns_b,
-            |p, o, a| p.evaluate_actions(o, a),
-        )?;
+        // --- Train step (single A2C update) ------------------------
+        // A2C drops old_log_probs / old_values: on-policy, one update per
+        // rollout, no importance ratio, no value clipping.
+        let stats = trainer.train_step(obs_b, actions_b, advantages_b, returns_b, |p, o, a| {
+            p.evaluate_actions(o, a)
+        })?;
 
         // --- Log progress ------------------------------------------
         if !completed_episode_lengths.is_empty() {
@@ -270,20 +267,25 @@ fn main() -> Result<()> {
             last_avg_len = sum as f32 / recent.len() as f32;
         }
 
-        // Emit one learning-curve row per update when CURVE_CSV is set.
+        // Emit one learning-curve row per logging interval when CURVE_CSV
+        // is set. A2C runs many short updates, so we throttle to keep the
+        // CSV manageable while still dense.
         if let Some(w) = curve_csv.as_mut() {
-            writeln!(w, "{},{:.4}", total_env_steps, last_avg_len)?;
+            if update % 20 == 0 || update == num_updates - 1 {
+                writeln!(w, "{},{:.4}", total_env_steps, last_avg_len)?;
+            }
         }
 
-        if update % 5 == 0 || update == num_updates - 1 {
+        if update % 200 == 0 || update == num_updates - 1 {
             tracing::info!(
-                "update {:>3}/{}  env_steps={:>7}  episodes={:>4}  avg_len(last≤100)={:6.1}  policy_loss={:7.4}  entropy={:5.3}",
+                "update {:>5}/{}  env_steps={:>7}  episodes={:>5}  avg_len(last≤100)={:6.1}  policy_loss={:8.4}  value_loss={:8.4}  entropy={:5.3}",
                 update + 1,
                 num_updates,
                 total_env_steps,
                 trainer.total_episodes(),
                 last_avg_len,
                 stats.policy_loss,
+                stats.value_loss,
                 stats.entropy,
             );
         }

--- a/tests/test_a2c_cartpole.rs
+++ b/tests/test_a2c_cartpole.rs
@@ -1,0 +1,277 @@
+//! A2C convergence tests on the [`CartPole`] discrete-control env.
+//!
+//! This is PR C of the A2C epic (#150, issue #153). Two tiers, mirroring
+//! the SAC Pendulum test convention (`tests/test_sac_pendulum.rs`):
+//!
+//! 1. **`a2c_cartpole_training_step_runs`** (always runs) — a fast, unit-level
+//!    check that the A2C env loop wires together end-to-end: a handful of
+//!    `EnvPool` rollouts push real CartPole transitions, at least one gradient
+//!    update fires, and every reported loss / entropy stat is finite. This is
+//!    the CI default — it executes in well under a second and asserts no
+//!    convergence bar.
+//!
+//! 2. **`a2c_cartpole_reaches_reward_bar`** (`#[ignore]`) — the architect's
+//!    convergence bar: seeded A2C solves CartPole, reaching **mean episode
+//!    length >= 195 over the final 100 episodes** within a fixed env-step
+//!    budget. CartPole reward is +1/step (max 500), so episode length ==
+//!    episode reward; a random policy sits near ~22 steps, so 195 cleanly
+//!    separates "learned" from "did not learn".
+//!
+//! ## Why the heavy bar is `#[ignore]`d
+//!
+//! The convergence run trains for hundreds of thousands of env steps on
+//! the CPU `NdArray` backend — multi-minute wall-clock, too slow to gate
+//! every `cargo test` run. It is kept opt-in:
+//!
+//! ```text
+//! cargo test --release --features training --test test_a2c_cartpole -- --ignored
+//! ```
+//!
+//! The fast step test above guarantees the trainer keeps working on every
+//! CI run; the convergence test is the periodic / release-gate check.
+
+#![cfg(feature = "training")]
+
+use burn::{
+    backend::{Autodiff, NdArray},
+    optim::AdamConfig,
+    tensor::{Int, Tensor, TensorData},
+};
+use thrust_rl::{
+    env::{Environment, cartpole::CartPole, pool::EnvPool},
+    policy::mlp::{BurnActivation, MlpBurnConfig, MlpBurnPolicy},
+    train::{
+        a2c::{A2cConfig, A2cTrainer},
+        optimizer::BurnOptimizer,
+    },
+};
+
+type B = Autodiff<NdArray<f32>>;
+
+const GAMMA: f32 = 0.99;
+const GAE_LAMBDA: f32 = 1.0;
+
+/// Build a seeded A2C trainer + EnvPool for CartPole.
+#[allow(clippy::type_complexity)]
+fn build(
+    num_envs: usize,
+    n_steps: usize,
+    seed: u64,
+) -> (
+    A2cTrainer<B, MlpBurnPolicy<B>, impl burn::optim::Optimizer<MlpBurnPolicy<B>, B>>,
+    EnvPool<CartPole>,
+    usize,
+    usize,
+) {
+    let device = Default::default();
+
+    let probe = CartPole::new();
+    let obs_dim = probe.observation_space().shape[0];
+    let action_dim = match probe.action_space().space_type {
+        thrust_rl::env::SpaceType::Discrete(n) => n,
+        _ => panic!("expected discrete action space"),
+    };
+    drop(probe);
+
+    let policy_config = MlpBurnConfig {
+        num_layers: 2,
+        hidden_dim: 128,
+        use_orthogonal_init: true,
+        activation: BurnActivation::ReLU,
+        seed: Some(seed),
+    };
+    let policy = MlpBurnPolicy::<B>::with_config(obs_dim, action_dim, policy_config, &device);
+
+    let inner_opt = AdamConfig::new().init();
+    let burn_opt: BurnOptimizer<B, MlpBurnPolicy<B>, _> = BurnOptimizer::new(inner_opt, 7e-4);
+
+    let config = A2cConfig::new()
+        .learning_rate(7e-4)
+        .gamma(GAMMA as f64)
+        .gae_lambda(GAE_LAMBDA as f64)
+        .n_steps(n_steps)
+        .num_envs(num_envs)
+        .seed(seed);
+
+    let trainer = A2cTrainer::new(config, policy, burn_opt).expect("trainer constructs");
+    let env_pool = EnvPool::new(CartPole::new, num_envs);
+    (trainer, env_pool, obs_dim, num_envs)
+}
+
+/// Host-side per-env GAE (step-major `[T * N]` layout). Mirrors the
+/// example's `compute_gae`.
+#[allow(clippy::too_many_arguments)]
+fn compute_gae(
+    rewards: &[f32],
+    values: &[f32],
+    dones: &[f32],
+    last_values: &[f32],
+    gamma: f32,
+    gae_lambda: f32,
+    num_steps: usize,
+    num_envs: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    let cap = num_steps * num_envs;
+    let mut advantages = vec![0.0_f32; cap];
+    let mut returns = vec![0.0_f32; cap];
+    let mut last_gae = vec![0.0_f32; num_envs];
+    for t in (0..num_steps).rev() {
+        for n in 0..num_envs {
+            let idx = t * num_envs + n;
+            let next_value = if t == num_steps - 1 {
+                last_values[n]
+            } else {
+                values[(t + 1) * num_envs + n]
+            };
+            let next_nonterminal = 1.0 - dones[idx];
+            let delta = rewards[idx] + gamma * next_value * next_nonterminal - values[idx];
+            last_gae[n] = delta + gamma * gae_lambda * next_nonterminal * last_gae[n];
+            advantages[idx] = last_gae[n];
+            returns[idx] = advantages[idx] + values[idx];
+        }
+    }
+    (advantages, returns)
+}
+
+/// Run `num_updates` A2C updates against the CartPole `EnvPool`, returning
+/// the completed episode lengths (in completion order) and the stats from
+/// the final update. CartPole reward is +1/step so length == reward.
+fn train(
+    trainer: &mut A2cTrainer<B, MlpBurnPolicy<B>, impl burn::optim::Optimizer<MlpBurnPolicy<B>, B>>,
+    env_pool: &mut EnvPool<CartPole>,
+    obs_dim: usize,
+    num_envs: usize,
+    n_steps: usize,
+    num_updates: usize,
+) -> (Vec<u32>, thrust_rl::train::a2c::A2cStats) {
+    let device = Default::default();
+    let cap = n_steps * num_envs;
+    let mut buf_obs: Vec<f32> = Vec::with_capacity(cap * obs_dim);
+    let mut buf_actions: Vec<i64> = Vec::with_capacity(cap);
+    let mut buf_values: Vec<f32> = Vec::with_capacity(cap);
+    let mut buf_rewards: Vec<f32> = Vec::with_capacity(cap);
+    let mut buf_dones: Vec<f32> = Vec::with_capacity(cap);
+
+    let mut observations = env_pool.reset();
+    let mut episode_lengths = vec![0u32; num_envs];
+    let mut completed: Vec<u32> = Vec::new();
+    let mut last_stats = thrust_rl::train::a2c::A2cStats::default();
+
+    for _update in 0..num_updates {
+        buf_obs.clear();
+        buf_actions.clear();
+        buf_values.clear();
+        buf_rewards.clear();
+        buf_dones.clear();
+
+        for _step in 0..n_steps {
+            let obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+            let obs_t: Tensor<B, 2> =
+                Tensor::from_data(TensorData::new(obs_flat, [num_envs, obs_dim]), &device);
+            let (actions, _log_probs, values) = trainer.policy().get_action_host(obs_t);
+            let results = env_pool.step(&actions);
+
+            for env_id in 0..num_envs {
+                buf_obs.extend_from_slice(&observations[env_id]);
+                buf_actions.push(actions[env_id]);
+                buf_values.push(values[env_id]);
+                buf_rewards.push(results[env_id].reward);
+                let done = results[env_id].terminated || results[env_id].truncated;
+                buf_dones.push(if done { 1.0 } else { 0.0 });
+                episode_lengths[env_id] += 1;
+                observations[env_id] = results[env_id].observation.clone();
+                if done {
+                    completed.push(episode_lengths[env_id]);
+                    trainer.increment_episodes(1);
+                    episode_lengths[env_id] = 0;
+                    observations[env_id] = env_pool.reset_env(env_id).expect("reset env");
+                }
+            }
+        }
+
+        let last_obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+        let last_obs_t: Tensor<B, 2> =
+            Tensor::from_data(TensorData::new(last_obs_flat, [num_envs, obs_dim]), &device);
+        let (_, _, last_values) = trainer.policy().get_action_host(last_obs_t);
+
+        let (adv_host, ret_host) = compute_gae(
+            &buf_rewards,
+            &buf_values,
+            &buf_dones,
+            &last_values,
+            GAMMA,
+            GAE_LAMBDA,
+            n_steps,
+            num_envs,
+        );
+
+        let batch = n_steps * num_envs;
+        let obs_b: Tensor<B, 2> =
+            Tensor::from_data(TensorData::new(buf_obs.clone(), [batch, obs_dim]), &device);
+        let actions_b: Tensor<B, 1, Int> =
+            Tensor::from_data(TensorData::new(buf_actions.clone(), [batch]), &device);
+        let adv_b: Tensor<B, 1> = Tensor::from_data(TensorData::new(adv_host, [batch]), &device);
+        let ret_b: Tensor<B, 1> = Tensor::from_data(TensorData::new(ret_host, [batch]), &device);
+
+        last_stats = trainer
+            .train_step(obs_b, actions_b, adv_b, ret_b, |p, o, a| p.evaluate_actions(o, a))
+            .expect("train step is finite");
+    }
+
+    (completed, last_stats)
+}
+
+/// Fast, always-on smoke test: drive a few real CartPole rollouts through
+/// the A2C trainer and assert finite gradient steps occur. Keeps the
+/// trainer wired up on every CI run without a convergence bar.
+#[test]
+fn a2c_cartpole_training_step_runs() {
+    let num_envs = 8;
+    let n_steps = 5;
+    let (mut trainer, mut env_pool, obs_dim, num_envs) = build(num_envs, n_steps, 0);
+
+    let (_completed, stats) = train(&mut trainer, &mut env_pool, obs_dim, num_envs, n_steps, 50);
+
+    assert!(trainer.total_steps() >= 50, "expected at least 50 gradient updates");
+    assert!(stats.policy_loss.is_finite(), "policy loss finite");
+    assert!(stats.value_loss.is_finite(), "value loss finite");
+    assert!(stats.entropy.is_finite(), "entropy finite");
+    assert!(stats.total_loss.is_finite(), "total loss finite");
+}
+
+/// Heavy convergence test (opt-in via `--ignored`): seeded A2C solves
+/// CartPole, reaching mean episode length >= 195 over the final 100
+/// episodes within a fixed env-step budget.
+///
+/// Run with:
+/// ```text
+/// cargo test --release --features training --test test_a2c_cartpole -- --ignored
+/// ```
+#[test]
+#[ignore = "multi-minute convergence run; opt in with --ignored (prefer --release)"]
+fn a2c_cartpole_reaches_reward_bar() {
+    let num_envs = 16;
+    let n_steps = 5;
+    let total_timesteps = 600_000;
+    let num_updates = total_timesteps / (n_steps * num_envs);
+
+    let (mut trainer, mut env_pool, obs_dim, num_envs) = build(num_envs, n_steps, 0);
+    let (completed, _stats) =
+        train(&mut trainer, &mut env_pool, obs_dim, num_envs, n_steps, num_updates);
+
+    assert!(
+        completed.len() >= 100,
+        "expected at least 100 completed episodes, got {}",
+        completed.len()
+    );
+
+    let n = completed.len();
+    let recent = &completed[n - 100..];
+    let mean_len: f32 = recent.iter().map(|&x| x as f32).sum::<f32>() / 100.0;
+
+    assert!(
+        mean_len >= 195.0,
+        "A2C mean episode length over final 100 episodes was {mean_len:.1}, expected >= 195.0 \
+         (random baseline ~22)"
+    );
+}


### PR DESCRIPTION
## Summary

PR C of the A2C epic (#150). With `A2cTrainer`/`A2cConfig` landed (#152),
this adds the A2C CartPole training example, a reproducible opt-in
learning-curve CSV (on both the new A2C example and the existing PPO
example, for overlay comparison), and a seeded convergence test gated out
of the fast CI lane.

## Changes

- **NEW `examples/games/cartpole/train_cartpole_a2c.rs`** — mirrors the PPO
  example's `EnvPool` rollout-collect + GAE pattern, swapping
  `PPOTrainerBurn`/`PPOConfig` for `A2cTrainer`/`A2cConfig`. Defaults:
  `n_steps=5`, `num_envs=16`, `learning_rate=7e-4`, `gae_lambda=1.0`,
  seeded policy init via `MlpBurnConfig::with_seed` + `A2cConfig::seed`.
  Single update per rollout (no `old_log_probs`/`old_values`). Honors
  `TOTAL_TIMESTEPS`.
- **Opt-in `CURVE_CSV` writer** on the A2C example and added (additive,
  behind the env var) to `train_cartpole_modern.rs`. Writes
  `env_steps,mean_episode_reward` (header + rows). Unset = no file, no
  behavior change. PPO example's policy init is now seeded so the curves
  are overlay-comparable. No plotting (CSV data is the deliverable).
- **NEW `tests/test_a2c_cartpole.rs`** — two tiers mirroring
  `tests/test_sac_pendulum.rs`: a fast always-on smoke test
  (`a2c_cartpole_training_step_runs`) and an `#[ignore]`d convergence bar
  (`a2c_cartpole_reaches_reward_bar`) asserting mean episode length >= 195
  over the final 100 episodes within a 600k env-step budget.
- **`Cargo.toml`** — `[[example]]` block for `train_cartpole_a2c`
  (`required-features = ["training"]`). Edit localized to the
  `[[example]]` region to minimize conflict with PR #154.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| A2C example trains; mean length climbs above ~22 baseline | ✅ | Full 600k-step run reached final avg length 500.00 (CartPole max) |
| `CURVE_CSV=...` produces well-formed CSV; unset = no file | ✅ | Verified header + rows written; confirmed no file created when unset |
| PPO example gains same opt-in CSV; default unchanged | ✅ | Writer behind `CURVE_CSV`; no-op when unset |
| Convergence test seeded, asserts >= 195/100, excluded from fast lane | ✅ | `#[ignore]`d; fast lane runs only the smoke test |
| `[[example]]` block added | ✅ | Added to Cargo.toml |
| Build + tests pass; clippy clean | ✅ | See Test Plan |

## Test Plan

- `cargo test --release --features training --test test_a2c_cartpole -- --ignored`:
  **PASS**, ~16.8s wall-clock (test body), mean episode length over final
  100 episodes >= 195 (full-budget example run shows final avg length
  **500.00** over last 100 episodes at 600k env steps).
- Fast lane `cargo test --features training --test test_a2c_cartpole`:
  smoke test passes, convergence test ignored.
- `cargo test --features training --lib a2c`: 10 passed.
- `cargo fmt --check`: clean.
- `cargo clippy` on touched targets: zero errors in touched files
  (pre-existing `src/inference/mod.rs` lib lints are out of scope).
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean.

Closes #153