### PR TITLE
BC PR A: Demonstrations dataset + BcConfig

### DIFF
--- a/src/train/bc/config.rs
+++ b/src/train/bc/config.rs
@@ -1,0 +1,136 @@
+//! Behavioral Cloning (BC) configuration and hyperparameters.
+//!
+//! [`BcConfig`] mirrors the builder + `validate()` style of
+//! [`crate::train::a2c::A2cConfig`] and [`crate::train::sac::SacConfig`].
+//! Behavioral cloning trains a policy to reproduce expert actions from a
+//! fixed [`Demonstrations`](crate::train::bc::Demonstrations) dataset via
+//! supervised cross-entropy. Defaults target classic discrete-control
+//! tasks like CartPole: a `1e-3` learning rate over `64`-sample minibatches
+//! for `10` epochs.
+//!
+//! This is the config half of PR A of the BC decomposition (#164); the BC
+//! trainer (#167) consumes it.
+
+use anyhow::{Result, anyhow};
+
+/// Behavioral Cloning configuration parameters.
+///
+/// These hyperparameters control the supervised imitation-learning process:
+/// the policy is trained for `epochs` passes over a fixed dataset of expert
+/// `(observation, action)` pairs, drawing shuffled minibatches of
+/// `batch_size` examples and minimizing cross-entropy against the expert
+/// labels.
+#[derive(Debug, Clone)]
+pub struct BcConfig {
+    /// Learning rate for the supervised policy optimizer.
+    pub learning_rate: f64,
+
+    /// Number of demonstration examples per minibatch.
+    pub batch_size: usize,
+
+    /// Number of full passes over the demonstration dataset.
+    pub epochs: usize,
+
+    /// Seed threaded into seeded network init and minibatch shuffling for
+    /// reproducibility. Two trainers built with the same `seed` produce
+    /// bit-identical training trajectories.
+    pub seed: u64,
+}
+
+impl Default for BcConfig {
+    fn default() -> Self {
+        Self { learning_rate: 1e-3, batch_size: 64, epochs: 10, seed: 0 }
+    }
+}
+
+impl BcConfig {
+    /// Create a new default configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Validate configuration parameters.
+    ///
+    /// Returns an `Err` describing the first invalid field encountered.
+    pub fn validate(&self) -> Result<()> {
+        if self.learning_rate <= 0.0 {
+            return Err(anyhow!("learning_rate must be positive, got {}", self.learning_rate));
+        }
+        if self.batch_size == 0 {
+            return Err(anyhow!("batch_size must be positive"));
+        }
+        if self.epochs == 0 {
+            return Err(anyhow!("epochs must be positive"));
+        }
+        Ok(())
+    }
+
+    // ----- Builder-style setters (mirroring A2cConfig / SacConfig) -----
+
+    /// Set the learning rate.
+    pub fn learning_rate(mut self, lr: f64) -> Self {
+        self.learning_rate = lr;
+        self
+    }
+
+    /// Set the minibatch size.
+    pub fn batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    /// Set the number of training epochs.
+    pub fn epochs(mut self, epochs: usize) -> Self {
+        self.epochs = epochs;
+        self
+    }
+
+    /// Set the reproducibility seed.
+    pub fn seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = BcConfig::default();
+        assert!(config.validate().is_ok());
+        assert_eq!(config.learning_rate, 1e-3);
+        assert_eq!(config.batch_size, 64);
+        assert_eq!(config.epochs, 10);
+        assert_eq!(config.seed, 0);
+    }
+
+    #[test]
+    fn test_config_validation() {
+        // Valid config should pass
+        let config = BcConfig::new();
+        assert!(config.validate().is_ok());
+
+        // Invalid learning rate
+        assert!(BcConfig::new().learning_rate(0.0).validate().is_err());
+        assert!(BcConfig::new().learning_rate(-1.0).validate().is_err());
+
+        // Invalid batch_size
+        assert!(BcConfig::new().batch_size(0).validate().is_err());
+
+        // Invalid epochs
+        assert!(BcConfig::new().epochs(0).validate().is_err());
+    }
+
+    #[test]
+    fn test_config_builder() {
+        let config = BcConfig::new().learning_rate(5e-4).batch_size(128).epochs(25).seed(42);
+
+        assert!(config.validate().is_ok());
+        assert_eq!(config.learning_rate, 5e-4);
+        assert_eq!(config.batch_size, 128);
+        assert_eq!(config.epochs, 25);
+        assert_eq!(config.seed, 42);
+    }
+}

--- a/src/train/bc/dataset.rs
+++ b/src/train/bc/dataset.rs
@@ -1,0 +1,212 @@
+//! Fixed dataset of expert demonstrations for Behavioral Cloning.
+//!
+//! [`Demonstrations`] is a small, flat supervised dataset of discrete-action
+//! demonstrations: a contiguous block of observations paired with the expert
+//! action taken at each. It is intentionally NOT a reuse of
+//! [`crate::buffer::rollout::RolloutBuffer`] or
+//! [`crate::buffer::replay::ReplayBuffer`], which carry rewards, dones,
+//! advantages, and priorities that supervised imitation has no use for (BC
+//! epic #161, decision 2).
+//!
+//! Seeded minibatching reuses PPO's
+//! [`generate_minibatch_indices_with_rng`](crate::train::ppo::loss::generate_minibatch_indices_with_rng)
+//! so the BC trainer (#167) can produce bit-reproducible shuffles from a
+//! [`BcConfig`](crate::train::bc::BcConfig) seed.
+//!
+//! This is the dataset half of PR A of the BC decomposition (#164). A
+//! `from_file` constructor can be layered on later without disturbing the
+//! in-memory API.
+
+use anyhow::{Result, anyhow};
+use burn::tensor::{Int, Tensor, TensorData, backend::Backend};
+
+/// A fixed dataset of expert `(observation, action)` pairs for supervised
+/// imitation learning.
+///
+/// Observations are stored as a single flat row-major `Vec<f32>` of shape
+/// `[len, obs_dim]`; the discrete expert action for example `i` lives at
+/// `actions[i]`. The dataset is immutable once constructed and serves
+/// host-side minibatches by index via [`Demonstrations::batch`].
+#[derive(Debug, Clone)]
+pub struct Demonstrations {
+    /// Flat row-major observation buffer of shape `[len, obs_dim]`.
+    obs: Vec<f32>,
+    /// Discrete expert action per example, length `len`.
+    actions: Vec<i64>,
+    /// Dimensionality of a single observation.
+    obs_dim: usize,
+    /// Number of `(observation, action)` examples.
+    len: usize,
+}
+
+impl Demonstrations {
+    /// Build a dataset from a flat observation buffer and a parallel action
+    /// vector.
+    ///
+    /// `obs` must be row-major of length `len * obs_dim` and `actions` must
+    /// have length `len`, where `len` is inferred from `actions`. Returns an
+    /// `Err` if the lengths are inconsistent or `obs_dim` is zero.
+    ///
+    /// # Arguments
+    ///
+    /// * `obs` - Flat row-major observations of shape `[len, obs_dim]`.
+    /// * `actions` - Expert action index per example.
+    /// * `obs_dim` - Dimensionality of a single observation.
+    pub fn new(obs: Vec<f32>, actions: Vec<i64>, obs_dim: usize) -> Result<Self> {
+        if obs_dim == 0 {
+            return Err(anyhow!("obs_dim must be positive"));
+        }
+        let len = actions.len();
+        if obs.len() != len * obs_dim {
+            return Err(anyhow!(
+                "obs length {} does not match actions.len() ({}) * obs_dim ({}) = {}",
+                obs.len(),
+                len,
+                obs_dim,
+                len * obs_dim
+            ));
+        }
+        Ok(Self { obs, actions, obs_dim, len })
+    }
+
+    /// Number of `(observation, action)` examples in the dataset.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Whether the dataset contains no examples.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Dimensionality of a single observation.
+    pub fn obs_dim(&self) -> usize {
+        self.obs_dim
+    }
+
+    /// Gather the given example indices into a minibatch of tensors.
+    ///
+    /// Returns `(obs, actions)` where `obs` has shape `[k, obs_dim]` and
+    /// `actions` has shape `[k]`, with `k = indices.len()`. Gathering is done
+    /// host-side; the resulting tensors are plain inputs/labels with no
+    /// gradient tracking concerns.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any index is out of bounds (`>= len`).
+    ///
+    /// # Arguments
+    ///
+    /// * `indices` - Example indices to gather into the minibatch.
+    /// * `device` - Backend device the tensors are allocated on.
+    pub fn batch<B: Backend>(
+        &self,
+        indices: &[usize],
+        device: &B::Device,
+    ) -> (Tensor<B, 2>, Tensor<B, 1, Int>) {
+        let k = indices.len();
+        let mut obs_data = Vec::with_capacity(k * self.obs_dim);
+        let mut action_data = Vec::with_capacity(k);
+
+        for &i in indices {
+            assert!(i < self.len, "index {} out of bounds for dataset of len {}", i, self.len);
+            let start = i * self.obs_dim;
+            obs_data.extend_from_slice(&self.obs[start..start + self.obs_dim]);
+            action_data.push(self.actions[i]);
+        }
+
+        let obs = Tensor::<B, 2>::from_data(TensorData::new(obs_data, [k, self.obs_dim]), device);
+        let actions = Tensor::<B, 1, Int>::from_data(TensorData::new(action_data, [k]), device);
+        (obs, actions)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::backend::{Autodiff, NdArray};
+
+    use super::*;
+    use crate::train::ppo::loss::generate_minibatch_indices_with_rng;
+
+    type B = Autodiff<NdArray<f32>>;
+
+    fn sample_dataset() -> Demonstrations {
+        // 4 examples, obs_dim = 2.
+        let obs = vec![
+            0.0, 0.1, // ex 0
+            1.0, 1.1, // ex 1
+            2.0, 2.1, // ex 2
+            3.0, 3.1, // ex 3
+        ];
+        let actions = vec![0i64, 1, 0, 1];
+        Demonstrations::new(obs, actions, 2).unwrap()
+    }
+
+    #[test]
+    fn test_new_validates_dimensions() {
+        // Valid: 4 actions * obs_dim 2 == 8 floats.
+        assert!(Demonstrations::new(vec![0.0; 8], vec![0i64; 4], 2).is_ok());
+
+        // obs too short.
+        assert!(Demonstrations::new(vec![0.0; 6], vec![0i64; 4], 2).is_err());
+
+        // obs too long.
+        assert!(Demonstrations::new(vec![0.0; 10], vec![0i64; 4], 2).is_err());
+
+        // obs_dim zero rejected.
+        assert!(Demonstrations::new(vec![], vec![], 0).is_err());
+    }
+
+    #[test]
+    fn test_len_and_is_empty() {
+        let ds = sample_dataset();
+        assert_eq!(ds.len(), 4);
+        assert_eq!(ds.obs_dim(), 2);
+        assert!(!ds.is_empty());
+
+        let empty = Demonstrations::new(vec![], vec![], 2).unwrap();
+        assert_eq!(empty.len(), 0);
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn test_batch_shapes_and_contents() {
+        let ds = sample_dataset();
+        let device = Default::default();
+
+        let indices = [2usize, 1];
+        let (obs, actions) = ds.batch::<B>(&indices, &device);
+
+        assert_eq!(obs.dims(), [2, 2]);
+        assert_eq!(actions.dims(), [2]);
+
+        let obs_vals: Vec<f32> = obs.into_data().to_vec().unwrap();
+        // Row 0 -> example 2, row 1 -> example 1.
+        assert_eq!(obs_vals, vec![2.0, 2.1, 1.0, 1.1]);
+
+        let action_vals: Vec<i64> = actions.into_data().to_vec().unwrap();
+        // actions[2] == 0, actions[1] == 1.
+        assert_eq!(action_vals, vec![0, 1]);
+    }
+
+    #[test]
+    fn test_seeded_minibatch_shuffle_is_reproducible() {
+        use rand::{SeedableRng, rngs::StdRng};
+
+        let ds = sample_dataset();
+
+        let mut rng_a = StdRng::seed_from_u64(7);
+        let batches_a = generate_minibatch_indices_with_rng(ds.len(), 2, &mut rng_a);
+
+        let mut rng_b = StdRng::seed_from_u64(7);
+        let batches_b = generate_minibatch_indices_with_rng(ds.len(), 2, &mut rng_b);
+
+        // Same seed -> identical minibatch partition.
+        assert_eq!(batches_a, batches_b);
+
+        // Every example index appears exactly once across the partition.
+        let mut seen: Vec<usize> = batches_a.iter().flatten().copied().collect();
+        seen.sort_unstable();
+        assert_eq!(seen, vec![0, 1, 2, 3]);
+    }
+}

--- a/src/train/bc/mod.rs
+++ b/src/train/bc/mod.rs
@@ -1,0 +1,20 @@
+//! Behavioral Cloning (BC) — supervised imitation learning.
+//!
+//! Behavioral cloning trains a policy to reproduce expert actions from a
+//! fixed dataset of `(observation, action)` pairs via supervised
+//! cross-entropy. It lands as a sibling module to [`crate::train::a2c`],
+//! reusing the same policy/optimizer infrastructure with a plain supervised
+//! epoch loop in place of an environment-interaction loop.
+//!
+//! This module is built incrementally by the BC decomposition (#161):
+//! - [`BcConfig`] — supervised hyperparameters (builder + `validate()`),
+//!   mirroring [`crate::train::a2c::A2cConfig`] (#164).
+//! - [`Demonstrations`] — the fixed expert dataset serving seeded minibatches
+//!   (#164).
+//! - The cross-entropy loss and `BcTrainer` epoch loop land in #167.
+
+pub mod config;
+pub mod dataset;
+
+pub use config::BcConfig;
+pub use dataset::Demonstrations;

--- a/src/train/mod.rs
+++ b/src/train/mod.rs
@@ -9,11 +9,13 @@
 pub mod optimizer;
 
 pub mod a2c;
+pub mod bc;
 pub mod dqn;
 pub mod ppo;
 pub mod sac;
 
 pub use a2c::{A2cConfig, A2cStats, A2cTrainer, compute_a2c_policy_loss, compute_a2c_value_loss};
+pub use bc::{BcConfig, Demonstrations};
 pub use dqn::{DQNConfig, DQNStepStatsBurn, DQNTrainerBurn};
 pub use optimizer::{BackendOptimizer, BurnOptimizer};
 pub use ppo::{


### PR DESCRIPTION
Closes #164

PR A of the Behavioral Cloning epic (#161): dataset + config + module skeleton only. **No trainer or loss yet** — those land in #167 (PR B).

## What this implements

### `src/train/bc/config.rs` — `BcConfig`
Mirrors `A2cConfig`/`SacConfig` (builder setters + `Default` + `new()` + `validate()`).

| Knob | Default |
|---|---|
| `learning_rate` | `1e-3` |
| `batch_size` | `64` |
| `epochs` | `10` |
| `seed` | `0` |

`validate()` rejects non-positive `learning_rate`, zero `batch_size`, zero `epochs`.

### `src/train/bc/dataset.rs` — `Demonstrations`
A small NEW flat supervised dataset of expert `(obs, action)` pairs — intentionally **not** a reuse of `RolloutBuffer`/`ReplayBuffer` (those carry rewards/dones/advantages/priorities BC has no use for; epic decision 2).
- `new(obs, actions, obs_dim)` validates `obs.len() == len * obs_dim` and rejects `obs_dim == 0`.
- `len()`, `is_empty()`, `obs_dim()` accessors.
- `batch::<B>(indices, device) -> (Tensor<B,2>, Tensor<B,1,Int>)` gathers a host-side minibatch by index.
- Seeded minibatch shuffling reuses PPO's public `generate_minibatch_indices_with_rng` (verified `pub`).
- Designed so a `from_file` constructor can be added later without touching the in-memory API.

### Module wiring
- NEW `src/train/bc/mod.rs` declares `config` + `dataset`, re-exports `BcConfig` + `Demonstrations`.
- EDIT `src/train/mod.rs`: additive `pub mod bc;` + `pub use bc::{BcConfig, Demonstrations};`.

## Tests (all passing — 7/7)
- Config: default, validation rejection cases, builder roundtrip.
- Dataset: dimension validation, `len`/`is_empty`, `batch` shapes + contents, seeded reproducible minibatch shuffle.

## Verification
- `cargo fmt --check`: clean.
- `cargo clippy --all-targets --features training -- -D warnings`: **zero errors in touched files** (`src/train/bc/*`, `src/train/mod.rs`). Pre-existing clippy errors remain in unrelated files (`src/buffer/rollout/tests.rs`, `src/inference/snake.rs`, `src/policy/universal_inference.rs`, etc.) on the base commit; not introduced or touched by this PR.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean.
- `cargo test --features training --lib bc`: 7 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)