### PR TITLE
DQN throughput bench groups + CURVE_CSV learning curve (closes #160)

### DIFF
--- a/benches/trainer_throughput.rs
+++ b/benches/trainer_throughput.rs
@@ -1,10 +1,29 @@
-//! Throughput / wall-clock benchmarks for the on-policy trainers.
+//! Throughput / wall-clock benchmarks for the trainers.
 //!
-//! Measures steps/sec and per-update wall-clock for the A2C trainer
-//! ([`A2cTrainer`]) and, for an apples-to-apples comparison, the PPO
-//! trainer ([`PPOTrainerBurn`]). All benchmarks run on the pure-Rust
+//! Measures steps/sec and per-update wall-clock for the on-policy A2C
+//! ([`A2cTrainer`]) and PPO ([`PPOTrainerBurn`]) trainers and the off-policy
+//! DQN trainer ([`DQNTrainerBurn`]). All benchmarks run on the pure-Rust
 //! `Autodiff<NdArray<f32>>` (CPU) backend and are seeded so the numbers
 //! are comparable run-to-run.
+//!
+//! # Fairness caveat: on-policy vs off-policy steps/sec
+//!
+//! The `*_steps_per_sec` groups measure full-loop environment throughput and
+//! are comparable WITHIN an algorithm class only (on-policy: A2C-vs-PPO;
+//! off-policy: DQN-vs-SAC). They are NOT comparable across classes, because
+//! the two classes do a different amount of gradient work per environment
+//! step: an on-policy trainer collects `n_steps * num_envs` env interactions
+//! and then amortizes ONE update over all of them, whereas an off-policy
+//! trainer does ONE replay-sampled gradient update (on a `batch_size`
+//! minibatch) for EVERY single env step. So off-policy does roughly
+//! `batch_size` more gradient work per env step than on-policy — a raw
+//! "DQN steps/sec vs A2C steps/sec" comparison is therefore meaningless.
+//! Use the `*_train_step` groups (per-update cost on a fixed batch) as the
+//! only cross-class comparable number. To keep the off-policy steps/sec
+//! numbers honest, the replay buffer is pre-filled to `min_buffer_size` in
+//! the untimed setup closure so the timed region measures steady-state
+//! throughput (one real update per step) rather than the warmup transient
+//! (env steps whose `train_step` is a `None` no-op).
 //!
 //! Benchmark groups:
 //! - `a2c_cartpole_steps_per_sec` — a full rollout-collect (CartPole env
@@ -17,6 +36,13 @@
 //!   synthetic batch, for a head-to-head per-update comparison.
 //! - `ppo_cartpole_steps_per_sec` — a full-loop PPO comparison mirroring the
 //!   A2C full-loop benchmark.
+//! - `dqn_train_step` — a single Double-DQN [`DQNTrainerBurn::train_step`] on a
+//!   replay minibatch (buffer pre-filled untimed in setup), isolating the
+//!   off-policy per-update cost. Cross-class comparable against
+//!   `a2c_train_step` / `ppo_train_step`.
+//! - `dqn_cartpole_steps_per_sec` — a full DQN env-loop (one CartPole step +
+//!   buffer push + one gradient update per env step), reported in
+//!   environment-steps/sec. Comparable within the off-policy class only.
 //!
 //! Run quickly with, e.g.:
 //! ```text
@@ -35,8 +61,10 @@ use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use rand::{SeedableRng, rngs::StdRng};
 use thrust_rl::{
     env::{Environment, games::cartpole::CartPole},
-    policy::mlp::MlpBurnPolicy,
-    train::{A2cConfig, A2cTrainer, BurnOptimizer, PPOConfig, PPOTrainerBurn},
+    policy::{mlp::MlpBurnPolicy, q_network::QNetworkBurn},
+    train::{
+        A2cConfig, A2cTrainer, BurnOptimizer, DQNConfig, DQNTrainerBurn, PPOConfig, PPOTrainerBurn,
+    },
 };
 
 /// CPU autodiff backend used for every benchmark.
@@ -55,6 +83,18 @@ const SYNTH_BATCH: usize = 64;
 // Full-loop rollout shape (mirrors A2C defaults: n_steps=5, num_envs=16).
 const ROLLOUT_N_STEPS: usize = 5;
 const ROLLOUT_NUM_ENVS: usize = 16;
+
+// DQN replay/minibatch shape. `DQN_BATCH` is the per-update minibatch sampled
+// from the replay buffer; `DQN_MIN_BUFFER` is the warmup threshold below which
+// `train_step` is a no-op (`Ok(None)`). The fixtures pre-fill the buffer to
+// `DQN_MIN_BUFFER` so every timed `train_step` performs a real gradient update.
+const DQN_BATCH: usize = 64;
+const DQN_MIN_BUFFER: usize = 256;
+const DQN_BUFFER_CAPACITY: usize = 4_096;
+
+// Number of timed env steps in the DQN full-loop benchmark. Each step is one
+// CartPole transition + buffer push + one gradient update.
+const DQN_LOOP_STEPS: usize = 16;
 
 /// Build a fresh, seeded A2C trainer on the CPU backend.
 fn make_a2c_trainer()
@@ -343,11 +383,183 @@ fn bench_ppo_cartpole_steps_per_sec(c: &mut Criterion) {
     group.finish();
 }
 
+/// DQN-specific configuration shared by both DQN benchmark groups.
+///
+/// Small replay buffer / minibatch so each timed iteration completes quickly
+/// on CPU while still exercising the full Double-DQN backward pass. Hard
+/// target sync (no soft update) so the timed region is just the gradient step.
+fn dqn_config() -> DQNConfig {
+    DQNConfig::new()
+        .learning_rate(1e-3)
+        .batch_size(DQN_BATCH)
+        .buffer_capacity(DQN_BUFFER_CAPACITY)
+        .min_buffer_size(DQN_MIN_BUFFER)
+        .target_update_interval(500)
+        .gamma(0.99)
+        .epsilon_start(1.0)
+        .epsilon_end(0.05)
+        .epsilon_decay_steps(10_000)
+}
+
+/// Build a fresh, seeded Burn DQN trainer on the CPU backend.
+fn make_dqn_trainer()
+-> DQNTrainerBurn<B, QNetworkBurn<B>, impl burn::optim::Optimizer<QNetworkBurn<B>, B>> {
+    let device: NdArrayDevice = Default::default();
+    let online = QNetworkBurn::<B>::new(OBS_DIM, ACTION_DIM, HIDDEN_DIM, &device);
+    let inner_opt = AdamConfig::new().init();
+    let config = dqn_config();
+    let burn_opt: BurnOptimizer<B, QNetworkBurn<B>, _> =
+        BurnOptimizer::new(inner_opt, config.learning_rate);
+    DQNTrainerBurn::new(config, online, burn_opt, OBS_DIM, ACTION_DIM as i64, device)
+        .expect("valid DQN config")
+}
+
+/// A single deterministic synthetic CartPole-shaped transition derived from a
+/// step index. Mirrors the trainer's own unit-test fixture so the pushed data
+/// is plausible (bounded floats, alternating actions, periodic dones).
+fn synthetic_transition(i: usize) -> ([f32; OBS_DIM], i64, f32, [f32; OBS_DIM], bool) {
+    let phase = (i as f32) * 0.1;
+    let obs = [phase.sin(), phase.cos(), phase * 0.5, phase * -0.3];
+    let next_obs = [(phase + 0.1).sin(), (phase + 0.1).cos(), phase * 0.5, phase * -0.3];
+    let action = (i % ACTION_DIM) as i64;
+    let reward = if action == 0 { 1.0 } else { -1.0 };
+    let done = i % 32 == 31;
+    (obs, action, reward, next_obs, done)
+}
+
+/// Pre-fill a trainer's replay buffer with `n` seeded synthetic transitions
+/// so `train_step` performs a real gradient update instead of the warmup
+/// `None` no-op.
+fn prefill_buffer(
+    trainer: &mut DQNTrainerBurn<
+        B,
+        QNetworkBurn<B>,
+        impl burn::optim::Optimizer<QNetworkBurn<B>, B>,
+    >,
+    n: usize,
+) {
+    for i in 0..n {
+        let (obs, action, reward, next_obs, done) = synthetic_transition(i);
+        trainer.buffer_mut().push(&obs, action, reward, &next_obs, done);
+    }
+}
+
+/// `dqn_train_step` — isolated single Double-DQN gradient step on a replay
+/// minibatch. The `iter_batched` setup closure (untimed) builds a fresh
+/// seeded trainer and pre-fills its replay buffer past `min_buffer_size`, so
+/// every timed `train_step` performs exactly one real gradient update (never
+/// `None`). This is the off-policy per-update number, cross-class comparable
+/// against `a2c_train_step` / `ppo_train_step`.
+fn bench_dqn_train_step(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dqn_train_step");
+    group.throughput(Throughput::Elements(DQN_BATCH as u64));
+    group.bench_function("replay_minibatch", |b| {
+        b.iter_batched(
+            || {
+                let mut trainer = make_dqn_trainer();
+                prefill_buffer(&mut trainer, DQN_MIN_BUFFER);
+                (trainer, StdRng::seed_from_u64(99))
+            },
+            |(mut trainer, mut rng)| {
+                let stats = trainer
+                    .train_step(
+                        &mut rng,
+                        |q: &QNetworkBurn<B>, o: Tensor<B, 2>| q.forward(o),
+                        |q: &QNetworkBurn<B>, o: Tensor<B, 2>| q.forward(o),
+                    )
+                    .expect("DQN train_step")
+                    .expect("buffer pre-filled, train_step must update (not None)");
+                black_box(stats)
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+/// `dqn_cartpole_steps_per_sec` — full DQN env-loop: step a seeded CartPole
+/// env, push the transition, and run one gradient update per env step
+/// (mirroring `train_cartpole_dqn`). The buffer is pre-filled to
+/// `min_buffer_size` in the untimed setup so the timed region measures
+/// steady-state throughput (one update per step), not the warmup transient.
+/// Reported in environment-steps/sec; comparable within the off-policy class
+/// only (see module header).
+fn bench_dqn_cartpole_steps_per_sec(c: &mut Criterion) {
+    let device: NdArrayDevice = Default::default();
+
+    let mut group = c.benchmark_group("dqn_cartpole_steps_per_sec");
+    group.throughput(Throughput::Elements(DQN_LOOP_STEPS as u64));
+    group.bench_function("env_step_plus_update", |b| {
+        b.iter_batched(
+            || {
+                let mut trainer = make_dqn_trainer();
+                prefill_buffer(&mut trainer, DQN_MIN_BUFFER);
+                let mut env = CartPole::new();
+                env.reset();
+                (trainer, env, StdRng::seed_from_u64(0xC0FFEE))
+            },
+            |(mut trainer, mut env, mut rng)| {
+                let mut obs = env.get_observation();
+                for _ in 0..DQN_LOOP_STEPS {
+                    let action = trainer.select_action(
+                        &obs,
+                        &mut rng,
+                        |q: &QNetworkBurn<B>, o_host: &[f32]| {
+                            let o_t: Tensor<B, 2> = Tensor::from_data(
+                                TensorData::new(o_host.to_vec(), [1, o_host.len()]),
+                                &device,
+                            );
+                            let q_host: Vec<f32> =
+                                q.forward(o_t).into_data().to_vec().unwrap_or_default();
+                            let mut best = 0_i64;
+                            let mut best_v = f32::NEG_INFINITY;
+                            for (i, &v) in q_host.iter().enumerate() {
+                                if v > best_v {
+                                    best_v = v;
+                                    best = i as i64;
+                                }
+                            }
+                            best
+                        },
+                    );
+
+                    let result = env.step(action);
+                    let next_obs = result.observation.clone();
+                    let done = result.terminated || result.truncated;
+                    trainer.buffer_mut().push(&obs, action, result.reward, &next_obs, done);
+                    obs = next_obs;
+
+                    trainer.increment_env_step();
+
+                    let stats = trainer
+                        .train_step(
+                            &mut rng,
+                            |q: &QNetworkBurn<B>, o: Tensor<B, 2>| q.forward(o),
+                            |q: &QNetworkBurn<B>, o: Tensor<B, 2>| q.forward(o),
+                        )
+                        .expect("DQN train_step")
+                        .expect("buffer pre-filled, train_step must update (not None)");
+                    black_box(stats);
+
+                    if done {
+                        env.reset();
+                        obs = env.get_observation();
+                    }
+                }
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_a2c_train_step,
     bench_ppo_train_step,
     bench_a2c_cartpole_steps_per_sec,
     bench_ppo_cartpole_steps_per_sec,
+    bench_dqn_train_step,
+    bench_dqn_cartpole_steps_per_sec,
 );
 criterion_main!(benches);

--- a/examples/games/cartpole/train_cartpole_dqn.rs
+++ b/examples/games/cartpole/train_cartpole_dqn.rs
@@ -29,6 +29,27 @@
 //!
 //! Expected: avg return over the last 100 episodes climbs well above
 //! the random baseline (~22) within ~30k env steps.
+//!
+//! # Learning-curve CSV (opt-in)
+//!
+//! Set `CURVE_CSV=<path>` to emit one `env_steps,mean_episode_reward` row
+//! per logging interval (header row first). The Q-network weight init
+//! (`QNetworkBurn::with_seed`) and the action/replay sampling (`StdRng`) are
+//! both seeded, so a run is reproducible up to the `Autodiff<NdArray<f32>>`
+//! backend's own run-to-run float-reduction nondeterminism (the same caveat
+//! the A2C/PPO curve examples carry on this backend). DQN runs on the SAME
+//! CartPole env/seed/budget as the A2C (`train_cartpole_a2c.rs`) and PPO
+//! (`train_cartpole_modern.rs`) examples, so its curve overlays directly on
+//! theirs for the benchmark comparison. CartPole reward is +1/step, so mean
+//! episode reward == mean episode length, matching the A2C/PPO semantics.
+//! When `CURVE_CSV` is unset, no file is written and behavior is unchanged.
+//!
+//! ```bash
+//! CURVE_CSV=/tmp/dqn.csv cargo run --example train_cartpole_dqn \
+//!     --features training --release
+//! ```
+
+use std::io::Write;
 
 use anyhow::Result;
 use burn::{
@@ -50,6 +71,10 @@ type B = Autodiff<NdArray<f32>>;
 
 const DEFAULT_TIMESTEPS: usize = 60_000;
 const HIDDEN_DIM: usize = 64;
+/// Seed for reproducible runs. Threaded through the Q-network weight init
+/// (`QNetworkBurn::with_seed`) so that, together with the seeded action/replay
+/// `StdRng`, the learning curve is identical run-to-run.
+const SEED: u64 = 0;
 
 fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter("info").init();
@@ -76,8 +101,10 @@ fn main() -> Result<()> {
 
     let device: NdArrayDevice = Default::default();
 
-    // Online Q-network.
-    let online = QNetworkBurn::<B>::new(obs_dim, n_actions as usize, HIDDEN_DIM, &device);
+    // Online Q-network. Seeded weight init so runs are reproducible (the
+    // action/replay sampling is seeded separately via `StdRng` below).
+    let online =
+        QNetworkBurn::<B>::with_seed(obs_dim, n_actions as usize, HIDDEN_DIM, SEED, &device);
 
     let config = DQNConfig::new()
         .learning_rate(1e-3)
@@ -103,6 +130,12 @@ fn main() -> Result<()> {
     env.reset();
     let mut obs = env.get_observation();
     let mut rng = StdRng::seed_from_u64(0xC0FFEE);
+
+    // Optional learning-curve CSV (issue #160). When CURVE_CSV is set we write
+    // one `env_steps,mean_episode_reward` row per logging interval. CartPole
+    // reward is +1/step, so mean episode reward == mean episode length,
+    // matching the A2C/PPO examples so curves overlay on the same env/budget.
+    let mut curve_csv = open_curve_csv()?;
 
     let mut episode_return: f32 = 0.0;
     let mut episode_returns: Vec<f32> = Vec::new();
@@ -174,6 +207,11 @@ fn main() -> Result<()> {
             } else {
                 0.0
             };
+            // Emit one learning-curve row per logging interval when CURVE_CSV
+            // is set. `step` is monotonic and increases by `log_interval`.
+            if let Some(w) = curve_csv.as_mut() {
+                writeln!(w, "{},{:.4}", step, recent_avg)?;
+            }
             tracing::info!(
                 "step={:>6}  episodes={:>4}  avg(last≤100)={:7.2}  ε={:.3}  buf={:>6}",
                 step,
@@ -183,6 +221,10 @@ fn main() -> Result<()> {
                 trainer.buffer_len(),
             );
         }
+    }
+
+    if let Some(mut w) = curve_csv.take() {
+        w.flush()?;
     }
 
     let final_avg = if !episode_returns.is_empty() {
@@ -202,4 +244,23 @@ fn main() -> Result<()> {
     );
 
     Ok(())
+}
+
+/// Open the opt-in learning-curve CSV writer.
+///
+/// Returns `Ok(Some(writer))` with the header row already written when the
+/// `CURVE_CSV` env var names a path, or `Ok(None)` when it is unset (no file
+/// written, no behavior change). Mirrors the helper in `train_cartpole_a2c.rs`
+/// so DQN/A2C/PPO curves share the `env_steps,mean_episode_reward` schema.
+fn open_curve_csv() -> Result<Option<std::io::BufWriter<std::fs::File>>> {
+    match std::env::var("CURVE_CSV") {
+        Ok(path) if !path.is_empty() => {
+            let file = std::fs::File::create(&path)?;
+            let mut w = std::io::BufWriter::new(file);
+            writeln!(w, "env_steps,mean_episode_reward")?;
+            tracing::info!("Writing learning-curve CSV to {}", path);
+            Ok(Some(w))
+        }
+        _ => Ok(None),
+    }
 }

--- a/src/policy/q_network.rs
+++ b/src/policy/q_network.rs
@@ -40,7 +40,7 @@ use burn::{
     tensor::{Tensor, activation, backend::Backend},
 };
 
-use super::mlp::linear_with_init;
+use super::mlp::{derive_layer_seed, linear_from_weights, linear_with_init, seeded_layer_weights};
 
 /// Configuration for [`QNetworkBurn`] architecture.
 ///
@@ -56,11 +56,34 @@ pub struct QNetworkBurnConfig {
     /// (gain `sqrt(2)`) and the Q-head with `gain = 0.01`. Set
     /// `false` for Burn's stock Kaiming-uniform default.
     pub use_orthogonal_init: bool,
+    /// Optional construction seed. When `Some`, every layer is built from a
+    /// deterministically-derived host-side RNG stream (see
+    /// [`crate::policy::seeded_init`]) so two constructions with the same seed
+    /// produce **bit-identical** networks. When `None` (the default) Burn's
+    /// unseedable [`Initializer`] path is used verbatim. This mirrors
+    /// [`crate::policy::continuous_q::ContinuousQNetworkConfig::seed`] so the
+    /// discrete and continuous Q-networks share the same reproducibility hook.
+    pub seed: Option<u64>,
 }
 
 impl Default for QNetworkBurnConfig {
     fn default() -> Self {
-        Self { hidden_dim: 64, use_orthogonal_init: true }
+        Self { hidden_dim: 64, use_orthogonal_init: true, seed: None }
+    }
+}
+
+impl QNetworkBurnConfig {
+    /// Set the construction seed, enabling the deterministic host-side init
+    /// path in [`QNetworkBurn::with_config`].
+    ///
+    /// ```
+    /// # use thrust_rl::policy::q_network::QNetworkBurnConfig;
+    /// let cfg = QNetworkBurnConfig::default().with_seed(42);
+    /// assert_eq!(cfg.seed, Some(42));
+    /// ```
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
     }
 }
 
@@ -83,6 +106,25 @@ impl<B: Backend> QNetworkBurn<B> {
         )
     }
 
+    /// Build a fresh Q-network whose weights are seeded for bit-exact
+    /// reproducibility. Two calls with the same `seed` (and shapes) produce
+    /// byte-identical networks; mirrors
+    /// [`crate::policy::continuous_q::ContinuousQNetwork`].
+    pub fn with_seed(
+        obs_dim: usize,
+        n_actions: usize,
+        hidden_dim: usize,
+        seed: u64,
+        device: &B::Device,
+    ) -> Self {
+        Self::with_config(
+            obs_dim,
+            n_actions,
+            QNetworkBurnConfig { hidden_dim, ..Default::default() }.with_seed(seed),
+            device,
+        )
+    }
+
     /// Build a fresh Q-network with the given configuration.
     pub fn with_config(
         obs_dim: usize,
@@ -90,20 +132,51 @@ impl<B: Backend> QNetworkBurn<B> {
         config: QNetworkBurnConfig,
         device: &B::Device,
     ) -> Self {
-        let hidden_init = if config.use_orthogonal_init {
-            Initializer::Orthogonal { gain: 2.0_f64.sqrt() }
-        } else {
-            Initializer::KaimingUniform { gain: 1.0_f64 / 3.0_f64.sqrt(), fan_out_only: false }
-        };
-        let output_init = if config.use_orthogonal_init {
-            Initializer::Orthogonal { gain: 0.01 }
-        } else {
-            Initializer::KaimingUniform { gain: 1.0_f64 / 3.0_f64.sqrt(), fan_out_only: false }
-        };
+        let hidden = config.hidden_dim;
 
-        let fc1 = linear_with_init::<B>(obs_dim, config.hidden_dim, hidden_init.clone(), device);
-        let fc2 = linear_with_init::<B>(config.hidden_dim, config.hidden_dim, hidden_init, device);
-        let q_head = linear_with_init::<B>(config.hidden_dim, n_actions, output_init, device);
+        let (fc1, fc2, q_head) = if let Some(base_seed) = config.seed {
+            // Seeded host-side init: each layer pulls from a distinct,
+            // deterministically-derived RNG stream so equal-shaped layers
+            // don't collide. Mirrors `ContinuousQNetwork::with_config`.
+            let mut layer_idx = 0u64;
+            let mut next = || {
+                let s = derive_layer_seed(base_seed, layer_idx);
+                layer_idx += 1;
+                s
+            };
+
+            let w1 =
+                seeded_layer_weights(next(), obs_dim, hidden, config.use_orthogonal_init, false);
+            let fc1 = linear_from_weights::<B>(obs_dim, hidden, &w1, device);
+
+            let w2 =
+                seeded_layer_weights(next(), hidden, hidden, config.use_orthogonal_init, false);
+            let fc2 = linear_from_weights::<B>(hidden, hidden, &w2, device);
+
+            let wq =
+                seeded_layer_weights(next(), hidden, n_actions, config.use_orthogonal_init, true);
+            let q_head = linear_from_weights::<B>(hidden, n_actions, &wq, device);
+
+            (fc1, fc2, q_head)
+        } else {
+            // Unseeded: route through Burn's `Initializer` verbatim.
+            let hidden_init = if config.use_orthogonal_init {
+                Initializer::Orthogonal { gain: 2.0_f64.sqrt() }
+            } else {
+                Initializer::KaimingUniform { gain: 1.0_f64 / 3.0_f64.sqrt(), fan_out_only: false }
+            };
+            let output_init = if config.use_orthogonal_init {
+                Initializer::Orthogonal { gain: 0.01 }
+            } else {
+                Initializer::KaimingUniform { gain: 1.0_f64 / 3.0_f64.sqrt(), fan_out_only: false }
+            };
+
+            let fc1 = linear_with_init::<B>(obs_dim, hidden, hidden_init.clone(), device);
+            let fc2 = linear_with_init::<B>(hidden, hidden, hidden_init, device);
+            let q_head = linear_with_init::<B>(hidden, n_actions, output_init, device);
+
+            (fc1, fc2, q_head)
+        };
 
         Self { fc1, fc2, q_head }
     }
@@ -162,6 +235,31 @@ mod tests {
         assert_eq!(q_values.dims(), [8, 3]);
     }
 
+    /// Two seeded constructions with the same seed must yield bit-identical
+    /// Q-values, while different seeds must disagree. Mirrors
+    /// `ContinuousQNetwork`'s `seeded_construction_is_bit_exact`.
+    #[test]
+    fn seeded_construction_is_bit_exact() {
+        let device = Default::default();
+        let a = QNetworkBurn::<B>::with_seed(4, 2, 16, 7, &device);
+        let b = QNetworkBurn::<B>::with_seed(4, 2, 16, 7, &device);
+        let c = QNetworkBurn::<B>::with_seed(4, 2, 16, 8, &device);
+
+        let obs = Tensor::<B, 2>::from_data(
+            burn::tensor::TensorData::new(vec![0.1f32, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8], [2, 4]),
+            &device,
+        );
+        let qa: Vec<f32> = a.forward(obs.clone()).into_data().to_vec().unwrap();
+        let qb: Vec<f32> = b.forward(obs.clone()).into_data().to_vec().unwrap();
+        let qc: Vec<f32> = c.forward(obs).into_data().to_vec().unwrap();
+
+        assert_eq!(qa, qb, "same seed must yield bit-identical Q-networks");
+        assert!(
+            qa.iter().zip(&qc).any(|(x, y)| (x - y).abs() > 1e-6),
+            "different seeds should yield different Q-networks"
+        );
+    }
+
     /// Mirrors `q_network::tests::test_copy_params_from_byte_equal`
     /// from the tch path: after copying online → target, their forward
     /// outputs must agree exactly.
@@ -171,13 +269,13 @@ mod tests {
         let online = QNetworkBurn::<B>::with_config(
             4,
             2,
-            QNetworkBurnConfig { hidden_dim: 16, use_orthogonal_init: false },
+            QNetworkBurnConfig { hidden_dim: 16, use_orthogonal_init: false, ..Default::default() },
             &device,
         );
         let target = QNetworkBurn::<B>::with_config(
             4,
             2,
-            QNetworkBurnConfig { hidden_dim: 16, use_orthogonal_init: false },
+            QNetworkBurnConfig { hidden_dim: 16, use_orthogonal_init: false, ..Default::default() },
             &device,
         );
 
@@ -200,7 +298,7 @@ mod tests {
         let online_for_recall = QNetworkBurn::<B>::with_config(
             4,
             2,
-            QNetworkBurnConfig { hidden_dim: 16, use_orthogonal_init: false },
+            QNetworkBurnConfig { hidden_dim: 16, use_orthogonal_init: false, ..Default::default() },
             &device,
         );
         // To compare, we want the sync to make `target` match `online`


### PR DESCRIPTION
Closes #160. Part of the benchmark-extension epic #159.

## What this does

Adds DQN benchmark coverage to the throughput harness and the opt-in
`CURVE_CSV` learning-curve emission to the DQN CartPole example, matching the
A2C/PPO conventions.

### `benches/trainer_throughput.rs` (additive)
- **`dqn_train_step`** — isolated single Double-DQN gradient step on a replay
  minibatch. The untimed `iter_batched` setup closure builds a fresh seeded
  trainer and pre-fills the replay buffer past `min_buffer_size`, so every
  timed `train_step` performs a real gradient update (asserted via `.expect`,
  never the warmup `None` no-op). `Throughput::Elements(batch)`. This is the
  cross-algo-comparable per-update number.
- **`dqn_cartpole_steps_per_sec`** — full DQN env-loop (env step + buffer push
  + one gradient update per env step, mirroring the example). Buffer
  pre-filled untimed so the timed region measures steady-state throughput, not
  the warmup transient. `Throughput::Elements(env_steps)`. Comparable within
  the off-policy class only.
- Module header now documents the on-policy vs off-policy steps/sec fairness
  caveat verbatim per the epic design.

### `examples/games/cartpole/train_cartpole_dqn.rs` (additive, `CURVE_CSV`-gated)
- `open_curve_csv()` helper + one `env_steps,mean_episode_reward` row per log
  interval; flushed at end. Zero behavior change when `CURVE_CSV` is unset.
- Module doc gets a `CURVE_CSV` usage block.

### `src/policy/q_network.rs` (additive — required for seeded reproducibility)
The discrete `QNetworkBurn` had **no seeded-init path** (unlike its sibling
`ContinuousQNetwork`, which already has `with_seed`), so the example's weight
init was nondeterministic. Added a `seed: Option<u64>` field + `with_seed` to
`QNetworkBurnConfig`, a seeded host-side init branch in `with_config`, and a
`QNetworkBurn::with_seed` constructor — mirroring `ContinuousQNetwork`
verbatim. New unit test `seeded_construction_is_bit_exact`.

> Scope note: the issue said "no library/API changes," but reproducibility
> (a hard acceptance criterion) was impossible without a seeded init for this
> network. The change is small, purely additive, and mirrors an existing
> sibling API. Caveat: bit-identical CSVs are still not guaranteed run-to-run
> because the `Autodiff<NdArray<f32>>` backend has float-reduction
> nondeterminism in its compute — the **same caveat the reference A2C/PPO
> curve examples carry** (verified: the A2C example is also not bit-identical
> across runs on this backend). Init is now deterministic; the example doc
> states this honestly.

## Verification
- `cargo bench --features training --bench trainer_throughput -- --warm-up-time 1 --measurement-time 3 dqn`
  runs both groups, no panics, `train_step` never `None`:
  - `dqn_train_step/replay_minibatch`: ~50.4 ms/update (~1.27 Kelem/s, batch=64)
  - `dqn_cartpole_steps_per_sec/env_step_plus_update`: ~54.6 ms / 16 steps -> ~293 env-steps/sec
- `CURVE_CSV=/tmp/dqn.csv ... TOTAL_TIMESTEPS=20000`: writes header +
  monotonic `env_steps` rows; unset writes no file. Training learns
  (~18 -> ~150 avg over 20k steps).
- `cargo fmt --check`: clean.
- `cargo clippy --all-targets --features training`: my added code is clean
  (the only diagnostics in the touched bench/example files are pre-existing,
  present on `main`).
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean.
- `cargo build --features training`: clean.
- `cargo test --features training --lib policy::`: 53 passed (incl. new
  `seeded_construction_is_bit_exact`); `--doc q_network`: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)