### PR TITLE
Warning-free build + cargo publish dry-run CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,61 @@ jobs:
       - name: cargo doc --no-deps --all-features
         run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
 
+  # Publish dry-run gate. Validates that the crate actually packages and
+  # that no non-library assets (model checkpoints, the web app, the
+  # bucket-brigade submodule, tooling) leak into the tarball. This catches
+  # `exclude = [...]` regressions and path-dependency slips at PR time
+  # instead of at hand-publish time. CI-safe: `--dry-run` never uploads and
+  # needs no crates.io token.
+  #
+  # `bucket-brigade-core` is a path-only dependency behind the optional
+  # `env-bucket-brigade` feature. `cargo publish` rejects *any* path
+  # dependency (even an optional, unselected one), so this job applies the
+  # same Cargo.toml edits that docs/RELEASING.md Step 2.5 prescribes for a
+  # real publish: comment out the path dep + its feature and re-add the
+  # `unexpected_cfgs` lint shim. The runner is ephemeral, so these edits
+  # are throwaway (no revert needed). `--no-default-features` keeps the
+  # verification rebuild fast by skipping the Burn training stack.
+  publish_dry_run:
+    name: Publish dry-run + tarball audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Disable env-bucket-brigade for publish (RELEASING.md Step 2.5)
+        run: |
+          set -euo pipefail
+          sed -i \
+            's|^bucket-brigade-core = { path = "envs/bucket-brigade/bucket-brigade-core", default-features = false, optional = true }|# &|' \
+            Cargo.toml
+          sed -i \
+            's|^env-bucket-brigade = \["bucket-brigade-core"\]|# &|' \
+            Cargo.toml
+          # Re-add the unexpected_cfgs shim so the now-disabled feature's
+          # #[cfg(feature = "env-bucket-brigade")] gates don't warn. printf
+          # (not a YAML-indented heredoc) keeps the appended TOML flush-left.
+          printf '\n[lints.rust]\nunexpected_cfgs = { level = "warn", check-cfg = ['"'"'cfg(feature, values("env-bucket-brigade"))'"'"'] }\n' >> Cargo.toml
+          # Fail loudly if the expected lines were not found (manifest drift).
+          grep -q '^# bucket-brigade-core = { path' Cargo.toml
+          grep -q '^# env-bucket-brigade = ' Cargo.toml
+      - name: Assert tarball excludes non-library assets
+        run: |
+          set -euo pipefail
+          # --allow-dirty: we just edited Cargo.toml above (a real publish
+          # commits these edits first; here the runner is throwaway).
+          cargo package --list --no-default-features --allow-dirty > /tmp/pkg-files.txt
+          echo "Tarball contains $(wc -l < /tmp/pkg-files.txt) files:"
+          cat /tmp/pkg-files.txt
+          if grep -E '(^|/)models/|\.safetensors$|\.pt$|\.onnx$|(^|/)web/|(^|/)envs/|(^|/)scripts/|(^|/)\.loom/|(^|/)\.claude/|(^|/)\.github/' /tmp/pkg-files.txt; then
+            echo "::error::Publish tarball includes excluded non-library assets (see matches above). Fix the exclude = [...] list in Cargo.toml."
+            exit 1
+          fi
+          echo "Tarball content audit passed: no excluded assets present."
+      - name: cargo publish --dry-run (no-default-features)
+        run: cargo publish --dry-run --no-default-features --allow-dirty
+
   # Security audit
   security_audit:
     name: Security Audit

--- a/src/buffer/rollout/sampling.rs
+++ b/src/buffer/rollout/sampling.rs
@@ -133,7 +133,6 @@ impl Minibatch {
 /// Useful for training loops that process data incrementally.
 pub struct MinibatchIterator<'a> {
     buffer: &'a RolloutBuffer,
-    batch_size: usize,
     indices: Vec<Vec<usize>>,
     current_batch: usize,
 }
@@ -157,7 +156,7 @@ impl<'a> MinibatchIterator<'a> {
                 .collect()
         };
 
-        Self { buffer, batch_size, indices, current_batch: 0 }
+        Self { buffer, indices, current_batch: 0 }
     }
 }
 
@@ -208,7 +207,7 @@ pub fn train_val_split(buffer: &RolloutBuffer, train_ratio: f32) -> (Vec<usize>,
     let total_size = buffer.len();
     let train_size = ((total_size as f32) * train_ratio) as usize;
 
-    let mut indices: Vec<usize> = (0..total_size).collect();
+    let indices: Vec<usize> = (0..total_size).collect();
     // Note: In a real implementation, you'd want to shuffle here
     // but we'll keep it deterministic for reproducibility
 

--- a/src/env/games/cartpole.rs
+++ b/src/env/games/cartpole.rs
@@ -18,7 +18,6 @@
 //! Based on OpenAI Gym CartPole-v1:
 //! <https://github.com/openai/gym/blob/master/gym/envs/classic_control/cartpole.py>
 
-use anyhow::Result;
 use rand::Rng;
 
 use crate::env::{Environment, SpaceInfo, SpaceType, StepInfo, StepResult};

--- a/src/env/games/snake.rs
+++ b/src/env/games/snake.rs
@@ -11,14 +11,10 @@
 // #[cfg(feature = "training")]
 // use crate::multi_agent::environment::{MultiAgentEnvironment,
 // MultiAgentResult};
-use anyhow::Result;
 pub use environment::SnakeEnv;
-use rand::Rng;
 pub use snake::{Food, Snake};
 // Re-export main components
 pub use types::{Cell, Direction, GameState, Position};
-
-use crate::env::{Environment, SpaceInfo, SpaceType, StepInfo, StepResult};
 // TODO: Re-enable after fixing multi-agent code
 // #[cfg(feature = "training")]
 // pub use multi_agent::MultiAgentSnakeEnv;

--- a/src/env/games/snake/environment.rs
+++ b/src/env/games/snake/environment.rs
@@ -3,7 +3,6 @@
 //! This module implements the SnakeEnv struct and the Environment trait
 //! for both single-agent and multi-agent snake games.
 
-use anyhow::Result;
 use rand::Rng;
 
 use super::{

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -60,8 +60,6 @@
 //! reproduction is deterministic only across steps that do not draw
 //! from the RNG. Per-env docs spell out the exact guarantee.
 
-use anyhow::Result;
-
 /// Core trait for RL environments
 pub trait Environment {
     /// Action type accepted by [`Environment::step`].

--- a/src/policy/inference.rs
+++ b/src/policy/inference.rs
@@ -6,8 +6,6 @@
 //! on Burn; weights are exported as JSON and consumed here for browser
 //! inference. See `crate::inference` module docs and `WASM_ROADMAP.md`.
 
-use std::collections::HashMap;
-
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
@@ -390,7 +388,7 @@ impl InferenceModel {
 
         // Value head: hidden_dim -> 1
         let mut value = 0.0;
-        for (i, row) in self.value_weight.iter().enumerate() {
+        for row in self.value_weight.iter() {
             for (j, &val) in hidden2.iter().enumerate() {
                 value += row[j] * val;
             }


### PR DESCRIPTION
Closes #189 (part of crates.io-polish epic #186).

## Summary

Two polish gaps before a clean crates.io publish:

1. **Warning-free build** — removed the ten trivial warnings emitted by `cargo build --features training`. Cleanup-only; no library behavior change.
2. **Publish dry-run CI gate** — new `publish_dry_run` job that packages the crate and audits the tarball, catching `exclude` regressions and path-dependency slips at PR time instead of hand-publish time.

## Warning cleanup (10 → 0)

| Site | Fix |
| --- | --- |
| `src/env/mod.rs:63` | drop unused `anyhow::Result` import |
| `src/env/games/cartpole.rs:21` | drop unused `anyhow::Result` import (`rand::Rng` is kept — `random_range` needs it) |
| `src/env/games/snake.rs:14,16,21` | drop unused `anyhow::Result`, `rand::Rng`, and the unused `crate::env::{Environment, SpaceInfo, SpaceType, StepInfo, StepResult}` glob |
| `src/env/games/snake/environment.rs:6` | drop unused `anyhow::Result` |
| `src/policy/inference.rs:9` | drop unused `std::collections::HashMap` import (line 272 uses the fully-qualified path) |
| `src/policy/inference.rs:393` | drop unused `i` binding — `.iter().enumerate()` → `.iter()` |
| `src/buffer/rollout/sampling.rs:211` | drop needless `mut` in `train_val_split` |
| `src/buffer/rollout/sampling.rs:136` | remove never-read `batch_size` field from `MinibatchIterator` (vestigial; the constructor still consumes the param to build the index chunks) |

`touch src/lib.rs && cargo build --features training 2>&1 | grep -c warning` → **0**.

## CI gate

New `publish_dry_run` job in `.github/workflows/ci.yml`:
- Mirrors `docs/RELEASING.md` Step 2.5: comments out the path-only `bucket-brigade-core` dep + `env-bucket-brigade` feature and re-adds the `unexpected_cfgs` lint shim, so `cargo publish --dry-run` succeeds (cargo rejects *any* path dependency at publish, even an optional/unselected one). The runner is ephemeral, so the throwaway Cargo.toml edits need no revert; the source `Cargo.toml` is unchanged on disk.
- Asserts the tarball excludes `models/**`, `*.safetensors`/`*.pt`/`*.onnx`, `web/**`, `envs/**`, `scripts/**`, `.loom/**`, `.claude/**`, `.github/**`.
- Runs `cargo publish --dry-run --no-default-features` (skips the heavy Burn rebuild). CI-safe: `--dry-run` never uploads and needs no crates.io token.

## Verification (local)

- `cargo build --features training`: **0 warnings** (forced clean rebuild).
- `cargo publish --dry-run --no-default-features` with the Step-2.5 transform: **succeeds** (packaged 145 files, ~1.7 MiB / 443 KiB compressed).
- Tarball audit: **no excluded assets present**.
- `cargo fmt -- --check`: clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features training`: clean. (`--all-features` not run locally — pulls in the wgpu/cuda backends and exceeded local disk; the existing `docs` CI job covers that path on a clean runner.)
- `cargo test --features training --lib`: **359 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)