### PR TITLE
Register wgpu/cuda benchmark variants + GPU docs (closes #183)

### DIFF
--- a/benches/trainer_throughput.rs
+++ b/benches/trainer_throughput.rs
@@ -21,11 +21,22 @@
 //! register_all::<Cpu>(c, &default_burn_device::<Cpu>(), "ndarray");
 //! ```
 //!
-//! This is the only place a concrete `NdArray` backend appears. The default
-//! `cargo bench --features training` path therefore always emits the same eight
-//! logical groups as before, now suffixed `/ndarray`. A later PR can add
-//! cfg-gated `register_all::<Gpu>(..)` calls (wgpu/cuda) at this seam without
-//! touching any bench body; this PR adds no GPU code.
+//! The CPU `NdArray` baseline is always registered. GPU backends are added at
+//! the same seam behind Cargo-feature gates, reusing the exact same generic
+//! bench bodies with no logic duplication:
+//!
+//! ```text
+//! #[cfg(feature = "wgpu")]
+//! { type Gpu = Autodiff<Wgpu<f32, i32>>;
+//!   register_all::<Gpu>(c, &default_burn_device::<Gpu>(), "wgpu"); }
+//! ```
+//!
+//! Because CI is CPU-host only and never sets `wgpu`/`cuda`, the default
+//! `cargo bench --features training` path always emits exactly the same eight
+//! logical groups as before, now suffixed `/ndarray`, and never compiles or
+//! constructs a GPU backend. The GPU registration code only compiles when the
+//! corresponding feature is enabled — see the "Throughput benchmarking on GPU
+//! backends" section of `docs/BURN_BACKENDS.md`.
 //!
 //! All benchmarks are seeded so the numbers are comparable run-to-run.
 //!
@@ -96,6 +107,13 @@
 
 use std::hint::black_box;
 
+// GPU backend types are pulled in only when the corresponding feature is
+// enabled, so the default CPU build never references (or compiles) them. CI is
+// CPU-host only and never sets `wgpu`/`cuda` — see the driver `benches()`.
+#[cfg(feature = "cuda")]
+use burn::backend::Cuda;
+#[cfg(feature = "wgpu")]
+use burn::backend::Wgpu;
 use burn::{
     backend::{Autodiff, NdArray},
     optim::AdamConfig,
@@ -806,13 +824,38 @@ fn register_all<B: AutodiffBackend>(c: &mut Criterion, device: &B::Device, suffi
     bench_sac_pendulum_steps_per_sec::<B>(c, device, suffix);
 }
 
-/// Criterion driver. Registers the CPU baseline unconditionally; this is the
-/// only place a concrete backend type appears. GPU backends (wgpu/cuda) are
-/// added at this seam in a later PR behind cfg gates and are NOT referenced
-/// here — the default `cargo bench --features training` path is CPU-only.
+/// Criterion driver. Registers the CPU `ndarray` baseline unconditionally, then
+/// registers the GPU backends behind Cargo-feature gates.
+///
+/// The CPU baseline is always present, so a single run produces the paired
+/// CPU-vs-GPU comparison (e.g. `a2c_train_step/ndarray` alongside
+/// `a2c_train_step/wgpu`). CI is CPU-host only and never sets `wgpu`/`cuda`, so
+/// the default `cargo bench --features training` path compiles and runs only
+/// the `ndarray` registration — the GPU branches below are not compiled.
+///
+/// No runtime adapter detection is performed: criterion has no skip primitive,
+/// and a host without a GPU would never enable the feature in the first place.
+/// If a GPU feature is compiled where no adapter exists, Burn panics on first
+/// device use — acceptable because the feature is opt-in and only compiled on
+/// operator GPU hosts (the actual GPU run is operator-gated, see #184).
 fn benches(c: &mut Criterion) {
     type Cpu = Autodiff<NdArray<f32>>;
     register_all::<Cpu>(c, &default_burn_device::<Cpu>(), "ndarray");
+
+    #[cfg(feature = "wgpu")]
+    {
+        // Cross-platform GPU (Vulkan / Metal / DX12 / WebGPU). Mirrors the
+        // `Wgpu<f32, i32>` InnerBackend alias used in examples/games/**.
+        type Gpu = Autodiff<Wgpu<f32, i32>>;
+        register_all::<Gpu>(c, &default_burn_device::<Gpu>(), "wgpu");
+    }
+
+    #[cfg(feature = "cuda")]
+    {
+        // Linux + NVIDIA. `Cuda` defaults to `<f32, i32>` element/index types.
+        type Gpu = Autodiff<Cuda<f32, i32>>;
+        register_all::<Gpu>(c, &default_burn_device::<Gpu>(), "cuda");
+    }
 }
 
 criterion_group!(benches_group, benches);

--- a/docs/BURN_BACKENDS.md
+++ b/docs/BURN_BACKENDS.md
@@ -141,6 +141,85 @@ also inflates the wall-clock numbers above. Real wins on wgpu show up
 for larger nets, bigger batches, or convolution-heavy workloads
 (Snake CNN, image envs) — see issue #65 follow-ups.
 
+## Throughput benchmarking on GPU backends
+
+The `trainer_throughput` criterion harness (`benches/trainer_throughput.rs`) is
+generic over the Burn backend, so the exact same bench bodies run on CPU and
+GPU. The CPU `ndarray` baseline is **always** registered; the wgpu and cuda
+variants are added behind Cargo-feature gates. A single run therefore produces a
+paired CPU-vs-GPU comparison.
+
+### Running
+
+```bash
+# CPU only (default — what CI runs). Emits the `/ndarray` groups.
+cargo bench --features training --bench trainer_throughput
+
+# wgpu (cross-platform GPU: Vulkan/Metal/DX12/WebGPU).
+# Emits BOTH the `/ndarray` baseline AND the `/wgpu` groups in one run.
+cargo bench --features "training,wgpu" --bench trainer_throughput
+
+# cuda (Linux + NVIDIA + CUDA toolkit).
+# Emits BOTH the `/ndarray` baseline AND the `/cuda` groups in one run.
+cargo bench --features "training,cuda" --bench trainer_throughput
+```
+
+A quick smoke run (short warm-up / measurement windows) is:
+
+```bash
+cargo bench --features "training,wgpu" --bench trainer_throughput -- \
+    --warm-up-time 1 --measurement-time 3
+```
+
+### Reading the results
+
+Every benchmark group is suffixed with its backend tag, so the eight logical
+groups appear once per compiled backend, side by side:
+
+| Logical group | CPU group id | wgpu group id | cuda group id |
+| --- | --- | --- | --- |
+| A2C per-update | `a2c_train_step/ndarray` | `a2c_train_step/wgpu` | `a2c_train_step/cuda` |
+| PPO per-update | `ppo_train_step/ndarray` | `ppo_train_step/wgpu` | `ppo_train_step/cuda` |
+| DQN per-update | `dqn_train_step/ndarray` | `dqn_train_step/wgpu` | `dqn_train_step/cuda` |
+| SAC per-update | `sac_train_step/ndarray` | `sac_train_step/wgpu` | `sac_train_step/cuda` |
+| A2C full loop | `a2c_cartpole_steps_per_sec/ndarray` | …`/wgpu` | …`/cuda` |
+| PPO full loop | `ppo_cartpole_steps_per_sec/ndarray` | …`/wgpu` | …`/cuda` |
+| DQN full loop | `dqn_cartpole_steps_per_sec/ndarray` | …`/wgpu` | …`/cuda` |
+| SAC full loop | `sac_pendulum_steps_per_sec/ndarray` | …`/wgpu` | …`/cuda` |
+
+To compare a backend against the CPU baseline, read the matching `/ndarray` and
+`/wgpu` (or `/cuda`) groups from the same run. (The same fairness caveats as the
+CPU benches apply: `*_train_step` groups are cross-algorithm comparable;
+`*_steps_per_sec` groups are comparable only within an algorithm class, and the
+SAC Pendulum loop is not comparable across environments — see the module header
+of `benches/trainer_throughput.rs`.)
+
+### Caveats
+
+- **GPU toolchain required to compile.** The GPU registration code only compiles
+  when its feature is on. `wgpu` uses Metal on macOS and generally builds on a
+  developer laptop; `cuda` requires Linux + an NVIDIA GPU + the CUDA toolkit and
+  will not build elsewhere. CI is CPU-host only and never sets these features, so
+  the default `cargo bench --features training` path is unaffected.
+- **No graceful skip.** Criterion has no skip primitive, and there is no runtime
+  adapter probe. If a GPU feature is compiled on a host with no adapter, Burn
+  panics on first device use. This is acceptable because the feature is opt-in
+  and only enabled on GPU hosts.
+- **Small nets favour the CPU.** As with the validation runs above, autotune and
+  kernel-launch overhead dominate per-op latency on the small (4-input,
+  64-unit) MLPs these benches use, so wgpu/Metal can look slower than the
+  SIMD-friendly NdArray path. See the [Performance note](#performance-note)
+  above — real GPU wins show up for larger nets, bigger batches, or
+  convolution-heavy workloads. Treat these benches as a relative harness, not an
+  absolute GPU endorsement.
+
+### Committing the numbers
+
+Capturing and committing the actual CPU-vs-GPU throughput table requires running
+the harness on operator GPU hardware, which is **operator-gated** and tracked
+separately (issue #184). This document intentionally ships only the run
+instructions; the measured numbers land via that issue.
+
 ## Why Burn instead of libtorch?
 
 The pre-v0.1.0 trainer stack used `tch` (Rust bindings to libtorch).


### PR DESCRIPTION
Closes #183. PR B of the GPU-benchmark epic #179 (depends on #181, merged).

## What this does

Adds cfg-gated GPU backend registration to the throughput harness and documents the GPU bench workflow. No trainer/bench logic is duplicated — the GPU paths reuse the exact same generic bench bodies introduced in #181.

### `benches/trainer_throughput.rs`
- In the `benches()` driver, after the unconditional CPU `ndarray` baseline:
  - `#[cfg(feature = "wgpu")]` → `register_all::<Autodiff<Wgpu<f32, i32>>>(c, &default_burn_device::<…>(), "wgpu")`
  - `#[cfg(feature = "cuda")]` → `register_all::<Autodiff<Cuda<f32, i32>>>(c, &default_burn_device::<…>(), "cuda")`
- `Wgpu` / `Cuda` imports are gated behind the same features so the default CPU build never references them.
- Module header updated to document the GPU seam. Type aliases mirror `examples/games/cartpole/train_cartpole_a2c.rs` (`Wgpu<f32, i32>`).

### `docs/BURN_BACKENDS.md`
- New "Throughput benchmarking on GPU backends" section: exact `cargo bench --features "training,wgpu"` / `"training,cuda"` commands, a table mapping each logical group to its `/ndarray` `/wgpu` `/cuda` group id, how to read the paired CPU-vs-GPU comparison, the small-net caveat (cross-linked to the existing Performance note), the no-graceful-skip design note, and a pointer to the operator-gated numbers issue (#184).

## CI safety

CI is CPU-host only and never sets `wgpu`/`cuda`, so the default `cargo bench --features training` path is unchanged — the GPU branches are not compiled. Verified the CPU run emits all 8 groups, all `/ndarray`-suffixed, with no `/wgpu` or `/cuda`.

## Verification (this macOS host)

- `cargo fmt -- --check`: clean.
- `cargo bench --features training --bench trainer_throughput -- --warm-up-time 1 --measurement-time 3`: all 8 groups run, `/ndarray` only. CPU path unaffected.
- `cargo check --benches --features "training,wgpu"`: **compiles** (Metal). The cfg-gated wgpu registration is validated.
- `cuda`: cfg-correct but not compilable here (no NVIDIA toolkit); the actual GPU run is operator-gated (#184).
- `cargo clippy --bench trainer_throughput --features training`: no warnings attributable to the bench file. (Full-workspace `-D warnings` fails only on pre-existing lib lints in `src/inference/mod.rs` etc., present on clean main and unrelated to this PR.)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features training`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)