### PR TITLE
feat: add DQN GridWorld example + seeded convergence test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,16 @@ name = "train_cartpole_dqn"
 path = "examples/games/cartpole/train_cartpole_dqn.rs"
 required-features = ["training"]
 
+# DQN on GridWorld (issue #185, PR B of the more-environments epic #180).
+# Seeded Double-DQN on the 4x4 FrozenLake-style GridWorld env (16-dim one-hot
+# obs, 4 discrete actions). Emits an opt-in learning-curve CSV via CURVE_CSV,
+# mirroring train_cartpole_dqn. Runnable counterpart of
+# tests/test_dqn_grid_world.rs.
+[[example]]
+name = "train_dqn_grid_world"
+path = "examples/games/grid_world/train_dqn_grid_world.rs"
+required-features = ["training"]
+
 # A2C CartPole trainer (issue #153, PR C of the A2C epic #150). Same
 # EnvPool rollout + GAE pattern as train_cartpole_modern but with the
 # single-update-per-rollout A2cTrainer. Emits an opt-in learning-curve

--- a/examples/games/grid_world/train_dqn_grid_world.rs
+++ b/examples/games/grid_world/train_dqn_grid_world.rs
@@ -1,0 +1,287 @@
+//! GridWorld DQN training on the Burn backend.
+//!
+//! End-to-end Double-DQN trainer for the sparse-reward
+//! [`GridWorld`](thrust_rl::env::games::grid_world::GridWorld) navigation env
+//! (issue #185, PR B of the more-environments epic #180), using the
+//! [`QNetworkBurn`](thrust_rl::policy::q_network::QNetworkBurn) +
+//! [`DQNTrainerBurn`](thrust_rl::train::dqn::DQNTrainerBurn) stack on
+//! `Autodiff<NdArray<f32>>` (CPU). Modeled on `train_cartpole_dqn.rs`.
+//!
+//! # Environment
+//!
+//! `GridWorld` is a `4x4` FrozenLake-style grid (default layout, no slip):
+//!
+//! ```text
+//! S F F F
+//! F H F H
+//! F F F H
+//! H F F G
+//! ```
+//!
+//! - **Observation:** 16-dim one-hot over cells (tabular-like, DQN handles this
+//!   well). `obs_dim = 16`.
+//! - **Actions:** 4 discrete moves (`0=Up`, `1=Right`, `2=Down`, `3=Left`).
+//!   `n_actions = 4`.
+//! - **Reward:** `+1.0` at the goal (terminates), `-1.0` in a hole
+//!   (terminates), `-0.01` per non-terminal step, truncation at 100 steps.
+//!
+//! Because the goal reward dominates, the highest-return policy is the
+//! shortest path to the goal: a return of `+1 - 0.01 * path_len`, i.e. just
+//! under `+1`. A random policy mostly falls into holes (negative return) or
+//! times out (`-0.01 * 100 = -1.0`), so the learning signal is the mean
+//! episode return climbing from a negative floor toward near-`+1`.
+//!
+//! # Configuration
+//!
+//! - 2-layer Tanh Q-network, 64 hidden units, orthogonal init.
+//! - Replay buffer capacity 50k, min buffer 1k.
+//! - ε linearly annealed `1.0 → 0.10` over 20k env steps.
+//! - γ = 0.95 (short-horizon credit assignment for the shortest path).
+//! - Polyak soft target updates with τ = 0.005.
+//! - Default total budget: 80k env steps (matches the convergence test; the
+//!   greedy policy converges to the optimal 6-step path, return ≈ +0.94).
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example train_dqn_grid_world --features training --release
+//! ```
+//!
+//! Override the total step budget via the `TOTAL_TIMESTEPS` env var:
+//!
+//! ```bash
+//! TOTAL_TIMESTEPS=20000 cargo run --example train_dqn_grid_world \
+//!     --features training --release
+//! ```
+//!
+//! Expected: the avg return over the last 100 episodes climbs from the
+//! negative/timeout floor toward the near-`+1` optimal-path return within
+//! the budget.
+//!
+//! # Learning-curve CSV (opt-in)
+//!
+//! Set `CURVE_CSV=<path>` to emit one `env_steps,mean_episode_reward` row
+//! per logging interval (header row first), using the same `open_curve_csv()`
+//! convention as the CartPole DQN/A2C examples. The Q-network weight init
+//! (`QNetworkBurn::with_seed`) and the action/replay sampling (`StdRng`) are
+//! both seeded, so a run is reproducible up to the `Autodiff<NdArray<f32>>`
+//! backend's own run-to-run float-reduction nondeterminism. When `CURVE_CSV`
+//! is unset, no file is written and behavior is unchanged.
+//!
+//! ```bash
+//! CURVE_CSV=/tmp/dqn_grid_world.csv cargo run --example train_dqn_grid_world \
+//!     --features training --release
+//! ```
+
+use std::io::Write;
+
+use anyhow::Result;
+use burn::{
+    backend::{Autodiff, NdArray, ndarray::NdArrayDevice},
+    optim::AdamConfig,
+    tensor::{Tensor, TensorData},
+};
+use rand::{SeedableRng, rngs::StdRng};
+use thrust_rl::{
+    env::{Environment, games::grid_world::GridWorld},
+    policy::q_network::QNetworkBurn,
+    train::{
+        dqn::{DQNConfig, DQNTrainerBurn},
+        optimizer::BurnOptimizer,
+    },
+};
+
+type B = Autodiff<NdArray<f32>>;
+
+const DEFAULT_TIMESTEPS: usize = 80_000;
+const HIDDEN_DIM: usize = 64;
+/// Seed for reproducible runs. Threaded through the Q-network weight init
+/// (`QNetworkBurn::with_seed`) so that, together with the seeded action/replay
+/// `StdRng`, the learning curve is identical run-to-run (up to backend
+/// float-reduction nondeterminism).
+const SEED: u64 = 0;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt().with_env_filter("info").init();
+
+    let total_timesteps: usize = std::env::var("TOTAL_TIMESTEPS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_TIMESTEPS);
+
+    tracing::info!("Starting GridWorld DQN Training (Burn backend)");
+
+    let probe = GridWorld::new();
+    let obs_dim = probe.observation_space().shape[0];
+    let n_actions = match probe.action_space().space_type {
+        thrust_rl::env::SpaceType::Discrete(n) => n as i64,
+        _ => panic!("Expected discrete action space"),
+    };
+    drop(probe);
+
+    tracing::info!("Environment: GridWorld 4x4 (FrozenLake-style, no slip)");
+    tracing::info!("  obs_dim    = {}", obs_dim);
+    tracing::info!("  n_actions  = {}", n_actions);
+    tracing::info!("  total_timesteps = {}", total_timesteps);
+
+    let device: NdArrayDevice = Default::default();
+
+    // Online Q-network. Seeded weight init so runs are reproducible (the
+    // action/replay sampling is seeded separately via `StdRng` below).
+    let online =
+        QNetworkBurn::<B>::with_seed(obs_dim, n_actions as usize, HIDDEN_DIM, SEED, &device);
+
+    let config = DQNConfig::new()
+        .learning_rate(5e-4)
+        .batch_size(128)
+        .buffer_capacity(50_000)
+        .min_buffer_size(1_000)
+        .target_update_interval(500)
+        .gamma(0.95)
+        .epsilon_start(1.0)
+        .epsilon_end(0.10)
+        .epsilon_decay_steps(20_000)
+        .max_grad_norm(10.0)
+        .soft_update_tau(0.005);
+
+    let inner_opt = AdamConfig::new().init();
+    let burn_opt: BurnOptimizer<B, QNetworkBurn<B>, _> =
+        BurnOptimizer::new(inner_opt, config.learning_rate);
+
+    let mut trainer =
+        DQNTrainerBurn::new(config, online, burn_opt, obs_dim, n_actions, device.clone())?;
+
+    let mut env = GridWorld::new();
+    env.reset();
+    let mut obs = env.get_observation();
+    let mut rng = StdRng::seed_from_u64(0xC0FFEE);
+
+    // Optional learning-curve CSV (issue #160 convention). When CURVE_CSV is
+    // set we write one `env_steps,mean_episode_reward` row per logging
+    // interval; the mean episode return climbs from the negative/timeout floor
+    // toward the near-+1 optimal-path return as the policy learns.
+    let mut curve_csv = open_curve_csv()?;
+
+    let mut episode_return: f32 = 0.0;
+    let mut episode_returns: Vec<f32> = Vec::new();
+    let mut last_log_step = 0_usize;
+    let log_interval = 1_000_usize;
+
+    while trainer.total_env_steps() < total_timesteps {
+        // ε-greedy action selection.
+        let action = {
+            let device_local = device.clone();
+            trainer.select_action(&obs, &mut rng, |q: &QNetworkBurn<B>, o_host: &[f32]| {
+                let o_t: Tensor<B, 2> = Tensor::from_data(
+                    TensorData::new(o_host.to_vec(), [1, o_host.len()]),
+                    &device_local,
+                );
+                let q_values = q.forward(o_t);
+                // Argmax over actions.
+                let q_host: Vec<f32> = q_values.into_data().to_vec().unwrap_or_default();
+                let mut best = 0_i64;
+                let mut best_v = f32::NEG_INFINITY;
+                for (i, &v) in q_host.iter().enumerate() {
+                    if v > best_v {
+                        best_v = v;
+                        best = i as i64;
+                    }
+                }
+                best
+            })
+        };
+
+        let result = env.step(action);
+        let next_obs = result.observation.clone();
+        let done = result.terminated || result.truncated;
+        trainer.buffer_mut().push(&obs, action, result.reward, &next_obs, done);
+
+        episode_return += result.reward;
+        obs = next_obs;
+
+        trainer.increment_env_step();
+        let _ = trainer.maybe_sync_target(|online, _target, _tau| online.clone());
+
+        if done {
+            episode_returns.push(episode_return);
+            trainer.increment_episodes(1);
+            episode_return = 0.0;
+            env.reset();
+            obs = env.get_observation();
+        }
+
+        // One gradient update per env step.
+        let _ = trainer.train_step(
+            &mut rng,
+            |q: &QNetworkBurn<B>, o: Tensor<B, 2>| q.forward(o),
+            |q: &QNetworkBurn<B>, o: Tensor<B, 2>| q.forward(o),
+        )?;
+
+        // Periodic logging.
+        let step = trainer.total_env_steps();
+        if step.saturating_sub(last_log_step) >= log_interval {
+            last_log_step = step;
+            let recent_avg = if !episode_returns.is_empty() {
+                let n = episode_returns.len();
+                let slice = &episode_returns[n.saturating_sub(100)..];
+                slice.iter().copied().sum::<f32>() / slice.len() as f32
+            } else {
+                0.0
+            };
+            // Emit one learning-curve row per logging interval when CURVE_CSV
+            // is set. `step` is monotonic and increases by ~`log_interval`.
+            if let Some(w) = curve_csv.as_mut() {
+                writeln!(w, "{},{:.4}", step, recent_avg)?;
+            }
+            tracing::info!(
+                "step={:>6}  episodes={:>4}  avg(last≤100)={:7.3}  ε={:.3}  buf={:>6}",
+                step,
+                trainer.total_episodes(),
+                recent_avg,
+                trainer.last_epsilon(),
+                trainer.buffer_len(),
+            );
+        }
+    }
+
+    if let Some(mut w) = curve_csv.take() {
+        w.flush()?;
+    }
+
+    let final_avg = if !episode_returns.is_empty() {
+        let n = episode_returns.len();
+        let slice = &episode_returns[n.saturating_sub(100)..];
+        slice.iter().copied().sum::<f32>() / slice.len() as f32
+    } else {
+        0.0
+    };
+    tracing::info!("------------------------------------------------------------");
+    tracing::info!(
+        "Training complete.  episodes={}  env_steps={}  train_steps={}  avg(last≤100)={:.3}",
+        trainer.total_episodes(),
+        trainer.total_env_steps(),
+        trainer.total_train_steps(),
+        final_avg,
+    );
+
+    Ok(())
+}
+
+/// Open the opt-in learning-curve CSV writer.
+///
+/// Returns `Ok(Some(writer))` with the header row already written when the
+/// `CURVE_CSV` env var names a path, or `Ok(None)` when it is unset (no file
+/// written, no behavior change). Mirrors the helper in `train_cartpole_dqn.rs`
+/// so the curve shares the `env_steps,mean_episode_reward` schema.
+fn open_curve_csv() -> Result<Option<std::io::BufWriter<std::fs::File>>> {
+    match std::env::var("CURVE_CSV") {
+        Ok(path) if !path.is_empty() => {
+            let file = std::fs::File::create(&path)?;
+            let mut w = std::io::BufWriter::new(file);
+            writeln!(w, "env_steps,mean_episode_reward")?;
+            tracing::info!("Writing learning-curve CSV to {}", path);
+            Ok(Some(w))
+        }
+        _ => Ok(None),
+    }
+}

--- a/tests/test_dqn_grid_world.rs
+++ b/tests/test_dqn_grid_world.rs
@@ -1,0 +1,283 @@
+//! DQN smoke + convergence tests on the
+//! [`GridWorld`](thrust_rl::env::games::grid_world::GridWorld) sparse-reward
+//! navigation env.
+//!
+//! This is PR B of the more-environments epic (#180, issue #185), the
+//! discrete-navigation counterpart to the existing DQN CartPole stack. Two
+//! tiers, mirroring `tests/test_a2c_cartpole.rs` /
+//! `tests/test_sac_mountain_car.rs`:
+//!
+//! 1. **`dqn_grid_world_training_step_runs`** (always runs) — a fast,
+//!    unit-level check that the DQN env loop wires together end-to-end on
+//!    GridWorld: a few hundred real env steps push transitions, at least one
+//!    gradient update fires, and every reported loss / Q stat / ε is finite.
+//!    This is the CI default — it executes in well under a second and never
+//!    asserts a convergence bar.
+//!
+//! 2. **`dqn_grid_world_reaches_reward_bar`** (`#[ignore]`) — the convergence
+//!    bar: seeded DQN solves the default `4x4` layout, reaching **mean eval
+//!    return >= +0.90 over the final 20 greedy evaluation episodes** within a
+//!    fixed env-step budget. The optimal shortest path earns `+1 - 0.01 *
+//!    path_len` (≈ `+0.94` for the 6-step Manhattan path), so `+0.90` cleanly
+//!    separates "found a reliable path to the goal" from "wandered / fell in
+//!    holes / timed out" (negative floor: a hole is `-1.0`, a timeout is `-0.01
+//!    * 100 = -1.0`, and a random policy on this deceptive layout averages well
+//!    below zero).
+//!
+//! ## Why the heavy bar is `#[ignore]`d
+//!
+//! The convergence run trains for 80k env steps with one gradient update per
+//! step on the CPU `NdArray` backend (~35 s wall-clock in `--release`,
+//! measured) — too slow to gate every `cargo test` run. It is kept opt-in:
+//!
+//! ```text
+//! cargo test --release --features training --test test_dqn_grid_world -- --ignored
+//! ```
+//!
+//! The fast step test above guarantees the trainer keeps working on every CI
+//! run; the convergence test is the periodic / release-gate check.
+
+#![cfg(feature = "training")]
+
+use burn::{
+    backend::{Autodiff, NdArray, ndarray::NdArrayDevice},
+    optim::AdamConfig,
+    tensor::{Tensor, TensorData},
+};
+use rand::{SeedableRng, rngs::StdRng};
+use thrust_rl::{
+    env::{Environment, SpaceType, games::grid_world::GridWorld},
+    policy::q_network::QNetworkBurn,
+    train::{
+        dqn::{DQNConfig, DQNTrainerBurn},
+        optimizer::BurnOptimizer,
+    },
+};
+
+type B = Autodiff<NdArray<f32>>;
+
+const HIDDEN_DIM: usize = 64;
+
+/// Greedy argmax over the Q-network's action values for a single observation.
+fn greedy_action(q: &QNetworkBurn<B>, obs: &[f32], device: &NdArrayDevice) -> i64 {
+    let o_t: Tensor<B, 2> =
+        Tensor::from_data(TensorData::new(obs.to_vec(), [1, obs.len()]), device);
+    let q_host: Vec<f32> = q.forward(o_t).into_data().to_vec().unwrap_or_default();
+    let mut best = 0_i64;
+    let mut best_v = f32::NEG_INFINITY;
+    for (i, &v) in q_host.iter().enumerate() {
+        if v > best_v {
+            best_v = v;
+            best = i as i64;
+        }
+    }
+    best
+}
+
+/// Build a seeded DQN trainer for GridWorld.
+#[allow(clippy::type_complexity)]
+fn build(
+    config: DQNConfig,
+    seed: u64,
+) -> (
+    DQNTrainerBurn<B, QNetworkBurn<B>, impl burn::optim::Optimizer<QNetworkBurn<B>, B>>,
+    NdArrayDevice,
+    usize,
+) {
+    let device: NdArrayDevice = Default::default();
+
+    let probe = GridWorld::new();
+    let obs_dim = probe.observation_space().shape[0];
+    let n_actions = match probe.action_space().space_type {
+        SpaceType::Discrete(n) => n as i64,
+        _ => panic!("expected discrete action space"),
+    };
+    drop(probe);
+
+    let lr = config.learning_rate;
+    let online =
+        QNetworkBurn::<B>::with_seed(obs_dim, n_actions as usize, HIDDEN_DIM, seed, &device);
+    let inner_opt = AdamConfig::new().init();
+    let burn_opt: BurnOptimizer<B, QNetworkBurn<B>, _> = BurnOptimizer::new(inner_opt, lr);
+
+    let trainer = DQNTrainerBurn::new(config, online, burn_opt, obs_dim, n_actions, device.clone())
+        .expect("trainer constructs");
+    (trainer, device, obs_dim)
+}
+
+/// Fast, always-on smoke test: drive a few hundred real GridWorld steps
+/// through the DQN trainer and assert a finite gradient step occurs. Keeps the
+/// trainer wired up on every CI run without a convergence bar.
+#[test]
+fn dqn_grid_world_training_step_runs() {
+    let config = DQNConfig::new()
+        .learning_rate(1e-3)
+        .batch_size(32)
+        .buffer_capacity(2_000)
+        .min_buffer_size(64)
+        .target_update_interval(100)
+        .gamma(0.99)
+        .epsilon_start(1.0)
+        .epsilon_end(0.05)
+        .epsilon_decay_steps(500)
+        .max_grad_norm(10.0)
+        .soft_update_tau(0.01);
+    let (mut trainer, device, _obs_dim) = build(config, 0);
+
+    let mut env = GridWorld::new();
+    env.reset();
+    let mut obs = env.get_observation();
+    let mut rng = StdRng::seed_from_u64(0xC0FFEE);
+
+    let mut performed_update = false;
+    let mut last_stats = None;
+    let mut valid_actions = true;
+
+    for _ in 0..400 {
+        let dev = device.clone();
+        let action = trainer.select_action(&obs, &mut rng, |q: &QNetworkBurn<B>, o: &[f32]| {
+            greedy_action(q, o, &dev)
+        });
+        if !(0..4).contains(&action) {
+            valid_actions = false;
+        }
+
+        let result = env.step(action);
+        let done = result.terminated || result.truncated;
+        trainer
+            .buffer_mut()
+            .push(&obs, action, result.reward, &result.observation, done);
+
+        trainer.increment_env_step();
+        let _ = trainer.maybe_sync_target(|online, _target, _tau| online.clone());
+
+        if let Some(stats) = trainer
+            .train_step(
+                &mut rng,
+                |q: &QNetworkBurn<B>, o: Tensor<B, 2>| q.forward(o),
+                |q: &QNetworkBurn<B>, o: Tensor<B, 2>| q.forward(o),
+            )
+            .expect("train step is finite")
+        {
+            performed_update = true;
+            last_stats = Some(stats);
+        }
+
+        if done {
+            trainer.increment_episodes(1);
+            env.reset();
+            obs = env.get_observation();
+        } else {
+            obs = result.observation;
+        }
+    }
+
+    assert!(valid_actions, "every selected action must be a valid move in 0..4");
+    assert!(performed_update, "at least one gradient update should have fired");
+    let stats = last_stats.unwrap();
+    assert!(stats.td_loss.is_finite(), "td loss finite");
+    assert!(stats.mean_q.is_finite(), "mean_q finite");
+    assert!(stats.epsilon.is_finite(), "epsilon finite");
+    assert!(trainer.total_train_steps() > 0, "trainer recorded gradient updates");
+}
+
+/// Heavy convergence test (opt-in via `--ignored`): seeded DQN solves the
+/// default GridWorld layout, reaching mean greedy eval return >= +0.90 over
+/// the final 20 evaluation episodes within a fixed env-step budget.
+///
+/// Run with:
+/// ```text
+/// cargo test --release --features training --test test_dqn_grid_world -- --ignored
+/// ```
+#[test]
+#[ignore = "convergence run (tens of thousands of env steps); opt in with --ignored (prefer --release)"]
+fn dqn_grid_world_reaches_reward_bar() {
+    /// Total env-step budget. Empirically ample for seeded DQN to learn the
+    /// optimal shortest path to the goal on the deterministic 4x4 layout: the
+    /// greedy policy converges to the 6-step path 0→4→8→9→13→14→15 and every
+    /// eval episode returns +0.94 (well above the +0.90 bar). ~35 s release.
+    const TOTAL_TIMESTEPS: usize = 80_000;
+    /// Solved bar: the optimal shortest path earns ~+0.94 (+1 minus a handful
+    /// of -0.01 step penalties); +0.90 cleanly separates "reaches the goal
+    /// reliably" from any hole/timeout outcome (negative floor).
+    const REWARD_BAR: f32 = 0.90;
+
+    let config = DQNConfig::new()
+        .learning_rate(5e-4)
+        .batch_size(128)
+        .buffer_capacity(50_000)
+        .min_buffer_size(1_000)
+        .target_update_interval(500)
+        .gamma(0.95)
+        .epsilon_start(1.0)
+        .epsilon_end(0.10)
+        .epsilon_decay_steps(20_000)
+        .max_grad_norm(10.0)
+        .soft_update_tau(0.005);
+    let (mut trainer, device, _obs_dim) = build(config, 0);
+
+    // ----- Training loop -----
+    let mut env = GridWorld::new();
+    env.reset();
+    let mut obs = env.get_observation();
+    let mut rng = StdRng::seed_from_u64(0xC0FFEE);
+
+    while trainer.total_env_steps() < TOTAL_TIMESTEPS {
+        let dev = device.clone();
+        let action = trainer.select_action(&obs, &mut rng, |q: &QNetworkBurn<B>, o: &[f32]| {
+            greedy_action(q, o, &dev)
+        });
+
+        let result = env.step(action);
+        let done = result.terminated || result.truncated;
+        trainer
+            .buffer_mut()
+            .push(&obs, action, result.reward, &result.observation, done);
+
+        trainer.increment_env_step();
+        let _ = trainer.maybe_sync_target(|online, _target, _tau| online.clone());
+
+        if done {
+            trainer.increment_episodes(1);
+            env.reset();
+            obs = env.get_observation();
+        } else {
+            obs = result.observation;
+        }
+
+        trainer
+            .train_step(
+                &mut rng,
+                |q: &QNetworkBurn<B>, o: Tensor<B, 2>| q.forward(o),
+                |q: &QNetworkBurn<B>, o: Tensor<B, 2>| q.forward(o),
+            )
+            .expect("train step is finite");
+    }
+
+    // ----- Evaluation: 20 greedy episodes on the deterministic layout -----
+    let n_eval = 20;
+    let mut returns = Vec::with_capacity(n_eval);
+    for _ in 0..n_eval {
+        let mut eval_env = GridWorld::new();
+        eval_env.reset();
+        let mut eval_obs = eval_env.get_observation();
+        let mut ep_return = 0.0_f32;
+        loop {
+            let action = greedy_action(trainer.online(), &eval_obs, &device);
+            let result = eval_env.step(action);
+            ep_return += result.reward;
+            if result.terminated || result.truncated {
+                break;
+            }
+            eval_obs = result.observation;
+        }
+        returns.push(ep_return);
+    }
+
+    let mean_return: f32 = returns.iter().sum::<f32>() / returns.len() as f32;
+    assert!(
+        mean_return >= REWARD_BAR,
+        "DQN mean greedy eval return over {n_eval} episodes was {mean_return:.3}, expected >= {REWARD_BAR:.3}; \
+         per-episode returns: {returns:?}"
+    );
+}


### PR DESCRIPTION
## Summary

PR B of the more-environments epic (#180). Wires the merged `GridWorld` env (#182, on main at `src/env/games/grid_world.rs`) into the existing DQN stack with a runnable training example and a seeded two-tier smoke/convergence test. No `src/` library changes — only a new example, a new test, and one additive `Cargo.toml` `[[example]]` block.

## Changes

- **`examples/games/grid_world/train_dqn_grid_world.rs`** (new): seeded Double-DQN training loop (`QNetworkBurn` + `DQNTrainerBurn` on `Autodiff<NdArray<f32>>`, CPU), modeled on `train_cartpole_dqn.rs`. `obs_dim=16` one-hot, `n_actions=4`. Honors `TOTAL_TIMESTEPS` override and opt-in `CURVE_CSV` learning-curve emission (`env_steps,mean_episode_reward`) via the same `open_curve_csv()` helper. No file written when `CURVE_CSV` unset.
- **`tests/test_dqn_grid_world.rs`** (new): two tiers mirroring `test_a2c_cartpole.rs` / `test_sac_mountain_car.rs`:
  - `dqn_grid_world_training_step_runs` (always-on smoke): ~400 real env steps, asserts >=1 gradient update, finite `td_loss`/`mean_q`/`epsilon`, valid actions in `0..4`. Sub-2s.
  - `dqn_grid_world_reaches_reward_bar` (`#[ignore]`): seeded DQN reaches **mean greedy eval return >= +0.90** over 20 eval episodes within an 80k env-step budget.
- **`Cargo.toml`**: additive `[[example]]` block for `train_dqn_grid_world`.

## Convergence result

Ran `cargo test --release --features training --test test_dqn_grid_world -- --ignored`:
- **Passes.** Test execution ~35s (wall-clock ~83s incl. compile) on the CPU `NdArray` backend.
- Greedy policy converges to the **optimal 6-step path** `0→4→8→9→13→14→15`, return **+0.94** (= `+1 - 6×0.01`), comfortably above the **+0.90** bar.
- Bar rationale: optimal shortest path earns `+1 - 0.01·path_len ≈ +0.94`; any hole (`-1.0`) or timeout (`-0.01·100 = -1.0`) sits at the negative floor, so +0.90 cleanly separates "reaches the goal reliably" from "wandered/fell/timed out".
- Tuning note: the initial γ=0.99 / fast-ε config learned an ε-greedy policy (~0.8 training return) but the pure-greedy policy oscillated one cell short of the goal (bumped the bottom wall at cell 13 forever, return -1.0). Switching to γ=0.95 (sharper short-horizon credit assignment), slower ε decay (`1.0→0.10` over 20k) and lr=5e-4 / batch=128 resolved the Q-values at cell 13 so greedy picks Right→goal. The example config matches the convergent test config.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Example builds & runs with `--features training --release`, honors `TOTAL_TIMESTEPS`/`CURVE_CSV`, registered in `Cargo.toml` | ✅ | `cargo build --features training --example train_dqn_grid_world` + ran with both env vars; `[[example]]` block added |
| Smoke test (finite stats, >=1 gradient update) + `#[ignore]`d convergence bar with concrete bar/budget/seed | ✅ | `dqn_grid_world_training_step_runs` passes (<2s); ignored test pins bar +0.90 / budget 80k / seed 0+0xC0FFEE |
| Convergence test passes with `--ignored --release` | ✅ | Passes, mean eval return +0.94 |
| `cargo test --features training`, `cargo fmt --check` clean | ✅ | fmt clean; smoke lane passes |

## Test Plan

- `cargo fmt --check` — clean
- `cargo check --features training` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features training` — clean
- `cargo build --features training --example train_dqn_grid_world` — builds
- `cargo test --features training --test test_dqn_grid_world` — smoke passes
- `cargo test --release --features training --test test_dqn_grid_world -- --ignored` — convergence passes (+0.94 >= +0.90)

Note: CI runs fmt/check/test (not clippy). Local stable clippy reports pre-existing findings across `src/` (Snake, conv layers, A2C, etc.) unrelated to this PR; the new example and test files produce zero clippy findings.

Closes #185