### PR TITLE
docs: commit measured CPU-vs-GPU throughput numbers (closes #184)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -156,7 +156,7 @@ the validation run is the remaining piece (#134).*
 - [ ] Mixed precision training (FP16)
 - [ ] JIT compilation for environments
 - [ ] CUDA kernel optimization
-- [ ] GPU-backend (wgpu/cuda) training benchmarks vs the CPU NdArray baseline
+- [x] GPU-backend (wgpu) training benchmarks vs the CPU NdArray baseline — measured on RTX 4090; CPU wins 4.4–9.5× at current small-net sizes (see `docs/BURN_BACKENDS.md` → "Measured CPU-vs-GPU throughput")
 
 ---
 
@@ -193,9 +193,11 @@ place, the meaningful next moves are:
    - Pure-Rust inference path is already done; no weight-export blocker remains
      post-Burn. Highest-visibility "train in Rust, deploy to web" showcase.
 
-3. **GPU-backend benchmarking** (Milestone 7)
-   - Run the new throughput harness on the `wgpu` / `cuda` backends and compare
-     to the CPU NdArray baseline; the harness exists, the GPU numbers don't yet.
+3. **GPU-backend benchmarking** (Milestone 7) — ✅ done for `wgpu`
+   - Measured on an RTX 4090: CPU NdArray wins every group by 4.4–9.5× at the
+     harness's small-net sizes (kernel-launch/transfer overhead dominates). See
+     `docs/BURN_BACKENDS.md`. Remaining: a `cuda`-toolkit run, and re-measuring
+     once larger-net / high-parallelism workloads exist.
 
 4. **More environments** (Milestone 5)
    - The next env adds breadth: a discrete grid world, an Atari/ALE binding, or

--- a/docs/BURN_BACKENDS.md
+++ b/docs/BURN_BACKENDS.md
@@ -213,12 +213,55 @@ of `benches/trainer_throughput.rs`.)
   convolution-heavy workloads. Treat these benches as a relative harness, not an
   absolute GPU endorsement.
 
-### Committing the numbers
+### Measured CPU-vs-GPU throughput (issue #184)
 
-Capturing and committing the actual CPU-vs-GPU throughput table requires running
-the harness on operator GPU hardware, which is **operator-gated** and tracked
-separately (issue #184). This document intentionally ships only the run
-instructions; the measured numbers land via that issue.
+Run on an operator GPU host (the alc-2 workstation):
+
+- **CPU**: Intel Core i9-14900K (32 threads)
+- **GPU**: NVIDIA GeForce RTX 4090 (24 GB), driver 580.126.09
+- **OS**: Ubuntu 24.04.1 LTS, kernel 6.14
+- **Stack**: Burn 0.21, `ndarray` (CPU) vs `wgpu` → **Vulkan** (GPU)
+- **Command**: `cargo bench --features "training,wgpu" --bench trainer_throughput -- --warm-up-time 2 --measurement-time 10`
+
+Median per-iteration wall-clock, lower is better. "CPU faster ×" is `wgpu / ndarray`:
+
+| Benchmark group | NdArray (CPU) | wgpu (RTX 4090) | CPU faster × |
+| --- | --- | --- | --- |
+| `a2c_train_step` (per update) | 261 µs | 1.265 ms | 4.8× |
+| `ppo_train_step` (per update) | 296 µs | 1.890 ms | 6.4× |
+| `dqn_train_step` (per update) | 37.9 ms | 172.9 ms | 4.6× |
+| `sac_train_step` (per update) | 653 µs | 3.666 ms | 5.6× |
+| `a2c_cartpole_steps_per_sec` (full loop) | 477 µs | 2.973 ms | 6.2× |
+| `ppo_cartpole_steps_per_sec` (full loop) | 620 µs | 5.883 ms | 9.5× |
+| `dqn_cartpole_steps_per_sec` (full loop) | 43.4 ms | 188.7 ms | 4.4× |
+| `sac_pendulum_steps_per_sec` (full loop) | 10.7 ms | 65.8 ms | 6.2× |
+
+(`cuda` was not run — the alc-2 host has the NVIDIA driver but no CUDA toolkit /
+`nvcc`, which `cubecl-cuda` needs to compile. The `wgpu` → Vulkan path drives the
+same 4090 and is the portable GPU backend; the cuda column is left for a future
+toolkit-equipped run.)
+
+### Interpretation
+
+**The CPU NdArray backend wins every group by 4.4–9.5×.** This is the expected
+result at these sizes, not a misconfiguration — `nvidia-smi` sampled the 4090 at
+only **38–41 % utilization / ~150 MB** during the wgpu run, confirming Vulkan
+genuinely drove the discrete GPU (not a software/`lavapipe` fallback) but left it
+almost entirely idle. The benches use 64-unit MLPs with ≤256-row batches, so each
+op is dominated by GPU kernel-launch + host↔device transfer overhead rather than
+the matmul itself — there simply isn't enough arithmetic per launch to amortize
+the dispatch cost. The off-policy `*_train_step` groups (DQN/SAC) close the gap
+slightly (4.6× / 5.6×) because their larger replay minibatches give the GPU a
+bit more to chew on, which is the trend you'd expect.
+
+**What would flip the conclusion:** materially wider/deeper networks (e.g. CNN
+policies for image envs), much larger batch sizes, or many parallel environments
+batched into a single device dispatch — anything that raises arithmetic-per-launch
+above the dispatch-overhead floor. Until Thrust's default workloads grow in that
+direction, **NdArray (CPU) remains the right default**, and the GPU backends are
+best reserved for large-model / high-parallelism configurations. This is the
+quantified version of the [Performance note](#performance-note) and the
+validation-run observations above.
 
 ## Why Burn instead of libtorch?
 


### PR DESCRIPTION
## Summary

Closes #184 (the operator-gated GPU benchmark run) and completes epic #179. Ran the `trainer_throughput` harness on real GPU hardware via the alc cluster and committed the CPU-vs-GPU comparison table to `docs/BURN_BACKENDS.md`, replacing the placeholder that said the numbers were pending an operator.

**Host**: alc-2 — Intel i9-14900K (32T) + NVIDIA RTX 4090 (24 GB, driver 580.126.09), Ubuntu 24.04, Burn 0.21, `wgpu` → Vulkan.

## Result: CPU NdArray wins every group by 4.4–9.5×

| Group | NdArray (CPU) | wgpu (4090) | CPU faster × |
|-------|--------------|-------------|--------------|
| a2c_train_step | 261 µs | 1.265 ms | 4.8× |
| ppo_train_step | 296 µs | 1.890 ms | 6.4× |
| dqn_train_step | 37.9 ms | 172.9 ms | 4.6× |
| sac_train_step | 653 µs | 3.666 ms | 5.6× |
| a2c_cartpole loop | 477 µs | 2.973 ms | 6.2× |
| ppo_cartpole loop | 620 µs | 5.883 ms | 9.5× |
| dqn_cartpole loop | 43.4 ms | 188.7 ms | 4.4× |
| sac_pendulum loop | 10.7 ms | 65.8 ms | 6.2× |

This is the **expected** result, not a misconfiguration: `nvidia-smi` showed the 4090 at **38–41 % util / ~150 MB** during the wgpu run (confirming Vulkan genuinely drove the discrete GPU, not a lavapipe/software fallback) — it was just left nearly idle. The 64-unit MLPs + small batches are dominated by kernel-launch and host↔device transfer overhead. **NdArray (CPU) remains the right default**; GPU pays off only with much larger nets / batches / parallel-env batching.

`cuda` was not run (alc-2 has the driver but no CUDA toolkit for `cubecl-cuda`); the portable wgpu→Vulkan path covers the GPU and is documented as such.

## Changes (docs only)
- `docs/BURN_BACKENDS.md` — measured table + host spec + interpretation note (replaces the operator-gated placeholder)
- `ROADMAP.md` — Milestone 7 GPU-benchmark checkbox flipped + priority-queue item updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)