### PR TITLE
PSRO: mid-run checkpointing during run() via on_iteration callback (Part of #204)

### DIFF
--- a/examples/games/bucket_brigade/train_psro.rs
+++ b/examples/games/bucket_brigade/train_psro.rs
@@ -51,8 +51,23 @@
 //! - `psro_<cell>_final_meta_nash.json`
 //!
 //! Per-iteration progress is logged live via the PSRO `on_iteration`
-//! callback (NFSP-parity, issue #202). Mid-run intermediate checkpoint
-//! *writing* is tracked separately by issue #204.
+//! callback (NFSP-parity, issue #202).
+//!
+//! # Mid-run checkpointing (issue #204)
+//!
+//! The same `on_iteration` callback also writes **intermediate**
+//! per-agent BR checkpoints every `CHECKPOINT_INTERVAL_ITERATIONS`
+//! iterations *during* `run()`, not only after it returns:
+//! - `psro_<cell>_iter<n>_agent<i>.bin` (Burn binary, per agent)
+//! - `psro_<cell>_iter<n>_meta_nash.json` (α-rank meta-Nash per agent)
+//!
+//! A killed multi-hour run therefore leaves a resumable / partial-result
+//! safe artifact on disk rather than nothing. Set
+//! `CHECKPOINT_INTERVAL_ITERATIONS` (env var) to tune the cadence; `0`
+//! disables mid-run checkpointing. The callback receives the newest BR
+//! policy per agent (`brs[i]`) directly from the trainer, so no
+//! post-hoc accessor or borrow gymnastics are needed. Checkpointing is a
+//! side-effect-only write and does not change the training trajectory.
 //!
 //! # `gap_closed` baseline caveat
 //!
@@ -105,6 +120,11 @@ const SEED: u64 = 42;
 const DEFAULT_TOTAL_ITERATIONS: usize = 50;
 const DEFAULT_ROLLOUT_STEPS: usize = 2048;
 const DEFAULT_CELL: &str = "beta05";
+/// Default mid-run checkpoint cadence: write per-agent BR + meta-Nash
+/// every Nth outer iteration (issue #204). Overridable via the
+/// `CHECKPOINT_INTERVAL_ITERATIONS` env var; `0` disables mid-run
+/// checkpointing (only the final post-run artifacts are written).
+const DEFAULT_CHECKPOINT_INTERVAL_ITERATIONS: usize = 5;
 /// Length of the post-iteration deterministic eval rollout used to log
 /// the running per-step team estimate.
 const EVAL_STEPS: usize = 50;
@@ -179,10 +199,23 @@ fn main() -> Result<()> {
         .unwrap_or(DEFAULT_ROLLOUT_STEPS);
     let cell = std::env::var("CELL").unwrap_or_else(|_| DEFAULT_CELL.to_string());
     let (beta, kappa, cost) = cell_params(&cell);
+    let checkpoint_interval: usize = std::env::var("CHECKPOINT_INTERVAL_ITERATIONS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_CHECKPOINT_INTERVAL_ITERATIONS);
 
     tracing::info!("Starting PSRO bucket-brigade training (Burn backend: {BACKEND_LABEL})");
     tracing::info!("  cell             = {cell} (β={beta}, κ={kappa}, c={cost})");
     tracing::info!("  total_iterations = {total_iterations}");
+    tracing::info!(
+        "  checkpoint_every = {} iters{}",
+        checkpoint_interval,
+        if checkpoint_interval == 0 {
+            " (mid-run checkpointing disabled)"
+        } else {
+            ""
+        }
+    );
     tracing::info!("  rollout_steps    = {rollout_steps}");
     tracing::info!("  num_agents       = {NUM_AGENTS}");
     tracing::info!("  hidden_dim       = {HIDDEN_DIM}");
@@ -245,16 +278,29 @@ fn main() -> Result<()> {
         env_factory,
     )?;
 
+    let bin_recorder = BinFileRecorder::<FullPrecisionSettings>::new();
+    let json_recorder = PrettyJsonFileRecorder::<FullPrecisionSettings>::new();
+
     tracing::info!("------------------------------------------------------------");
     let training_start = std::time::Instant::now();
 
-    // Live per-iteration progress via the PSRO `on_iteration` callback
-    // (NFSP-parity, issue #202). The callback fires once per outer
-    // iteration with that iteration's `PsroIterationStats`, so progress
-    // is observable *during* multi-hour runs rather than only after
-    // `run()` returns. Mid-run checkpoint *writing* is issue #204; this
-    // path logs live and saves the final populations after `run()`.
-    let stats = trainer.run(|iter_stats| {
+    // Live per-iteration progress + mid-run checkpointing via the PSRO
+    // `on_iteration` callback (NFSP-parity, issue #202 + checkpointing,
+    // issue #204). The callback fires once per outer iteration with that
+    // iteration's `PsroIterationStats` AND the newest BR policy per
+    // agent (`brs[i]`), so progress is observable and partial results are
+    // persistable *during* multi-hour runs rather than only after
+    // `run()` returns.
+    //
+    // Every `checkpoint_interval` iterations we write
+    // `psro_<cell>_iter<n>_agent<i>.bin` (one per agent) plus a
+    // `psro_<cell>_iter<n>_meta_nash.json` snapshot. A killed run thus
+    // leaves a resumable / partial-result-safe artifact. Writing is a
+    // pure side effect on a *clone* of each policy and does not perturb
+    // the deterministic training trajectory. If any checkpoint write
+    // fails we log a warning and continue — a transient IO error must not
+    // abort an expensive multi-hour run.
+    let stats = trainer.run(|iter_stats, brs| {
         tracing::info!(
             "iter {:>3}/{}  pop_size={:>3}  exploitability={:>9.4}",
             iter_stats.iteration,
@@ -262,10 +308,36 @@ fn main() -> Result<()> {
             iter_stats.population_size,
             iter_stats.exploitability,
         );
-    })?;
 
-    let bin_recorder = BinFileRecorder::<FullPrecisionSettings>::new();
-    let json_recorder = PrettyJsonFileRecorder::<FullPrecisionSettings>::new();
+        if checkpoint_interval == 0 || iter_stats.iteration % checkpoint_interval != 0 {
+            return;
+        }
+        let n = iter_stats.iteration;
+        for (i, br) in brs.iter().enumerate() {
+            let bin_path = format!("psro_{cell}_iter{n}_agent{i}");
+            if let Err(e) = (*br).clone().save_file(&bin_path, &bin_recorder) {
+                tracing::warn!("checkpoint BIN save failed (iter {n}, agent {i}): {e}");
+            }
+        }
+        // Meta-Nash snapshot (per-agent marginals) alongside the BRs.
+        let mut as_map: HashMap<String, Vec<f32>> = HashMap::new();
+        for (i, dist) in iter_stats.meta_nash_per_agent.iter().enumerate() {
+            as_map.insert(format!("agent{i}"), dist.clone());
+        }
+        match serde_json::to_string_pretty(&as_map) {
+            Ok(json) => {
+                let meta_path = format!("psro_{cell}_iter{n}_meta_nash.json");
+                if let Err(e) = std::fs::write(&meta_path, json) {
+                    tracing::warn!("checkpoint meta-Nash write failed (iter {n}): {e}");
+                }
+            }
+            Err(e) => tracing::warn!("checkpoint meta-Nash serialize failed (iter {n}): {e}"),
+        }
+        tracing::info!(
+            "  checkpoint written: psro_{cell}_iter{n}_agent{{0..{}}}.bin (+ meta_nash.json)",
+            NUM_AGENTS - 1
+        );
+    })?;
 
     tracing::info!("------------------------------------------------------------");
     let final_population_size = stats.iterations.last().map(|s| s.population_size).unwrap_or(0);

--- a/src/multi_agent/psro.rs
+++ b/src/multi_agent/psro.rs
@@ -1286,15 +1286,27 @@ where
     /// and lets callers observe per-iteration progress *during* the run
     /// (live `tracing` logging, mid-run checkpoint triggers, etc.)
     /// rather than only inspecting the aggregate stats after `run`
-    /// returns. The callback receives `&PsroIterationStats`, whose
-    /// `iteration` field increases monotonically from `1` to
-    /// `config.max_iterations`.
+    /// returns.
+    ///
+    /// The callback receives two arguments:
+    /// 1. `&PsroIterationStats` — this iteration's stats, whose `iteration`
+    ///    field increases monotonically from `1` to `config.max_iterations`.
+    /// 2. `&[&P]` — the newest best-response policy for each agent (`brs[a]` is
+    ///    agent `a`'s freshly-trained BR appended this iteration, i.e.
+    ///    `populations(a).last()`). This lets the callback persist per-agent BR
+    ///    policies to disk *during* the run (mid-run checkpointing, issue #204)
+    ///    without a borrow conflict against the `&mut self` held by `run`: the
+    ///    trainer cannot itself write files (it is backend/format-agnostic, the
+    ///    `Recorder` lives in the example), so it hands the closure the policy
+    ///    references it needs to checkpoint. Checkpointing is a pure
+    ///    side-effect read; it does not alter the trainer state or the
+    ///    deterministic training trajectory.
     ///
     /// For the common case of "run with no per-iteration hook", use
     /// [`Self::run_silent`].
     pub fn run<F>(&mut self, mut on_iteration: F) -> Result<PsroStats>
     where
-        F: FnMut(&PsroIterationStats),
+        F: FnMut(&PsroIterationStats, &[&P]),
         // Bounds required by the rayon-parallel boundary-slab evaluation
         // (issue #203). Mirror the `EnvPool` Send-bound convention
         // (pool.rs:58). The parallel payoff result is bit-identical to a
@@ -1397,7 +1409,18 @@ where
                 br_stats_per_agent,
                 exploitability,
             };
-            on_iteration(&iter_stats);
+
+            // Newest best-response policy per agent, appended this
+            // iteration in the round-robin loop above. Handed to the
+            // callback so it can checkpoint per-agent BR policies
+            // mid-run (issue #204). `populations(a)` is guaranteed
+            // non-empty here: every agent was just trained and pushed.
+            let newest_brs: Vec<&P> = (0..num_agents)
+                .map(|a| {
+                    self.populations[a].last().expect("population non-empty after BR training")
+                })
+                .collect();
+            on_iteration(&iter_stats, &newest_brs);
             stats.iterations.push(iter_stats);
         }
         Ok(stats)
@@ -1414,7 +1437,7 @@ where
         FE: Sync,
         B::Device: Sync,
     {
-        self.run(|_| {})
+        self.run(|_, _| {})
     }
 
     /// Most-recent per-agent meta-Nash distributions (one row per
@@ -2376,7 +2399,7 @@ mod tests {
 
         let mut observed: Vec<usize> = Vec::new();
         let stats = trainer
-            .run(|it| observed.push(it.iteration))
+            .run(|it, _brs| observed.push(it.iteration))
             .expect("PSRO run should not error");
 
         // Callback fired exactly once per outer iteration.
@@ -2409,6 +2432,99 @@ mod tests {
         );
         let stats = trainer.run_silent().expect("PSRO run_silent should not error");
         assert_eq!(stats.iterations.len(), max_iterations);
+    }
+
+    /// Mid-run checkpointing (issue #204) rides on the `on_iteration`
+    /// callback's second argument: the slice of newest-per-agent BR
+    /// policies. This test exercises the checkpoint-trigger logic the
+    /// example uses, without touching disk:
+    ///
+    /// 1. The callback receives exactly one BR per agent each iteration.
+    /// 2. Those BR references are the same policies the trainer exposes via
+    ///    `populations(a).last()` (i.e. the freshly-appended BR), captured by
+    ///    their deterministic forward-pass logits.
+    /// 3. A `CHECKPOINT_INTERVAL`-gated counter fires on exactly the expected
+    ///    iterations (every Nth iteration), modelling the example's `iter %
+    ///    CHECKPOINT_INTERVAL_ITERATIONS == 0` knob.
+    /// 4. The number of distinct "checkpoints taken" matches the closed form,
+    ///    and the policies handed at checkpoint time round-trip bit-identically
+    ///    through a clone (the operation the example's `Recorder::save_file`
+    ///    performs on a clone).
+    #[test]
+    fn test_psro_checkpoint_callback_fires_at_intervals() {
+        let max_iterations = 6;
+        const CHECKPOINT_INTERVAL: usize = 2;
+        let mut trainer = build_matching_pennies_trainer(
+            Box::new(FictitiousPlayMetaSolver::new(500)),
+            max_iterations,
+        );
+        let num_agents = 2;
+
+        // Iterations on which a checkpoint was taken.
+        let mut checkpoint_iters: Vec<usize> = Vec::new();
+        // For each checkpoint, the per-agent BR logits captured at
+        // checkpoint time, plus the logits of a *clone* of the same
+        // policy (mirrors the example saving `br.clone()`).
+        let mut checkpoint_logits: Vec<Vec<(Vec<f32>, Vec<f32>)>> = Vec::new();
+
+        trainer
+            .run(|it, brs| {
+                // (1) One BR per agent, every iteration.
+                assert_eq!(brs.len(), num_agents, "callback must receive one newest BR per agent");
+
+                // (3) Interval gate exactly as the example drives it.
+                if it.iteration % CHECKPOINT_INTERVAL == 0 {
+                    checkpoint_iters.push(it.iteration);
+                    let per_agent: Vec<(Vec<f32>, Vec<f32>)> = brs
+                        .iter()
+                        .map(|br| {
+                            let original = read_policy_weight(br);
+                            // (4) Clone round-trip: cloning a policy (as
+                            // the recorder does before `save_file`) must
+                            // not perturb its forward pass.
+                            let cloned = (**br).clone();
+                            let cloned_logits = read_policy_weight(&cloned);
+                            (original, cloned_logits)
+                        })
+                        .collect();
+                    checkpoint_logits.push(per_agent);
+                }
+            })
+            .expect("PSRO run should not error");
+
+        // (3) Fired on exactly iterations 2, 4, 6.
+        assert_eq!(
+            checkpoint_iters,
+            vec![2, 4, 6],
+            "checkpoint must fire on every CHECKPOINT_INTERVAL-th iteration"
+        );
+        // Closed form: floor(max_iterations / interval) checkpoints.
+        assert_eq!(checkpoint_logits.len(), max_iterations / CHECKPOINT_INTERVAL);
+
+        for per_agent in &checkpoint_logits {
+            assert_eq!(per_agent.len(), num_agents);
+            for (original, cloned) in per_agent {
+                // (4) Clone is byte-identical to the checkpointed policy.
+                assert_eq!(
+                    original, cloned,
+                    "checkpointed BR clone must produce identical logits (save_file round-trip)"
+                );
+            }
+        }
+
+        // (2) The final-iteration checkpoint must match what the trainer
+        // exposes via the public `populations(a).last()` accessor — this
+        // is the same handle `train_psro.rs` uses for its final save, so
+        // the mid-run checkpoint and the post-run save are consistent.
+        let final_checkpoint = checkpoint_logits.last().expect("at least one checkpoint");
+        for (a, (checkpointed_logits, _)) in final_checkpoint.iter().enumerate().take(num_agents) {
+            let pop_last = trainer.populations(a).last().expect("non-empty population");
+            let from_accessor = read_policy_weight(pop_last);
+            assert_eq!(
+                checkpointed_logits, &from_accessor,
+                "checkpointed BR for agent {a} must equal populations(a).last() logits"
+            );
+        }
     }
 
     /// Read the policy_head weight buffer from a policy as a flat


### PR DESCRIPTION
Part of #204 — PR D of the PSRO perf epic #198. Implements the **mid-run checkpointing code** (the CPU-CI-testable half of #204). The cluster-calibration AC (committed speedup numbers + recalibrated #134 budget on the 32-core alc-2 box) is **operator-gated** and left for the operator, so this is `Part of #204`, not `Closes`.

Depends on #203 (rayon parallelize) and #202 (on_iteration callback) — both merged to main.

## What changed

### Checkpointing approach (callback wiring + minimal accessor)
The cleanest way to checkpoint per-agent BR policies *during* `run()` is to ride the existing `on_iteration` callback (#202). The blocker was a borrow conflict: the closure cannot capture `&trainer` while `trainer.run()` holds `&mut self`. Resolution — extend the callback to **hand the closure the policy references it needs**:

- `PsroTrainer::run` callback signature changes from `FnMut(&PsroIterationStats)` to `FnMut(&PsroIterationStats, &[&P])`. The second argument is the newest best-response policy per agent (`populations(a).last()`, freshly appended this iteration). No new public accessor was required — the existing `populations(agent)` already exists; the callback simply receives the per-agent newest-BR slice directly.
- The trainer stays backend/format-agnostic: file IO + the Burn `Recorder` live in the example (behind the `training` feature). Checkpointing is a side-effect-only read; it does not touch trainer state.
- `run_silent()` and the per-iteration callback unit test updated to the new arity. **All external callers (`tests/*`) use `run_silent()` and are unaffected.**

### Example wiring (`train_psro.rs`)
- New `CHECKPOINT_INTERVAL_ITERATIONS` env knob (default 5; `0` disables). #202 had removed the old post-hoc checkpoint; this re-adds it as a *live mid-run* checkpoint.
- Every Nth iteration the callback writes `psro_<cell>_iter<n>_agent<i>.bin` (one per agent, Burn binary) + `psro_<cell>_iter<n>_meta_nash.json` (α-rank meta-Nash snapshot), mirroring how the final-artifact block already saves.
- Writes are best-effort (warn + continue on IO error) so a transient failure cannot abort a multi-hour run. A killed run now leaves resumable / partial-result-safe artifacts.

### Test
`test_psro_checkpoint_callback_fires_at_intervals` (CPU CI, no disk): asserts the callback receives exactly one BR per agent each iteration, the `iter % INTERVAL == 0` gate fires on exactly the expected iterations, checkpointed policies round-trip **bit-identically** through a clone (the `save_file` operation), and the checkpointed BR equals `populations(a).last()`.

## Training results unchanged
Checkpointing is a pure side-effect write. The seeded-reproducibility test `test_psro_exploitability_trace_is_bit_identical` passes — the per-iteration exploitability trace is bit-identical to before, confirming the trajectory is unaffected.

## Verification
- `cargo test --features training --lib psro` — 27 passed (incl. new test).
- `cargo test --features training --test test_seeded_reproducibility` — 2 passed (bit-identical traces).
- `cargo build --features "training,env-bucket-brigade" --example train_psro` — clean.
- `cargo fmt --check` — clean.
- `cargo clippy --all-targets --features training -- -D warnings` — **zero errors in touched files** (`psro.rs`, `train_psro.rs`). The 54 remaining errors are pre-existing on clean `main` HEAD (snake/conv/buffer modules), unrelated to this change.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features training` — clean.

## Operator note
The `[operator]` acceptance criteria of #204 (multi-core run on alc-2 showing >1 core utilized + measured speedup vs single-thread baseline + per-iteration wall-clock + feasible #134 PSRO budget, committed to `docs/research/2026-06-bucket-brigade-validation.md`) require the 32-core cluster box and are **left for the operator**. This PR delivers only the CI-testable checkpointing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)