### PR TITLE
chore: clear clippy debt and gate CI on clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,21 @@ jobs:
         # and cannot be reformatted from this repo.
         run: cargo fmt -- --check
 
+  # Lint with clippy, denying all warnings, across the full training build
+  # (lib, tests, examples). Keeps clippy debt from accumulating silently.
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+      - name: cargo clippy --all-targets --features training -- -D warnings
+        run: cargo clippy --all-targets --features training -- -D warnings
+
   # Cheap "does it parse" check without the training stack.
   # `--no-default-features` drops the `training` feature (and thus `burn`).
   check_no_training:

--- a/examples/games/bandit/train_simple_bandit.rs
+++ b/examples/games/bandit/train_simple_bandit.rs
@@ -73,7 +73,6 @@ fn main() -> Result<()> {
         thrust_rl::env::SpaceType::Discrete(n) => n,
         _ => panic!("expected discrete action space"),
     };
-    drop(probe);
 
     let mut env_pool = EnvPool::new(SimpleBandit::new, NUM_ENVS);
     let device = Default::default();

--- a/examples/games/cartpole/train_cartpole_a2c.rs
+++ b/examples/games/cartpole/train_cartpole_a2c.rs
@@ -116,7 +116,6 @@ fn main() -> Result<()> {
         thrust_rl::env::SpaceType::Discrete(n) => n,
         _ => panic!("Expected discrete action space"),
     };
-    drop(probe);
 
     tracing::info!("Environment: CartPole-v1");
     tracing::info!("  obs_dim    = {}", obs_dim);
@@ -178,7 +177,7 @@ fn main() -> Result<()> {
     let mut observations = env_pool.reset();
 
     // Per-env running episode-length tracker. CartPole reward = +1/step.
-    let mut episode_lengths = vec![0u32; NUM_ENVS];
+    let mut episode_lengths = [0u32; NUM_ENVS];
     let mut completed_episode_lengths: Vec<u32> = Vec::new();
     let mut total_env_steps: usize = 0;
 
@@ -270,10 +269,10 @@ fn main() -> Result<()> {
         // Emit one learning-curve row per logging interval when CURVE_CSV
         // is set. A2C runs many short updates, so we throttle to keep the
         // CSV manageable while still dense.
-        if let Some(w) = curve_csv.as_mut() {
-            if update % 20 == 0 || update == num_updates - 1 {
-                writeln!(w, "{},{:.4}", total_env_steps, last_avg_len)?;
-            }
+        if let Some(w) = curve_csv.as_mut()
+            && (update % 20 == 0 || update == num_updates - 1)
+        {
+            writeln!(w, "{},{:.4}", total_env_steps, last_avg_len)?;
         }
 
         if update % 200 == 0 || update == num_updates - 1 {

--- a/examples/games/cartpole/train_cartpole_dqn.rs
+++ b/examples/games/cartpole/train_cartpole_dqn.rs
@@ -92,7 +92,6 @@ fn main() -> Result<()> {
         thrust_rl::env::SpaceType::Discrete(n) => n as i64,
         _ => panic!("Expected discrete action space"),
     };
-    drop(probe);
 
     tracing::info!("Environment: CartPole-v1");
     tracing::info!("  obs_dim    = {}", obs_dim);
@@ -123,8 +122,7 @@ fn main() -> Result<()> {
     let burn_opt: BurnOptimizer<B, QNetworkBurn<B>, _> =
         BurnOptimizer::new(inner_opt, config.learning_rate);
 
-    let mut trainer =
-        DQNTrainerBurn::new(config, online, burn_opt, obs_dim, n_actions, device.clone())?;
+    let mut trainer = DQNTrainerBurn::new(config, online, burn_opt, obs_dim, n_actions, device)?;
 
     let mut env = CartPole::new();
     env.reset();
@@ -145,7 +143,7 @@ fn main() -> Result<()> {
     while trainer.total_env_steps() < total_timesteps {
         // ε-greedy action selection.
         let action = {
-            let device_local = device.clone();
+            let device_local = device;
             trainer.select_action(&obs, &mut rng, |q: &QNetworkBurn<B>, o_host: &[f32]| {
                 // Forward pass on the inner (non-autodiff) backend for speed
                 // is not directly available — use the autodiff module's

--- a/examples/games/cartpole/train_cartpole_modern.rs
+++ b/examples/games/cartpole/train_cartpole_modern.rs
@@ -104,7 +104,6 @@ fn main() -> Result<()> {
         thrust_rl::env::SpaceType::Discrete(n) => n,
         _ => panic!("Expected discrete action space"),
     };
-    drop(probe);
 
     tracing::info!("Environment: CartPole-v1");
     tracing::info!("  obs_dim    = {}", obs_dim);
@@ -171,7 +170,7 @@ fn main() -> Result<()> {
     let mut observations = env_pool.reset();
 
     // Per-env running episode-length tracker. CartPole reward = +1/step.
-    let mut episode_lengths = vec![0u32; NUM_ENVS];
+    let mut episode_lengths = [0u32; NUM_ENVS];
     let mut completed_episode_lengths: Vec<u32> = Vec::new();
     let mut total_env_steps: usize = 0;
 

--- a/examples/games/grid_world/train_dqn_grid_world.rs
+++ b/examples/games/grid_world/train_dqn_grid_world.rs
@@ -117,7 +117,6 @@ fn main() -> Result<()> {
         thrust_rl::env::SpaceType::Discrete(n) => n as i64,
         _ => panic!("Expected discrete action space"),
     };
-    drop(probe);
 
     tracing::info!("Environment: GridWorld 4x4 (FrozenLake-style, no slip)");
     tracing::info!("  obs_dim    = {}", obs_dim);
@@ -148,8 +147,7 @@ fn main() -> Result<()> {
     let burn_opt: BurnOptimizer<B, QNetworkBurn<B>, _> =
         BurnOptimizer::new(inner_opt, config.learning_rate);
 
-    let mut trainer =
-        DQNTrainerBurn::new(config, online, burn_opt, obs_dim, n_actions, device.clone())?;
+    let mut trainer = DQNTrainerBurn::new(config, online, burn_opt, obs_dim, n_actions, device)?;
 
     let mut env = GridWorld::new();
     env.reset();
@@ -170,7 +168,7 @@ fn main() -> Result<()> {
     while trainer.total_env_steps() < total_timesteps {
         // ε-greedy action selection.
         let action = {
-            let device_local = device.clone();
+            let device_local = device;
             trainer.select_action(&obs, &mut rng, |q: &QNetworkBurn<B>, o_host: &[f32]| {
                 let o_t: Tensor<B, 2> = Tensor::from_data(
                     TensorData::new(o_host.to_vec(), [1, o_host.len()]),

--- a/examples/games/pong/train_pong_self_play.rs
+++ b/examples/games/pong/train_pong_self_play.rs
@@ -106,7 +106,6 @@ fn main() -> Result<()> {
         thrust_rl::env::SpaceType::Discrete(n) => n,
         _ => panic!("Expected discrete action space"),
     };
-    drop(probe);
 
     tracing::info!("Environment: Pong");
     tracing::info!("  obs_dim         = {}", obs_dim);
@@ -174,7 +173,7 @@ fn main() -> Result<()> {
     let mut buf_dones: Vec<f32> = Vec::with_capacity(cap);
 
     let mut episode_returns: Vec<f32> = Vec::new();
-    let mut current_returns = vec![0.0_f32; NUM_ENVS];
+    let mut current_returns = [0.0_f32; NUM_ENVS];
     let mut total_env_steps: usize = 0;
 
     for update in 0..num_updates {

--- a/examples/games/snake/train_snake_multi_v2.rs
+++ b/examples/games/snake/train_snake_multi_v2.rs
@@ -4,9 +4,9 @@
 //! v2 trainer runs N independent PPO learners (one per snake) sharing a
 //! single multi-agent SnakeEnv. Each snake has its own
 //! [`SnakeCnnBurnPolicy`](thrust_rl::policy::snake_cnn::SnakeCnnBurnPolicy)
-//! + [`PPOTrainerBurn`](thrust_rl::train::ppo::PPOTrainerBurn) instance,
-//! gets a per-agent grid observation from the shared env, and is
-//! updated independently on its own rollout buffer.
+//! + [`PPOTrainerBurn`](thrust_rl::train::ppo::PPOTrainerBurn) instance, gets a
+//!   per-agent grid observation from the shared env, and is updated
+//!   independently on its own rollout buffer.
 //!
 //! # Why "v2"?
 //!
@@ -127,7 +127,7 @@ fn main() -> Result<()> {
     let mut total_env_steps: usize = 0;
     let mut episodes_completed: usize = 0;
     let mut per_episode_returns: Vec<Vec<f32>> = vec![Vec::new(); NUM_AGENTS];
-    let mut current_returns = vec![0.0_f32; NUM_AGENTS];
+    let mut current_returns = [0.0_f32; NUM_AGENTS];
 
     for update in 0..num_updates {
         for buf in buf_obs.iter_mut() {

--- a/src/buffer/rollout/gae.rs
+++ b/src/buffer/rollout/gae.rs
@@ -359,6 +359,9 @@ pub fn compute_nstep_returns(
 ///
 /// # Arguments
 /// * `buffer` - Rollout buffer to compute returns for
+// Loops walk `[step][env]` rows with a sub-range backfill (`episode_start..=step`)
+// into a separately-borrowed `returns` array; enumerate() cannot express that.
+#[allow(clippy::needless_range_loop)]
 pub fn compute_mc_returns(buffer: &mut super::storage::RolloutBuffer) {
     let (num_steps, num_envs) = (buffer.shape().0, buffer.shape().1);
 
@@ -399,6 +402,9 @@ pub fn compute_mc_returns(buffer: &mut super::storage::RolloutBuffer) {
 ///
 /// # Arguments
 /// * `buffer` - Rollout buffer with computed advantages
+// Nested `[step][env]` indexing reads/writes a 2D buffer accessor; enumerate()
+// over the outer dimension cannot reach the inner accessor cleanly.
+#[allow(clippy::needless_range_loop)]
 pub fn normalize_advantages(buffer: &mut super::storage::RolloutBuffer) {
     let (num_steps, num_envs) = (buffer.shape().0, buffer.shape().1);
 

--- a/src/buffer/rollout/storage.rs
+++ b/src/buffer/rollout/storage.rs
@@ -111,6 +111,9 @@ impl RolloutBuffer {
     /// * `log_prob` - Log probability of the action
     /// * `terminated` - Whether the episode terminated
     /// * `truncated` - Whether the episode was truncated
+    // Each argument is a distinct transition field; bundling them into a struct
+    // would add boilerplate at every call site without improving clarity.
+    #[allow(clippy::too_many_arguments)]
     pub fn add(
         &mut self,
         step: usize,
@@ -343,11 +346,7 @@ impl RolloutBatch {
     /// Get the observation shape as (batch_size, obs_dim)
     pub fn obs_shape(&self) -> (usize, usize) {
         let batch_size = self.len();
-        let obs_dim = if batch_size == 0 {
-            0
-        } else {
-            self.observations.len() / batch_size
-        };
+        let obs_dim = self.observations.len().checked_div(batch_size).unwrap_or(0);
         (batch_size, obs_dim)
     }
 

--- a/src/buffer/rollout/tests.rs
+++ b/src/buffer/rollout/tests.rs
@@ -116,7 +116,7 @@ mod gae_tests {
                 buffer.add(
                     step,
                     env,
-                    &vec![0.0],
+                    &[0.0],
                     0,
                     1.0, // reward
                     0.5, // value
@@ -134,8 +134,8 @@ mod gae_tests {
         // Check that advantages were computed
         let advantages = buffer.advantages();
         println!("Buffer advantages:");
-        for step in 0..num_steps {
-            println!("  Step {}: {:?}", step, advantages[step]);
+        for (step, adv) in advantages.iter().enumerate().take(num_steps) {
+            println!("  Step {}: {:?}", step, adv);
         }
 
         // Advantages should be different before and after episode boundary
@@ -204,8 +204,8 @@ mod gae_tests {
         // Non-terminating slots: (env, agent) in {(0,0), (0,1), (1,0)}.
         for (env, agent) in [(0, 0), (0, 1), (1, 0)] {
             let slot = env * num_agents + agent;
-            let idx_step0 = 0 * stride + slot;
-            let idx_step1 = 1 * stride + slot;
+            let idx_step0 = slot; // step 0: 0 * stride + slot
+            let idx_step1 = stride + slot; // step 1: 1 * stride + slot
             assert!(
                 (advantages[idx_step0] - 2.0).abs() < eps,
                 "(env={}, agent={}) step 0 advantage expected 2.0, got {}",
@@ -224,9 +224,9 @@ mod gae_tests {
 
         // Terminating slot: (env=1, agent=1). The done at step 0 must
         // prevent the step-1 advantage from leaking back into step 0.
-        let term_slot = 1 * num_agents + 1;
-        let term_step0 = 0 * stride + term_slot;
-        let term_step1 = 1 * stride + term_slot;
+        let term_slot = num_agents + 1; // env=1, agent=1: 1 * num_agents + 1
+        let term_step0 = term_slot; // step 0: 0 * stride + term_slot
+        let term_step1 = stride + term_slot; // step 1: 1 * stride + term_slot
         assert!(
             (advantages[term_step0] - 1.0).abs() < eps,
             "terminating slot step 0 advantage expected 1.0 (no bootstrap, \

--- a/src/env/games/pong.rs
+++ b/src/env/games/pong.rs
@@ -158,29 +158,35 @@ impl Pong {
 
         let mut reward = 0.0f32;
 
-        // Left paddle collision: ball's left edge crosses LEFT_X this step
-        if old_bx - BALL_R >= LEFT_X && self.ball_x - BALL_R < LEFT_X && self.ball_dx < 0.0 {
-            if (self.ball_y - self.left_y).abs() <= PADDLE_H {
-                let hit_pos = (self.ball_y - self.left_y) / PADDLE_H;
-                self.ball_dx = BALL_SPEED;
-                self.ball_dy = (self.ball_dy + hit_pos * BALL_SPEED * 0.6)
-                    .clamp(-BALL_SPEED * 1.2, BALL_SPEED * 1.2);
-                self.ball_x = LEFT_X + BALL_R;
-                reward = 0.1;
-            }
-            // else: miss — ball continues to left wall
+        // Left paddle collision: ball's left edge crosses LEFT_X this step and
+        // the paddle is in range. A crossing with the paddle out of range is a
+        // miss — the ball continues to the left wall.
+        if old_bx - BALL_R >= LEFT_X
+            && self.ball_x - BALL_R < LEFT_X
+            && self.ball_dx < 0.0
+            && (self.ball_y - self.left_y).abs() <= PADDLE_H
+        {
+            let hit_pos = (self.ball_y - self.left_y) / PADDLE_H;
+            self.ball_dx = BALL_SPEED;
+            self.ball_dy = (self.ball_dy + hit_pos * BALL_SPEED * 0.6)
+                .clamp(-BALL_SPEED * 1.2, BALL_SPEED * 1.2);
+            self.ball_x = LEFT_X + BALL_R;
+            reward = 0.1;
         }
 
-        // Right paddle collision: ball's right edge crosses RIGHT_X this step
-        if old_bx + BALL_R <= RIGHT_X && self.ball_x + BALL_R > RIGHT_X && self.ball_dx > 0.0 {
-            if (self.ball_y - self.right_y).abs() <= PADDLE_H {
-                let hit_pos = (self.ball_y - self.right_y) / PADDLE_H;
-                self.ball_dx = -BALL_SPEED;
-                self.ball_dy = (self.ball_dy + hit_pos * BALL_SPEED * 0.6)
-                    .clamp(-BALL_SPEED * 1.2, BALL_SPEED * 1.2);
-                self.ball_x = RIGHT_X - BALL_R;
-            }
-            // else: agent scores when ball hits right wall below
+        // Right paddle collision: ball's right edge crosses RIGHT_X this step and
+        // the paddle is in range. A crossing with the paddle out of range lets the
+        // agent score when the ball hits the right wall below.
+        if old_bx + BALL_R <= RIGHT_X
+            && self.ball_x + BALL_R > RIGHT_X
+            && self.ball_dx > 0.0
+            && (self.ball_y - self.right_y).abs() <= PADDLE_H
+        {
+            let hit_pos = (self.ball_y - self.right_y) / PADDLE_H;
+            self.ball_dx = -BALL_SPEED;
+            self.ball_dy = (self.ball_dy + hit_pos * BALL_SPEED * 0.6)
+                .clamp(-BALL_SPEED * 1.2, BALL_SPEED * 1.2);
+            self.ball_x = RIGHT_X - BALL_R;
         }
 
         // Scoring: ball exits screen
@@ -282,29 +288,35 @@ impl Environment for Pong {
 
         let mut reward = 0.0f32;
 
-        // Left paddle collision: ball's left edge crosses LEFT_X this step
-        if old_bx - BALL_R >= LEFT_X && self.ball_x - BALL_R < LEFT_X && self.ball_dx < 0.0 {
-            if (self.ball_y - self.left_y).abs() <= PADDLE_H {
-                let hit_pos = (self.ball_y - self.left_y) / PADDLE_H;
-                self.ball_dx = BALL_SPEED;
-                self.ball_dy = (self.ball_dy + hit_pos * BALL_SPEED * 0.6)
-                    .clamp(-BALL_SPEED * 1.2, BALL_SPEED * 1.2);
-                self.ball_x = LEFT_X + BALL_R;
-                reward = 0.1;
-            }
-            // else: miss — ball continues to left wall
+        // Left paddle collision: ball's left edge crosses LEFT_X this step and
+        // the paddle is in range. A crossing with the paddle out of range is a
+        // miss — the ball continues to the left wall.
+        if old_bx - BALL_R >= LEFT_X
+            && self.ball_x - BALL_R < LEFT_X
+            && self.ball_dx < 0.0
+            && (self.ball_y - self.left_y).abs() <= PADDLE_H
+        {
+            let hit_pos = (self.ball_y - self.left_y) / PADDLE_H;
+            self.ball_dx = BALL_SPEED;
+            self.ball_dy = (self.ball_dy + hit_pos * BALL_SPEED * 0.6)
+                .clamp(-BALL_SPEED * 1.2, BALL_SPEED * 1.2);
+            self.ball_x = LEFT_X + BALL_R;
+            reward = 0.1;
         }
 
-        // Right paddle collision: ball's right edge crosses RIGHT_X this step
-        if old_bx + BALL_R <= RIGHT_X && self.ball_x + BALL_R > RIGHT_X && self.ball_dx > 0.0 {
-            if (self.ball_y - self.right_y).abs() <= PADDLE_H {
-                let hit_pos = (self.ball_y - self.right_y) / PADDLE_H;
-                self.ball_dx = -BALL_SPEED;
-                self.ball_dy = (self.ball_dy + hit_pos * BALL_SPEED * 0.6)
-                    .clamp(-BALL_SPEED * 1.2, BALL_SPEED * 1.2);
-                self.ball_x = RIGHT_X - BALL_R;
-            }
-            // else: agent scores when ball hits right wall below
+        // Right paddle collision: ball's right edge crosses RIGHT_X this step and
+        // the paddle is in range. A crossing with the paddle out of range lets the
+        // agent score when the ball hits the right wall below.
+        if old_bx + BALL_R <= RIGHT_X
+            && self.ball_x + BALL_R > RIGHT_X
+            && self.ball_dx > 0.0
+            && (self.ball_y - self.right_y).abs() <= PADDLE_H
+        {
+            let hit_pos = (self.ball_y - self.right_y) / PADDLE_H;
+            self.ball_dx = -BALL_SPEED;
+            self.ball_dy = (self.ball_dy + hit_pos * BALL_SPEED * 0.6)
+                .clamp(-BALL_SPEED * 1.2, BALL_SPEED * 1.2);
+            self.ball_x = RIGHT_X - BALL_R;
         }
 
         // Scoring: ball exits screen

--- a/src/env/games/snake.rs
+++ b/src/env/games/snake.rs
@@ -21,6 +21,9 @@ pub use types::{Cell, Direction, GameState, Position};
 
 // Submodules
 mod environment;
+// The `snake` submodule holds the core `Snake`/`Food` types; renaming it to
+// avoid the same-name parent module would churn every re-export for no benefit.
+#[allow(clippy::module_inception)]
 mod snake;
 mod types;
 // TODO: Re-enable after fixing multi-agent code

--- a/src/env/games/snake/environment.rs
+++ b/src/env/games/snake/environment.rs
@@ -103,8 +103,7 @@ impl SnakeEnv {
             (3 * width / 4, 3 * height / 4, Direction::Left), // Bottom-right
         ];
 
-        for i in 0..num_agents.min(4) {
-            let (x, y, dir) = positions[i];
+        for (i, &(x, y, dir)) in positions.iter().enumerate().take(num_agents.min(4)) {
             let start_pos = Position::new(x, y);
             snakes.push(Snake::new(i, start_pos, dir));
         }
@@ -151,8 +150,7 @@ impl SnakeEnv {
             (3 * self.width / 4, 3 * self.height / 4, Direction::Left),
         ];
 
-        for i in 0..self.num_agents.min(4) {
-            let (x, y, dir) = positions[i];
+        for (i, &(x, y, dir)) in positions.iter().enumerate().take(self.num_agents.min(4)) {
             let start_pos = Position::new(x, y);
             self.snakes.push(Snake::new(i, start_pos, dir));
         }
@@ -511,12 +509,12 @@ impl SnakeEnv {
         // Channel 4: Walls (boundaries)
         // Top and bottom walls
         for x in 0..self.width as usize {
-            obs[4 * grid_size + 0 * (self.width as usize) + x] = 1.0; // Top
+            obs[4 * grid_size + x] = 1.0; // Top
             obs[4 * grid_size + ((self.height as usize - 1) * (self.width as usize)) + x] = 1.0; // Bottom
         }
         // Left and right walls
         for y in 0..self.height as usize {
-            obs[4 * grid_size + y * (self.width as usize) + 0] = 1.0; // Left
+            obs[4 * grid_size + y * (self.width as usize)] = 1.0; // Left
             obs[4 * grid_size + y * (self.width as usize) + (self.width as usize - 1)] = 1.0; // Right
         }
 

--- a/src/env/games/snake/snake.rs
+++ b/src/env/games/snake/snake.rs
@@ -106,6 +106,14 @@ impl Snake {
         self.length
     }
 
+    /// Whether the snake has no body segments.
+    ///
+    /// A live snake always has at least one segment, so this is effectively
+    /// always `false`; provided to satisfy the `len`/`is_empty` convention.
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+
     /// Check if snake is alive
     pub fn is_alive(&self) -> bool {
         self.alive

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -106,6 +106,9 @@ impl LayerWeights {
     }
 
     /// Forward pass through a linear layer
+    // The matmul uses row-major flat indexing `weights[i * in_features + j]`,
+    // which needs both counters; enumerate() cannot express it cleanly.
+    #[allow(clippy::needless_range_loop)]
     pub fn forward(&self, input: &[f32]) -> Vec<f32> {
         assert_eq!(input.len(), self.in_features, "Input size mismatch");
 

--- a/src/inference/snake.rs
+++ b/src/inference/snake.rs
@@ -66,6 +66,10 @@ pub struct SnakeCNNInference {
 
 impl SnakeCNNInference {
     /// Apply 2D convolution with padding=1
+    // Indexed loops mirror the [out_c][h][w][in_c][kh][kw] tensor layout and the
+    // padded neighbor arithmetic; rewriting as enumerate() iterators would obscure
+    // the spatial indexing rather than clarify it.
+    #[allow(clippy::needless_range_loop)]
     fn conv2d(
         &self,
         input: &[Vec<Vec<f32>>],       // [in_channels, height, width]
@@ -129,6 +133,9 @@ impl SnakeCNNInference {
     /// # Returns
     /// * `(logits, value)` - Action logits `[num_actions]` and state value
     ///   (scalar)
+    // The [c][h][w] reshape loop computes a flat index from three counters;
+    // enumerate() cannot express that arithmetic cleanly.
+    #[allow(clippy::needless_range_loop)]
     pub fn forward(&self, grid: &[f32]) -> (Vec<f32>, f32) {
         let grid_size = self.grid_width * self.grid_height;
         assert_eq!(grid.len(), self.input_channels * grid_size);

--- a/src/policy/inference.rs
+++ b/src/policy/inference.rs
@@ -83,6 +83,10 @@ impl SnakeCNNInference {
     }
 
     /// Apply 2D convolution with padding=1
+    // Indexed loops mirror the [out_c][h][w][in_c][kh][kw] tensor layout and the
+    // padded neighbor arithmetic; rewriting as enumerate() iterators would obscure
+    // the spatial indexing rather than clarify it.
+    #[allow(clippy::needless_range_loop)]
     fn conv2d(
         &self,
         input: &[Vec<Vec<f32>>],       // [in_channels, height, width]
@@ -146,6 +150,9 @@ impl SnakeCNNInference {
     /// # Returns
     /// * `(logits, value)` - Action logits `[num_actions]` and state value
     ///   (scalar)
+    // The [c][h][w] reshape loop computes a flat index from three counters;
+    // enumerate() cannot express that arithmetic cleanly.
+    #[allow(clippy::needless_range_loop)]
     pub fn forward(&self, grid: &[f32]) -> (Vec<f32>, f32) {
         let grid_size = self.grid_width * self.grid_height;
         assert_eq!(grid.len(), self.input_channels * grid_size);

--- a/src/policy/universal_inference.rs
+++ b/src/policy/universal_inference.rs
@@ -44,7 +44,7 @@ impl Activation {
             Activation::Identity => x,
             Activation::Gelu => {
                 // Approximate GELU: 0.5 * x * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x^3)))
-                const SQRT_2_OVER_PI: f32 = 0.7978845608;
+                const SQRT_2_OVER_PI: f32 = 0.797_884_6;
                 0.5 * x * (1.0 + (SQRT_2_OVER_PI * (x + 0.044715 * x.powi(3))).tanh())
             }
             Activation::Swish => x / (1.0 + (-x).exp()), // x * sigmoid(x)
@@ -158,6 +158,9 @@ impl Layer {
     }
 
     /// Apply this layer to input data
+    // Reshape branches compute flat indices from per-axis counters
+    // (`idx = ch * h * w + row * w + col`); enumerate() cannot express that.
+    #[allow(clippy::needless_range_loop)]
     pub fn forward(&self, input: &Tensor) -> Result<Tensor> {
         match self {
             Layer::Linear { weight, bias, out_features, .. } => {
@@ -296,6 +299,9 @@ impl Layer {
     }
 
     /// Perform 2D convolution
+    // Indexed loops mirror the [out_c][h][w][in_c][kh][kw] tensor layout and the
+    // strided/padded neighbor arithmetic; enumerate() would obscure the indexing.
+    #[allow(clippy::needless_range_loop)]
     fn conv2d_forward(
         input: &[Vec<Vec<f32>>],
         weight: &[Vec<Vec<Vec<f32>>>],
@@ -514,6 +520,9 @@ impl UniversalModel {
     }
 
     /// Convert raw input to tensor based on input spec
+    // The grid reshape computes a flat index from three counters
+    // (`idx = c * height * width + h * width + w`); enumerate() cannot express it.
+    #[allow(clippy::needless_range_loop)]
     fn input_to_tensor(&self, input: &[f32]) -> Result<Tensor> {
         match &self.input {
             InputSpec::Vector { size } => {

--- a/src/train/dqn/config.rs
+++ b/src/train/dqn/config.rs
@@ -197,10 +197,10 @@ impl DQNConfig {
         if self.max_grad_norm <= 0.0 {
             return Err(anyhow!("max_grad_norm must be positive"));
         }
-        if let Some(tau) = self.soft_update_tau {
-            if !(tau > 0.0 && tau <= 1.0) {
-                return Err(anyhow!("soft_update_tau must be in (0, 1], got {}", tau));
-            }
+        if let Some(tau) = self.soft_update_tau
+            && !(tau > 0.0 && tau <= 1.0)
+        {
+            return Err(anyhow!("soft_update_tau must be in (0, 1], got {}", tau));
         }
         // Prioritized Experience Replay parameter ranges. We validate
         // even when `prioritized_replay = false` so callers that flip

--- a/src/train/dqn/trainer.rs
+++ b/src/train/dqn/trainer.rs
@@ -257,7 +257,7 @@ where
             }
             None => {
                 if self.total_env_steps > 0
-                    && self.total_env_steps % self.config.target_update_interval == 0
+                    && self.total_env_steps.is_multiple_of(self.config.target_update_interval)
                 {
                     self.target = self.online().clone();
                     true

--- a/src/utils/normalize.rs
+++ b/src/utils/normalize.rs
@@ -29,6 +29,10 @@ impl RunningMeanStd {
     ///
     /// # Arguments
     /// * `observations` - Batch of observations `[batch_size][obs_dim]`
+    // The mean/variance update loops index four parallel arrays
+    // (`mean`, `var`, `delta`, `batch_var`) by the same `i`; enumerate() over one
+    // would force awkward zip chains for the rest.
+    #[allow(clippy::needless_range_loop)]
     pub fn update(&mut self, observations: &[Vec<f32>]) {
         if observations.is_empty() {
             return;

--- a/tests/test_a2c_cartpole.rs
+++ b/tests/test_a2c_cartpole.rs
@@ -71,7 +71,6 @@ fn build(
         thrust_rl::env::SpaceType::Discrete(n) => n,
         _ => panic!("expected discrete action space"),
     };
-    drop(probe);
 
     let policy_config = MlpBurnConfig {
         num_layers: 2,

--- a/tests/test_dqn_grid_world.rs
+++ b/tests/test_dqn_grid_world.rs
@@ -22,7 +22,7 @@
 //!    separates "found a reliable path to the goal" from "wandered / fell in
 //!    holes / timed out" (negative floor: a hole is `-1.0`, a timeout is `-0.01
 //!    * 100 = -1.0`, and a random policy on this deceptive layout averages well
-//!    below zero).
+//!      below zero).
 //!
 //! ## Why the heavy bar is `#[ignore]`d
 //!
@@ -92,7 +92,6 @@ fn build(
         SpaceType::Discrete(n) => n as i64,
         _ => panic!("expected discrete action space"),
     };
-    drop(probe);
 
     let lr = config.learning_rate;
     let online =
@@ -100,7 +99,7 @@ fn build(
     let inner_opt = AdamConfig::new().init();
     let burn_opt: BurnOptimizer<B, QNetworkBurn<B>, _> = BurnOptimizer::new(inner_opt, lr);
 
-    let trainer = DQNTrainerBurn::new(config, online, burn_opt, obs_dim, n_actions, device.clone())
+    let trainer = DQNTrainerBurn::new(config, online, burn_opt, obs_dim, n_actions, device)
         .expect("trainer constructs");
     (trainer, device, obs_dim)
 }
@@ -134,7 +133,7 @@ fn dqn_grid_world_training_step_runs() {
     let mut valid_actions = true;
 
     for _ in 0..400 {
-        let dev = device.clone();
+        let dev = device;
         let action = trainer.select_action(&obs, &mut rng, |q: &QNetworkBurn<B>, o: &[f32]| {
             greedy_action(q, o, &dev)
         });
@@ -223,7 +222,7 @@ fn dqn_grid_world_reaches_reward_bar() {
     let mut rng = StdRng::seed_from_u64(0xC0FFEE);
 
     while trainer.total_env_steps() < TOTAL_TIMESTEPS {
-        let dev = device.clone();
+        let dev = device;
         let action = trainer.select_action(&obs, &mut rng, |q: &QNetworkBurn<B>, o: &[f32]| {
             greedy_action(q, o, &dev)
         });

--- a/tests/test_psro_bucket_brigade.rs
+++ b/tests/test_psro_bucket_brigade.rs
@@ -52,7 +52,7 @@
 //! swing. The PSRO smoke budget (12 outer iter × 2048 rollout × 4 agents
 //! × `[10, 2, 2]` action space) may or may not produce a `gap_closed_cell
 //! >= 0` policy on these `no_convergence` cells — the heterogeneous DO
-//! solver itself failed to here, per the workshop paper's verdict.
+//! > solver itself failed to here, per the workshop paper's verdict.
 //!
 //! Mirroring the NFSP sibling test (`tests/test_nfsp_bucket_brigade.rs`,
 //! PR #131), this test asserts the soft-but-strong bar

--- a/tests/test_psro_n_player_matching_pennies.rs
+++ b/tests/test_psro_n_player_matching_pennies.rs
@@ -223,10 +223,10 @@ fn psro_n4_smoke_runs_and_is_finite() {
 
     // Each agent's meta-Nash-weighted action marginal must be a valid
     // distribution: finite, in `[0, 1]`, and summing to ~1.
-    for agent in 0..num_agents {
+    for (agent, agent_meta_nash) in final_meta_nash.iter().enumerate().take(num_agents) {
         let marginal = meta_nash_action_marginal(
             trainer.populations(agent),
-            &final_meta_nash[agent],
+            agent_meta_nash,
             agent,
             num_agents,
             &Default::default(),
@@ -301,10 +301,10 @@ fn test_psro_n4_converges_to_uniform_on_majority_game() {
 
     let uniform = vec![0.5_f32; NPlayerMatchingPennies::ACTION_DIM];
     let mut max_tv_seen = 0.0_f32;
-    for agent in 0..num_agents {
+    for (agent, agent_meta_nash) in final_meta_nash.iter().enumerate().take(num_agents) {
         let marginal = meta_nash_action_marginal(
             trainer.populations(agent),
-            &final_meta_nash[agent],
+            agent_meta_nash,
             agent,
             num_agents,
             &Default::default(),


### PR DESCRIPTION
## Summary

`cargo clippy --all-targets --features training -- -D warnings` was failing across many files, and CI did not run clippy, so the debt accumulated silently. This PR clears every clippy error (clippy now exits 0) and adds a CI `clippy` job so it stays clean.

## Changes

- **Mechanical fixes** (real fixes, no allow): `needless_range_loop` where `enumerate()` is clean (snake env spawn loops, rollout test loops, matching-pennies tests), `collapsible_if` via let-chains (pong collision logic, DQN config validation), `manual_is_multiple_of` (DQN target-update cadence), `manual_checked_ops` (`checked_div().unwrap_or(0)`), `useless_vec`, `clone_on_copy`, `identity_op`/`erasing_op` (snake wall obs + rollout index math), `doc_lazy_continuation`, `excessive_precision` (GELU constant), and removal of no-op `drop(probe)` of non-`Drop` probe envs.
- **Justified `#[allow]`s** — each with an inline one-line comment (see table below).
- **`Snake::is_empty`** added to satisfy `len_without_is_empty`.
- **CI**: new `clippy` job running `cargo clippy --all-targets --features training -- -D warnings`, styled to match the existing fmt/check/test/doc jobs (nightly toolchain, `clippy` component, recursive submodules).

### `#[allow]`s added (with justification)

| Location | Lint | Why |
|----------|------|-----|
| `policy/inference.rs` `conv2d`, `forward` | needless_range_loop | indexed loops mirror `[out_c][h][w][in_c][kh][kw]` tensor layout / flat reshape index |
| `inference/snake.rs` `conv2d`, `forward` | needless_range_loop | same conv/reshape kernel pattern |
| `inference/mod.rs` `forward` | needless_range_loop | row-major matmul flat index `weights[i*in+j]` needs both counters |
| `policy/universal_inference.rs` `forward`, `conv2d_forward`, `input_to_tensor` | needless_range_loop | strided/padded conv + flat-index reshape |
| `buffer/rollout/gae.rs` `compute_mc_returns`, `normalize_advantages` | needless_range_loop | `[step][env]` 2D accessors + sub-range backfill |
| `utils/normalize.rs` `update` | needless_range_loop | four parallel arrays indexed by same `i` |
| `buffer/rollout/storage.rs` `add` | too_many_arguments | distinct transition fields; a struct adds boilerplate at every call site |
| `env/games/snake.rs` `mod snake` | module_inception | renaming the core-types submodule would churn every re-export |

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `cargo clippy --all-targets --features training -- -D warnings` exits 0 | ✅ | Ran locally: exit code 0 |
| A CI clippy job added and passing | ✅ | Added `clippy` job to `.github/workflows/ci.yml` running the same command |

## Test Plan

- `cargo clippy --all-targets --features training -- -D warnings` → exit 0
- `cargo build --features training` → success
- `cargo test --features training` → all pass (0 failed; heavy convergence tests remain `#[ignore]`d)
- `cargo fmt -- --check` → clean

Note: the bucket-brigade *example* files (`train_nfsp.rs`, `train_psro.rs`) were intentionally left untouched — their `drop(probe)` lines are not flagged by clippy under this build and are out of scope.

Closes #217