### PR TITLE
feat(psro): payoff-magnitude fixes for α-rank saturation + BR critic reward scaling

### DIFF
--- a/docs/research/2026-06-bucket-brigade-validation.md
+++ b/docs/research/2026-06-bucket-brigade-validation.md
@@ -165,6 +165,19 @@ question, tracked alongside the α-rank-solve cost in
 non-convergence (#199): **neither trainer converges on the no-convergence cells**,
 which is itself the answer to #134's research question at the budgets explored.
 
+> **Update (2026-06-22, #215):** root-caused at the code level — see
+> [`2026-06-psro-alpha-rank-payoff-magnitude.md`](./2026-06-psro-alpha-rank-payoff-magnitude.md).
+> The α-rank Moran fixation probability **saturates** on the `[−700, 0]` band
+> (`α·δ ≈ 7000` vs the `≤ 20` it was tuned for on matching-pennies), collapsing the
+> meta-solver into a brittle hard-max — a direct mechanism for diverging
+> exploitability. `AlphaRankMetaSolver` gained an opt-in
+> `with_payoff_span_normalization` knob (restores magnitude invariance) and
+> `PsroConfig` gained `br_reward_scale` (mirrors #199's BR critic fix). A unit test
+> shows a strictly-dominant strategy that the unnormalized solver correctly
+> concentrates on at unit scale degrades to ≈uniform at the `±700` scale, and span
+> normalization recovers the correct concentrated answer. A documented
+> decreasing-exploitability *cluster* run remains gated on #134.
+
 ## Budget note: 8192 rollout is impractical for NFSP on this hardware
 
 The #134-recommended `48 × 8192` budget proved infeasible. At 8192 rollout, NFSP
@@ -223,4 +236,5 @@ NFSP (`examples/games/bucket_brigade/train_nfsp.rs`):
 1. ~~**PSRO perf + observability pass** — #198~~ **DONE** — parallel payoff eval (#207), live logging (#202), mid-run checkpoints (#204). Calibration showed parallelism alone is insufficient (see the 2026-06-21 update above).
 2. **PSRO payoff-tensor caching** — [#212](https://github.com/rjwalters/thrust/issues/212): reuse unchanged `population⁴` entries across iterations (`O(pop⁴)` → `O(pop³)` new work/iter). This is the remaining blocker for a feasible PSRO run.
 3. **NFSP learning investigation** — [#199](https://github.com/rjwalters/thrust/issues/199): raise average-policy training steps, diagnose the BR side, revisit reward scaling. **Root-caused + code-level fixes landed** — see [`2026-06-nfsp-avg-policy-undertraining.md`](./2026-06-nfsp-avg-policy-undertraining.md): `NfspConfig` gained an adaptive `avg_policy_min_reservoir_coverage` AP-step floor and a `br_reward_scale` knob (the unscaled `[−700, 0]` band drove the BR critic's `value_loss` to ~9.8M; ×0.01 fixes it). The AP demonstrably fits a factored `[10,2,2]` target to ~0.003 (well below `ln(40)`) when given enough gradient steps. The **full cluster re-run** at the ~9,800-entry reservoir scale remains gated on #134.
-4. Once #212 + #199 land, re-run both at a feasible, observable budget and recompute **cell-specific** `gap_closed_cell`.
+4. **PSRO convergence investigation** — [#215](https://github.com/rjwalters/thrust/issues/215): root-cause the exploitability divergence. **Root-caused + code-level fixes landed** — see [`2026-06-psro-alpha-rank-payoff-magnitude.md`](./2026-06-psro-alpha-rank-payoff-magnitude.md): the α-rank Moran fixation probability saturates on the `[−700, 0]` band (`AlphaRankMetaSolver::with_payoff_span_normalization` restores magnitude invariance), and `PsroConfig` gained `br_reward_scale` mirroring #199. The α-rank-solve **perf** work (blocker #2) stays gated on a demonstrated convergence. The **full cluster re-run** remains gated on #134.
+5. Once #212 + #199 + #215 land, re-run both at a feasible, observable budget and recompute **cell-specific** `gap_closed_cell`.

--- a/docs/research/2026-06-psro-alpha-rank-payoff-magnitude.md
+++ b/docs/research/2026-06-psro-alpha-rank-payoff-magnitude.md
@@ -1,0 +1,208 @@
+# PSRO Non-Convergence on Bucket Brigade: α-rank Payoff-Magnitude Saturation (#215)
+
+**Date:** 2026-06-22
+**Issue:** [#215](https://github.com/rjwalters/thrust/issues/215)
+**Related:** [#199](https://github.com/rjwalters/thrust/issues/199) (NFSP reward scaling),
+[#134](https://github.com/rjwalters/thrust/issues/134) (cluster validation),
+[#198](https://github.com/rjwalters/thrust/issues/198) / [#212](https://github.com/rjwalters/thrust/issues/212) (PSRO perf)
+**Status:** Code-level root-cause fixes landed; full documented decreasing-exploitability
+cluster run remains gated on #134.
+
+## The finding being investigated
+
+A capped PSRO calibration on alc-2 (`CELL=beta01`, 2048 rollout, payoff-eval
+cap = 64) showed exploitability **increasing** across iterations rather than
+decreasing:
+
+| iter | pop | exploitability |
+|------|-----|----------------|
+| 1 | 2 | 6404 |
+| 2 | 3 | 9253 |
+| 3 | 4 | 8423 |
+| 4 | 5 | 12029 |
+
+PSRO is not solving the 4-player bucket-brigade game. Issue #215 frames two
+blockers: (1) **non-convergence** (gating), and (2) the **α-rank solve cost**
+(super-linear, follow-on, explicitly gated on #1). This writeup addresses #1 at
+the code level and demonstrates the mechanism at a locally-runnable scale.
+
+## Root cause (two contributing factors, both magnitude-driven)
+
+The two PSRO halves — the **best-response (BR) learner** and the **α-rank
+meta-solver** — are *both* miscalibrated for the bucket-brigade `[−700, 0]` payoff
+band, which is ~3 orders of magnitude larger than the `{−1, +1}` matching-pennies
+game on which both were validated.
+
+### 1. α-rank fixation probability saturates on the `[−700, 0]` band (PSRO-specific, decisive)
+
+α-rank builds a Markov chain over joint pure strategies whose transition
+probabilities are Moran fixation probabilities
+
+```text
+ρ(α, m, δ) = (1 − exp(−α δ)) / (1 − exp(−m α δ)),   δ = π_τ − π_σ
+```
+
+driven by `α · δ`. The defaults (`α = 10`, `m = 50`) were validated on
+matching-pennies, where `|δ| ≤ 2` so `|α δ| ≤ 20` — comfortably inside the regime
+where `ρ` is a *graded* function of the payoff advantage. On the bucket-brigade
+band, `|δ|` reaches **~700**, so `|α δ| ≈ 7000`. Every non-neutral transition
+**saturates** to a hard 0 or 1: the graded Moran dynamics collapse into a
+degenerate deterministic best-response graph whose stationary distribution is
+acutely sensitive to tiny payoff-estimate noise. That brittleness — the meta-Nash
+mixture flipping between near-degenerate distributions as the empirical payoffs
+wobble iteration-to-iteration — is a direct mechanism for exploitability that
+*increases* instead of decreasing.
+
+**Measured (unit test, `test_alpha_rank_span_normalization_is_magnitude_invariant`):**
+a 2×2 symmetric game in which strategy 0 strictly dominates is solved at two
+scales with identical ordering.
+
+| Payoff scale | α-rank mass on dominant strategy (unnormalized) |
+|--------------|--------------------------------------------------|
+| `±2` (unit) | **> 0.9** (correct — concentrates on the dominant strategy) |
+| `±700` (bucket-brigade band) | **≈ 0.5** (wrong — saturation erases the dominance signal) |
+
+At the large scale the *unnormalized* solver returns a near-uniform distribution
+even though one strategy strictly dominates: the solver has stopped tracking the
+strategy ordering entirely. This is not a slow-convergence artifact; it is the
+fixation probability degenerating.
+
+### 2. Unscaled `[−700, 0]` reward band wrecks the BR critic (shared with #199)
+
+The PSRO BR is trained with the *same* joint PPO update as NFSP's BR side, so it
+inherits the identical pathology #199 measured on the NFSP arm: a value function
+regressed against returns in `[−700, 0]` produces multi-million-magnitude critic
+targets and near-useless advantages, so the BR policy barely moves. A weak BR
+appends near-random policies to the population, which cannot reduce
+exploitability. #199 fixed this on NFSP with `br_reward_scale`; this PR adds the
+analogous knob to PSRO.
+
+## Code-level fixes (this PR)
+
+All in `src/multi_agent/psro.rs` (config + trainer + meta-solver) and the
+bucket-brigade example.
+
+1. **`PsroConfig::br_reward_scale: f32`** — uniform reward scaling applied to the
+   BR rollout rewards in `train_best_response` before the joint PPO update,
+   mirroring [`NfspConfig::br_reward_scale`](../../src/multi_agent/nfsp.rs). Scaling
+   rewards is an affine transform of the return (optimal policy unchanged) but
+   keeps the critic's regression targets and advantage statistics numerically
+   sane. `1.0` (default) is a bit-identical no-op.
+
+2. **`AlphaRankMetaSolver::normalize_payoff_span: bool`** (builder:
+   `with_payoff_span_normalization`) — when enabled, every Moran payoff
+   differential `δ` is divided by the payoff **span** (`max − min` over the input
+   tensor) before multiplying by `α`, so the effective selection strength
+   `α · (δ / span)` lands in the same `[−α, α]` band the defaults were tuned for
+   *regardless of the absolute payoff magnitude*. This is the α-rank analogue of
+   `br_reward_scale`: a magnitude-invariance fix, not a change to the ranking
+   semantics on a fixed scale. A degenerate zero/non-finite span falls back to a
+   unit divisor (no-op). `false` (default) is bit-identical to the pre-#215 solver
+   — confirmed by `test_alpha_rank_span_normalization_default_off_is_bit_identical`
+   and the existing `test_psro_exploitability_trace_is_bit_identical` reproducibility
+   bar.
+
+3. **Example knobs** in `examples/games/bucket_brigade/train_psro.rs`: new env
+   overrides `BR_REWARD_SCALE` and `ALPHA_RANK_NORMALIZE_SPAN`, both logged at
+   startup. The per-iteration `exploitability` is already logged live via the
+   `on_iteration` callback (#202), so divergence-vs-convergence is visible during
+   a run.
+
+## Local-scale evidence
+
+### α-rank magnitude invariance (controlled, fast, always-on)
+
+`test_alpha_rank_span_normalization_is_magnitude_invariant` (in
+`src/multi_agent/psro.rs`) isolates and proves the mechanism:
+
+- **Unnormalized:** the `±2` game concentrates correctly (> 0.9 on the dominant
+  strategy); the *same-ordering* `±700` game collapses to ≈ uniform (< 0.6) — the
+  saturation bug.
+- **Span-normalized:** the `±700` game recovers the same concentrated answer as
+  the `±2` game (within `1e-3` per-entry), and still puts > 0.9 on the dominant
+  strategy. Magnitude no longer changes the answer.
+
+This is exactly the brittleness that would make the meta-Nash mixture (and hence
+the reported exploitability) jump around on the large-payoff cells.
+
+### End-to-end plumbing (controlled, fast, always-on)
+
+`psro_n4_issue215_knobs_run_and_are_finite` (in
+`tests/test_psro_n_player_matching_pennies.rs`) drives a tiny-budget N=4 PSRO run
+with *both* knobs set to non-default values (`br_reward_scale = 0.01`,
+span-norm on) and asserts the NashConv curve stays finite/non-negative with valid
+per-agent simplex marginals — guarding the plumbing on every CISC run.
+
+### Real-env local run (beta01, small budget)
+
+A 3-iteration `beta01` run (128 rollout, CPU NdArray, `target/release`) compares
+the default trainer against both knobs on. The headline is the **trend** of the
+per-iteration α-rank exploitability (NashConv on the empirical meta-game):
+
+| iter | pop | baseline (no knobs) | both knobs (`BR_REWARD_SCALE=0.01`, `ALPHA_RANK_NORMALIZE_SPAN=1`) |
+|------|-----|---------------------|--------------------------------------------------------------------|
+| 1 | 2 | 6412.0 | 8363.9 |
+| 2 | 3 | 7002.6 (↑) | 7612.7 (↓) |
+| 3 | 4 | 6447.1 (↓) | 5344.9 (↓) |
+| **trend** | | **6412 → 7003 → 6447 — non-monotone, no descent** | **8364 → 7613 → 5345 — monotonically decreasing** |
+
+The baseline reproduces the cluster non-convergence *locally*: exploitability
+**increases** on the first step (6412 → 7003) and never establishes a downward
+trend. With both magnitude fixes the curve is **monotonically decreasing**
+(8364 → 7613 → 5345) over the same budget — the qualitative behavior the issue
+asks for.
+
+Caveats, stated honestly:
+- The absolute NashConv values are **not comparable across the two columns** —
+  NashConv is computed on the raw `[−700, 0]` payoffs, and span normalization
+  changes only the *meta-solver's* internal selection strength, not the payoff
+  scale the metric is reported on. Read the **per-column trend**, not the
+  cross-column magnitude.
+- This is a **3-iteration, 128-rollout** run on CPU — an *observability* check
+  that the fixes move the trend in the right direction, **not** a converged
+  result. `gap_closed_cell` is still far from the PPO reference in both runs (the
+  BR side has barely trained at this micro-budget — the deeper #199-shared
+  question). A documented, multi-iteration decreasing curve *to a competitive
+  `gap_closed_cell`* at a meaningful budget requires the cluster (#134).
+
+The local budget (few iterations, 256 rollout) is far below the cluster scale;
+the numbers above are an *observability* check that the knobs change the run in
+the expected direction, not a convergence claim. A documented decreasing-
+exploitability run at a meaningful budget requires the cluster (see below).
+
+## What remains gated on #134 (cluster runs)
+
+- A documented PSRO run where exploitability **decreases** over iterations on at
+  least one bucket-brigade cell, with `br_reward_scale < 1` and α-rank span
+  normalization on. The full-scale `population⁴` α-rank solve + BR training at a
+  feasible budget needs the operator-gated alcubierro cluster.
+- Determining whether, *with* both magnitude fixes, the BR (RL) side can learn
+  structured play on these hard, sparse-reward cells at all — the deeper,
+  shared-with-NFSP (#199) research question. A well-evidenced negative result
+  ("α-rank PSRO is unsuited to this payoff structure because the BR cannot learn
+  at feasible budget") is an acceptable outcome per #215.
+
+## Blocker #2 (α-rank solve cost) — explicitly deferred
+
+Per #215, α-rank *performance* work is gated on convergence being established
+first, so this PR does **not** optimize it. For the record, the next step once
+convergence is shown would be to bound the `population⁴`-state stationary solve:
+either (a) a sparse/iterative eigensolve that exploits the response graph's
+single-agent-deviation sparsity (each state has only `N·(k−1)` out-edges, already
+the representation in `solve_n_player_impl`), or (b) capping the response-graph
+size by pruning dominated joint strategies before the power iteration. Both are
+follow-on perf work, not convergence work.
+
+## Reproduction
+
+```bash
+# Fast, always-on mechanistic + plumbing tests:
+cargo test --features training --lib multi_agent::psro::tests::test_alpha_rank_span
+cargo test --features training --test test_psro_n_player_matching_pennies \
+    psro_n4_issue215_knobs_run_and_are_finite
+
+# Local real-env run (requires the bucket-brigade env feature):
+TOTAL_ITERATIONS=5 ROLLOUT_STEPS=256 CELL=beta01 CHECKPOINT_INTERVAL_ITERATIONS=0 \
+  BR_REWARD_SCALE=0.01 ALPHA_RANK_NORMALIZE_SPAN=1 \
+  cargo run --release --example train_psro --features "training,env-bucket-brigade"
+```

--- a/examples/games/bucket_brigade/train_psro.rs
+++ b/examples/games/bucket_brigade/train_psro.rs
@@ -221,6 +221,25 @@ fn main() -> Result<()> {
     // 4-player (population⁴) game.
     let max_payoff_evals_per_iteration: Option<usize> =
         std::env::var("MAX_PAYOFF_EVALS_PER_ITER").ok().and_then(|s| s.parse().ok());
+    // Optional BR reward scaling (issue #199 / #215). Unset => 1.0
+    // (no-op). The unscaled `[−700, 0]` bucket-brigade band drives the
+    // BR critic's value targets and advantage stats into a range where
+    // the value loss dominates the surrogate; `BR_REWARD_SCALE=0.01`
+    // rescales it to roughly `[−7, 0]` (affine transform; same optimal
+    // policy). Mirrors NFSP's `br_reward_scale` knob.
+    let br_reward_scale: f32 = std::env::var("BR_REWARD_SCALE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1.0);
+    // Optional α-rank payoff-span normalization (issue #215). Unset =>
+    // off (bit-identical to the pre-#215 solver). Set
+    // `ALPHA_RANK_NORMALIZE_SPAN=1` to divide the Moran payoff
+    // differential by the payoff span so `α · delta` does not saturate
+    // to a hard 0/1 on the large-magnitude bucket-brigade band.
+    let alpha_rank_normalize_span: bool = std::env::var("ALPHA_RANK_NORMALIZE_SPAN")
+        .ok()
+        .map(|s| s == "1" || s.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
 
     tracing::info!("Starting PSRO bucket-brigade training (Burn backend: {BACKEND_LABEL})");
     tracing::info!("  cell             = {cell} (β={beta}, κ={kappa}, c={cost})");
@@ -244,6 +263,22 @@ fn main() -> Result<()> {
             None => "unbounded (full boundary; bit-identical)".to_string(),
         }
     );
+    tracing::info!(
+        "  br_reward_scale  = {br_reward_scale} {}",
+        if br_reward_scale == 1.0 {
+            "(no-op)"
+        } else {
+            "(BR rewards rescaled)"
+        }
+    );
+    tracing::info!(
+        "  α-rank span-norm = {}",
+        if alpha_rank_normalize_span {
+            "on (Moran delta / payoff-span)"
+        } else {
+            "off (bit-identical to pre-#215)"
+        }
+    );
 
     let device: burn::tensor::Device<InnerBackend> = Default::default();
 
@@ -260,6 +295,7 @@ fn main() -> Result<()> {
         br_train_steps_per_iteration: 1,
         payoff_eval_episodes: 1,
         max_payoff_evals_per_iteration,
+        br_reward_scale,
         seed: SEED,
     };
     let joint_config = JointTrainerConfig {
@@ -269,7 +305,9 @@ fn main() -> Result<()> {
         minibatch_size: 256,
         ..Default::default()
     };
-    let meta_solver: Box<dyn MetaSolver> = Box::new(AlphaRankMetaSolver::default());
+    let meta_solver: Box<dyn MetaSolver> = Box::new(
+        AlphaRankMetaSolver::default().with_payoff_span_normalization(alpha_rank_normalize_span),
+    );
 
     let policy_factory = move |dev: &burn::tensor::Device<InnerBackend>, seed: u64| {
         MultiDiscreteMlpBurnPolicy::<B>::new_seeded(

--- a/src/multi_agent/psro.rs
+++ b/src/multi_agent/psro.rs
@@ -399,10 +399,45 @@ pub struct AlphaRankMetaSolver {
     pub max_iterations: usize,
     /// Power-iteration L1 convergence tolerance.
     pub tolerance: f32,
+    /// When `true`, normalize each Moran payoff differential
+    /// `delta = π_τ − π_σ` by the **payoff span** of the input tensor
+    /// (`max − min` over all per-agent payoffs) before multiplying by α
+    /// (issue #215).
+    ///
+    /// # Why this matters
+    ///
+    /// The Moran fixation probability is driven by `α · delta` (see
+    /// [`moran_fixation_probability`]). α-rank's defaults
+    /// (`α = 10`, `m = 50`) were validated on the `{−1, +1}`
+    /// matching-pennies game, where `|delta| ≤ 2` and `α · delta ≤ 20`
+    /// — comfortably inside the regime where the fixation probability is
+    /// a graded sigmoid-like function of the payoff advantage. On the
+    /// bucket-brigade `[−700, 0]` payoff band, `|delta|` can reach ~700
+    /// and `α · delta ≈ 7000`, which **saturates** every non-neutral
+    /// transition to a hard 0 or 1. The graded Moran dynamics collapse
+    /// into a degenerate deterministic best-response graph, and the
+    /// resulting stationary distribution is acutely sensitive to tiny
+    /// payoff-estimate noise — a plausible contributor to the
+    /// exploitability *divergence* observed on the no-convergence cells
+    /// (issue #215, #198).
+    ///
+    /// When enabled, the differential is rescaled to
+    /// `delta_norm = delta / span` (with `span = max − min`, guarded
+    /// against a degenerate zero span), so the **effective** selection
+    /// strength `α · delta_norm` lands in the same `[−α, α]` band the
+    /// defaults were tuned for regardless of the absolute payoff
+    /// magnitude. This is the α-rank analogue of NFSP's / PSRO's
+    /// `br_reward_scale`: a magnitude-invariance fix, not a change to
+    /// the ranking semantics on a fixed scale.
+    ///
+    /// `false` (the default) preserves the pre-#215 behavior bit-for-bit.
+    pub normalize_payoff_span: bool,
 }
 
 impl AlphaRankMetaSolver {
-    /// Construct with explicit hyperparameters.
+    /// Construct with explicit hyperparameters. Payoff-span
+    /// normalization defaults to `false` (pre-#215 behavior). Use
+    /// [`AlphaRankMetaSolver::with_payoff_span_normalization`] to opt in.
     pub fn new(
         ranking_intensity_alpha: f32,
         moran_population_size: u32,
@@ -414,7 +449,16 @@ impl AlphaRankMetaSolver {
             moran_population_size: moran_population_size.max(2),
             max_iterations: max_iterations.max(1),
             tolerance: tolerance.max(1e-12),
+            normalize_payoff_span: false,
         }
+    }
+
+    /// Builder-style setter: enable/disable payoff-span normalization of
+    /// the Moran payoff differential (issue #215). See
+    /// [`AlphaRankMetaSolver::normalize_payoff_span`] for the rationale.
+    pub fn with_payoff_span_normalization(mut self, enabled: bool) -> Self {
+        self.normalize_payoff_span = enabled;
+        self
     }
 
     /// Inherent N-player α-rank stationary distribution helper.
@@ -499,6 +543,41 @@ impl AlphaRankMetaSolver {
             0.0
         };
 
+        // Optional payoff-span normalization (issue #215). When enabled,
+        // every Moran payoff differential is divided by the payoff span
+        // (`max − min` over all per-agent payoffs) so the effective
+        // selection strength `α · (delta / span)` stays in the `[−α, α]`
+        // band the defaults were tuned for, regardless of the absolute
+        // payoff magnitude. This prevents the fixation probability from
+        // saturating to a hard 0/1 on large-magnitude bands (e.g.
+        // bucket-brigade's `[−700, 0]`). `1.0` divisor (the default,
+        // normalization off — or a degenerate flat payoff tensor) is a
+        // no-op and keeps the path bit-identical.
+        let delta_divisor: f32 = if self.normalize_payoff_span {
+            let mut min_v = f32::INFINITY;
+            let mut max_v = f32::NEG_INFINITY;
+            for row in payoffs.iter() {
+                for &v in row.iter() {
+                    if v < min_v {
+                        min_v = v;
+                    }
+                    if v > max_v {
+                        max_v = v;
+                    }
+                }
+            }
+            let span = max_v - min_v;
+            // Guard against a flat / degenerate tensor: a zero (or
+            // non-finite) span leaves the differential untouched.
+            if span.is_finite() && span > 1e-12 {
+                span
+            } else {
+                1.0
+            }
+        } else {
+            1.0
+        };
+
         // Sparse-friendly transition rep: per-state out-edges as
         // `Vec<(to_index, prob)>`. With n_joint potentially in the
         // thousands and only `n_deviations` non-self entries per row,
@@ -524,7 +603,7 @@ impl AlphaRankMetaSolver {
                     let p_fix = moran_fixation_probability(
                         self.ranking_intensity_alpha,
                         self.moran_population_size,
-                        to_payoff_a - from_payoff_a,
+                        (to_payoff_a - from_payoff_a) / delta_divisor,
                     );
                     let edge_prob = per_dev_weight * p_fix;
                     row_edges.push((t, edge_prob));
@@ -586,6 +665,11 @@ impl AlphaRankMetaSolver {
 
 impl Default for AlphaRankMetaSolver {
     fn default() -> Self {
+        // Payoff-span normalization defaults OFF to keep the
+        // matching-pennies regression bar and the `solve` API
+        // bit-identical to the pre-#215 solver. Opt in via
+        // `with_payoff_span_normalization(true)` for large-magnitude
+        // payoff bands like bucket-brigade's `[−700, 0]`.
         Self::new(10.0, 50, 200, 1e-6)
     }
 }
@@ -896,6 +980,26 @@ pub struct PsroConfig {
     /// subsampling path is purely opt-in; existing callers and the
     /// determinism discipline (#201) are unaffected.
     pub max_payoff_evals_per_iteration: Option<usize>,
+    /// Optional reward scaling applied to per-step rewards before the
+    /// best-response (PPO) update, mirroring
+    /// [`NfspConfig::br_reward_scale`](crate::multi_agent::nfsp::NfspConfig::br_reward_scale)
+    /// (issue #199 / #215).
+    ///
+    /// PSRO trains each new best response with the same joint PPO update
+    /// as NFSP's BR side, so it inherits the same numerical pathology on
+    /// the large-magnitude bucket-brigade payoff band (`[−700, 0]`): the
+    /// unscaled rewards drive the critic's regression targets and the
+    /// per-minibatch advantage normalization into a range where the
+    /// value loss dominates the surrogate and the BR effectively stops
+    /// learning a meaningful response. Scaling rewards by a constant is
+    /// an affine transform of the return — it does **not** change the
+    /// optimal policy — but keeps the critic targets and advantage stats
+    /// numerically friendly. A value like `0.01` rescales the
+    /// bucket-brigade band to roughly `[−7, 0]`.
+    ///
+    /// `1.0` (the default) is a no-op and preserves the pre-#215
+    /// behavior bit-for-bit.
+    pub br_reward_scale: f32,
     /// RNG seed for opponent sampling and deterministic tests.
     pub seed: u64,
 }
@@ -908,6 +1012,7 @@ impl Default for PsroConfig {
             br_train_steps_per_iteration: 1,
             payoff_eval_episodes: 8,
             max_payoff_evals_per_iteration: None,
+            br_reward_scale: 1.0,
             seed: 0,
         }
     }
@@ -1806,8 +1911,25 @@ where
             env.reset_joint(Some(self.config.seed.wrapping_add(active_agent as u64)));
 
         let mut last_stats = JointStats::zeros(num_agents);
+        let reward_scale = self.config.br_reward_scale;
         for _ in 0..self.config.br_train_steps_per_iteration {
-            let rollout = trainer.collect_rollout(&mut env, &mut last_obs, &mut self.rng);
+            let mut rollout = trainer.collect_rollout(&mut env, &mut last_obs, &mut self.rng);
+            // Apply the optional BR reward scaling (issue #199 / #215)
+            // before the PPO update. Scaling rewards uniformly is an
+            // affine transform of the return and does not change the
+            // optimal policy, but keeps the large-magnitude
+            // bucket-brigade band (`[−700, 0]`) in a numerically
+            // friendlier range for the BR critic's regression targets
+            // and advantage statistics. `reward_scale == 1.0` (the
+            // default) leaves the rollout untouched, so the default path
+            // is bit-identical to the pre-#215 behavior.
+            if reward_scale != 1.0 {
+                for agent_rewards in rollout.rewards.iter_mut() {
+                    for r in agent_rewards.iter_mut() {
+                        *r *= reward_scale;
+                    }
+                }
+            }
             last_stats = trainer.update_with_active_agents(
                 &rollout,
                 &active_mask,
@@ -2359,6 +2481,114 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
+    // α-rank payoff-span normalization (issue #215)
+    // ------------------------------------------------------------------
+
+    /// Span normalization must be a strict no-op by default and bit-for-bit
+    /// identical on a non-degenerate matrix when explicitly disabled.
+    /// This is the regression bar guaranteeing the default α-rank path is
+    /// unchanged by #215.
+    #[test]
+    fn test_alpha_rank_span_normalization_default_off_is_bit_identical() {
+        use rand::{Rng, SeedableRng, rngs::StdRng};
+        for seed in 0..5_u64 {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let payoffs: Vec<Vec<f32>> = (0..4)
+                .map(|_| (0..4).map(|_| rng.random_range(-5.0..5.0_f32)).collect())
+                .collect();
+            let default_solver = AlphaRankMetaSolver::default();
+            let explicit_off = AlphaRankMetaSolver::default().with_payoff_span_normalization(false);
+            assert_eq!(
+                default_solver.solve(&payoffs),
+                explicit_off.solve(&payoffs),
+                "default solver must equal explicitly-disabled span normalization (seed {seed})"
+            );
+        }
+    }
+
+    /// Root-cause demonstration (issue #215): on a large-magnitude payoff
+    /// band the default α-rank fixation probability **saturates** — every
+    /// non-neutral Moran transition collapses to a hard 0/1 — and the
+    /// resulting stationary distribution stops tracking the strategy
+    /// ordering. Concretely, a strategy that strictly dominates at unit
+    /// scale (and is correctly identified there) is *no longer*
+    /// concentrated on once the same ordinal game is rescaled to the
+    /// `[−700, 0]` band: the saturated transition matrix degenerates and
+    /// the solve returns a near-uniform / wrong answer.
+    ///
+    /// Span normalization restores magnitude invariance: the rescaled
+    /// game produces (essentially) the same distribution as the unit-scale
+    /// game, so the dominant strategy is concentrated on regardless of the
+    /// absolute payoff magnitude. This is the mechanism behind the
+    /// observed exploitability *divergence* — the meta-solver's mixture
+    /// becomes magnitude-dependent and brittle on the large-payoff cells.
+    #[test]
+    fn test_alpha_rank_span_normalization_is_magnitude_invariant() {
+        // Same ordinal structure (strategy 0 strictly dominates), two
+        // magnitudes 350x apart.
+        let small = vec![vec![2.0_f32, -1.0], vec![1.0, -2.0]];
+        let large = vec![vec![700.0_f32, -350.0], vec![350.0, -700.0]];
+
+        // (a) At unit scale, the *unnormalized* default solver already
+        // correctly concentrates on the dominant strategy.
+        let plain = AlphaRankMetaSolver::default();
+        let plain_small = plain.solve(&small);
+        assert!(
+            plain_small[0] > 0.9,
+            "unit-scale α-rank should concentrate on dominant strategy 0, got {plain_small:?}"
+        );
+
+        // (b) At the [−700, 0] scale, the *unnormalized* solver loses the
+        // dominance signal entirely — the saturated Moran transitions
+        // degenerate and it returns a near-uniform (wrong) distribution.
+        let plain_large = plain.solve(&large);
+        assert!(
+            plain_large[0] < 0.6,
+            "unnormalized large-scale α-rank should LOSE the dominance signal \
+             (saturation bug, issue #215), got {plain_large:?}"
+        );
+
+        // (c) With span normalization the rescaled game recovers the same
+        // concentrated answer as the unit-scale game — magnitude
+        // invariance.
+        let norm = AlphaRankMetaSolver::default().with_payoff_span_normalization(true);
+        let dist_small = norm.solve(&small);
+        let dist_large = norm.solve(&large);
+        for i in 0..2 {
+            assert!(
+                (dist_small[i] - dist_large[i]).abs() < 1e-3,
+                "span-normalized α-rank should be magnitude-invariant: \
+                 small={dist_small:?} large={dist_large:?}"
+            );
+        }
+        assert!(
+            dist_large[0] > 0.9,
+            "span-normalized large-scale α-rank should concentrate on dominant strategy 0, \
+             got {dist_large:?}"
+        );
+    }
+
+    /// A flat / degenerate payoff tensor (zero span) must not divide by
+    /// zero under span normalization — the guard falls back to a unit
+    /// divisor, giving the uniform stationary distribution (no
+    /// strategy dominates).
+    #[test]
+    fn test_alpha_rank_span_normalization_handles_flat_payoffs() {
+        let flat = vec![vec![3.0_f32, 3.0], vec![3.0, 3.0]];
+        let norm = AlphaRankMetaSolver::default().with_payoff_span_normalization(true);
+        let dist = norm.solve(&flat);
+        let total: f32 = dist.iter().sum();
+        assert!((total - 1.0).abs() < 1e-4, "flat-payoff dist must be normalized, got {dist:?}");
+        for &p in &dist {
+            assert!(p.is_finite(), "flat-payoff dist must be finite, got {dist:?}");
+            assert!(
+                (p - 0.5).abs() < 1e-3,
+                "flat payoffs should give uniform stationary dist, got {dist:?}"
+            );
+        }
+    }
+
+    // ------------------------------------------------------------------
     // PayoffCache
     // ------------------------------------------------------------------
 
@@ -2493,6 +2723,7 @@ mod tests {
             br_train_steps_per_iteration: 2,
             payoff_eval_episodes: 4,
             max_payoff_evals_per_iteration: None,
+            br_reward_scale: 1.0,
             seed: 0,
         };
         let joint_config = JointTrainerConfig {
@@ -2840,6 +3071,7 @@ mod tests {
             br_train_steps_per_iteration: 2,
             payoff_eval_episodes: 4,
             max_payoff_evals_per_iteration: None,
+            br_reward_scale: 1.0,
             seed: 12345,
         };
         let joint_config = JointTrainerConfig {
@@ -2930,6 +3162,7 @@ mod tests {
             br_train_steps_per_iteration: 2,
             payoff_eval_episodes: 4,
             max_payoff_evals_per_iteration: None,
+            br_reward_scale: 1.0,
             seed: 0xC0FF_EE12,
         };
         let joint_config = JointTrainerConfig {

--- a/src/multi_agent/psro.rs
+++ b/src/multi_agent/psro.rs
@@ -407,7 +407,7 @@ pub struct AlphaRankMetaSolver {
     /// # Why this matters
     ///
     /// The Moran fixation probability is driven by `α · delta` (see
-    /// [`moran_fixation_probability`]). α-rank's defaults
+    /// `moran_fixation_probability`). α-rank's defaults
     /// (`α = 10`, `m = 50`) were validated on the `{−1, +1}`
     /// matching-pennies game, where `|delta| ≤ 2` and `α · delta ≤ 20`
     /// — comfortably inside the regime where the fixation probability is

--- a/tests/test_psro_bucket_brigade.rs
+++ b/tests/test_psro_bucket_brigade.rs
@@ -375,6 +375,7 @@ fn test_psro_beats_ppo_on_no_convergence_cells() {
             // already a stable estimate.
             payoff_eval_episodes: 1,
             max_payoff_evals_per_iteration: None,
+            br_reward_scale: 1.0,
             seed: SEED.wrapping_add(cell_idx as u64),
         };
         let joint_config = JointTrainerConfig {

--- a/tests/test_psro_matching_pennies.rs
+++ b/tests/test_psro_matching_pennies.rs
@@ -90,6 +90,7 @@ fn psro_matching_pennies_smoke_runs_and_is_finite() {
         br_train_steps_per_iteration: 1,
         payoff_eval_episodes: 1,
         max_payoff_evals_per_iteration: None,
+        br_reward_scale: 1.0,
         seed: 17,
     };
     let joint_config = JointTrainerConfig {
@@ -168,6 +169,7 @@ fn test_psro_converges_to_uniform_on_matching_pennies() {
         br_train_steps_per_iteration: 1,
         payoff_eval_episodes: 2,
         max_payoff_evals_per_iteration: None,
+        br_reward_scale: 1.0,
         seed: 17,
     };
     let joint_config = JointTrainerConfig {
@@ -299,6 +301,7 @@ fn test_psro_exploitability_non_increasing_trend_on_matching_pennies() {
             br_train_steps_per_iteration: 2,
             payoff_eval_episodes: 4,
             max_payoff_evals_per_iteration: None,
+            br_reward_scale: 1.0,
             seed,
         };
         let mut trainer = PsroTrainer::new(

--- a/tests/test_psro_n_player_matching_pennies.rs
+++ b/tests/test_psro_n_player_matching_pennies.rs
@@ -132,6 +132,32 @@ fn run_psro_n4(
     >,
     PsroStats,
 ) {
+    run_psro_n4_cfg(max_iterations, seed, 1.0, false)
+}
+
+/// Generalized N=4 PSRO runner exposing the issue-#215 knobs:
+/// `br_reward_scale` (BR PPO reward scaling, mirroring NFSP) and
+/// `alpha_rank_span_norm` (α-rank payoff-span normalization). The
+/// `run_psro_n4` shim above pins both to their defaults so the existing
+/// tests are unchanged.
+#[allow(clippy::type_complexity)]
+fn run_psro_n4_cfg(
+    max_iterations: usize,
+    seed: u64,
+    br_reward_scale: f32,
+    alpha_rank_span_norm: bool,
+) -> (
+    PsroTrainer<
+        B,
+        MlpBurnPolicy<B>,
+        Opt,
+        NPlayerMatchingPennies,
+        impl Fn(&NdArrayDevice, u64) -> MlpBurnPolicy<B>,
+        impl Fn() -> BurnOptimizer<B, MlpBurnPolicy<B>, Opt>,
+        impl Fn() -> NPlayerMatchingPennies,
+    >,
+    PsroStats,
+) {
     let num_agents = 4_usize;
     let device: NdArrayDevice = Default::default();
     let psro_config = PsroConfig {
@@ -140,6 +166,7 @@ fn run_psro_n4(
         br_train_steps_per_iteration: 1,
         payoff_eval_episodes: 1,
         max_payoff_evals_per_iteration: None,
+        br_reward_scale,
         seed,
     };
     let joint_config = JointTrainerConfig {
@@ -149,7 +176,9 @@ fn run_psro_n4(
         minibatch_size: 32,
         ..Default::default()
     };
-    let meta_solver: Box<dyn MetaSolver> = Box::new(AlphaRankMetaSolver::default());
+    let meta_solver: Box<dyn MetaSolver> = Box::new(
+        AlphaRankMetaSolver::default().with_payoff_span_normalization(alpha_rank_span_norm),
+    );
 
     let mut trainer = PsroTrainer::new(
         psro_config,
@@ -246,6 +275,52 @@ fn psro_n4_smoke_runs_and_is_finite() {
             (sum - 1.0).abs() <= 1e-3,
             "agent {agent} marginal must sum to ~1, got {sum} on {marginal:?}"
         );
+    }
+}
+
+/// Issue #215 fast smoke: the two new knobs — BR reward scaling and
+/// α-rank payoff-span normalization — must drive a tiny-budget N=4 PSRO
+/// run end-to-end and produce FINITE, non-negative NashConv with valid
+/// per-agent simplex marginals, exactly like the default-config smoke
+/// test. This guards the plumbing of both knobs through the trainer (the
+/// `train_best_response` reward-scaling path and the
+/// `solve_n_player` span-normalized α-rank path) on every CI run, while
+/// the decisive *mechanistic* evidence for the span-normalization fix
+/// lives in the unit tests `test_alpha_rank_span_normalization_*` in
+/// `src/multi_agent/psro.rs`.
+#[test]
+fn psro_n4_issue215_knobs_run_and_are_finite() {
+    let max_iterations = 2_usize;
+    // Non-default values for BOTH knobs: rewards rescaled 100x down and
+    // α-rank span normalization on.
+    let (_trainer, stats) = run_psro_n4_cfg(max_iterations, 19, 0.01, true);
+
+    assert_eq!(
+        stats.iterations.len(),
+        max_iterations,
+        "smoke run should record {max_iterations} iterations"
+    );
+    for it in &stats.iterations {
+        assert!(
+            it.exploitability.is_finite(),
+            "NashConv must be finite, got {}",
+            it.exploitability
+        );
+        assert!(
+            it.exploitability >= 0.0,
+            "NashConv must be non-negative, got {}",
+            it.exploitability
+        );
+        for marginal in &it.meta_nash_per_agent {
+            let sum: f32 = marginal.iter().sum();
+            assert!(
+                (sum - 1.0).abs() <= 1e-3,
+                "per-agent meta-Nash marginal must sum to ~1, got {sum} on {marginal:?}"
+            );
+            for &p in marginal {
+                assert!(p.is_finite() && p >= -1e-6, "marginal entry must be valid, got {p}");
+            }
+        }
     }
 }
 

--- a/tests/test_seeded_reproducibility.rs
+++ b/tests/test_seeded_reproducibility.rs
@@ -42,6 +42,7 @@ fn psro_exploitability_trace(seed: u64) -> Vec<f32> {
         br_train_steps_per_iteration: 2,
         payoff_eval_episodes: 4,
         max_payoff_evals_per_iteration: None,
+        br_reward_scale: 1.0,
         seed,
     };
     let joint_config = JointTrainerConfig {


### PR DESCRIPTION
## Summary

Root-causes the PSRO exploitability **divergence** on the bucket-brigade
no-convergence cells (issue #215, blocker #1) and lands two code-level,
default-off magnitude fixes. Same root-cause family as the NFSP work in #199.

The divergence is driven by the `[−700, 0]` payoff band being ~3 orders of
magnitude larger than the `{−1, +1}` matching-pennies game both PSRO halves were
validated on:

1. **α-rank meta-solver saturates.** Its Moran fixation probability is driven by
   `α·δ`; on the `[−700, 0]` band `α·δ ≈ 7000` (vs the `≤ 20` it was tuned for),
   so every non-neutral transition collapses to a hard 0/1 and the meta-solver
   becomes a brittle hard-max whose stationary distribution flips on tiny
   payoff-estimate noise — a direct mechanism for *increasing* exploitability.
2. **BR critic blows up** on the unscaled band (the identical pathology #199
   measured on the NFSP BR side).

## Changes

- **`AlphaRankMetaSolver::normalize_payoff_span: bool`** (builder
  `with_payoff_span_normalization`): divides the Moran payoff differential by the
  payoff span so `α·(δ/span)` stays in the validated `[−α, α]` regime regardless
  of absolute magnitude. Degenerate zero-span falls back to a unit divisor.
  **Default off = bit-identical** to the pre-#215 solver.
- **`PsroConfig::br_reward_scale: f32`**: uniform reward scaling on the BR rollout
  rewards before the joint PPO update, mirroring `NfspConfig::br_reward_scale`
  (#199). Affine transform of the return (optimal policy unchanged). **Default
  1.0 = bit-identical no-op.**
- **Example** (`train_psro.rs`): new `BR_REWARD_SCALE` / `ALPHA_RANK_NORMALIZE_SPAN`
  env knobs, logged at startup. Per-iteration exploitability is already logged
  live via the `on_iteration` callback (#202).
- **Docs**: new `docs/research/2026-06-psro-alpha-rank-payoff-magnitude.md`
  (root-cause analysis + local evidence), cross-linked from the #134 validation
  doc and the #199 writeup.
- Test config literals updated for the new required fields (forced by the struct
  change).

## Acceptance Criteria Verification

| Criterion (from #215) | Status | Verification |
|-----------------------|--------|--------------|
| Root-cause the exploitability divergence (α-rank scaling vs BR under-training vs reward scaling), documented | ✅ | `docs/research/2026-06-psro-alpha-rank-payoff-magnitude.md`: α-rank fixation-probability saturation (decisive, PSRO-specific) + BR critic blow-up (shared with #199), each with measured evidence |
| A configuration where exploitability *decreases* over iterations (or a documented finding it is unsuited) | ✅ (local-scale) | Local 3-iter `beta01`: baseline `6412→7003→6447` (non-monotone) vs both knobs `8364→7613→5345` (**monotonically decreasing**). Documented `gap_closed_cell` caveat. Full converged cluster run gated on #134 |
| Bound the α-rank-solve cost (blocker #2) | ⏸️ gated | Per #215, explicitly gated on convergence being established first — **not** done here; a proposed sparse/iterative or response-graph-cap approach is sketched in the doc |

## Test Plan

- `cargo build --features training` — clean.
- `cargo test --features training --lib multi_agent::psro` — 36 pass, incl. new
  `test_alpha_rank_span_normalization_{is_magnitude_invariant,default_off_is_bit_identical,handles_flat_payoffs}`.
- `cargo test --features training --test test_psro_n_player_matching_pennies` —
  fast smoke + new `psro_n4_issue215_knobs_run_and_are_finite` pass; heavy
  convergence tests `#[ignore]`d (#208/#209).
- `cargo test --features training --test test_seeded_reproducibility` —
  `test_psro_exploitability_trace_is_bit_identical` passes (default path unchanged).
- `cargo clippy --all-targets --features training -- -D warnings` (the CI gate) — clean.
- `cargo fmt` — clean.

### Local-scale evidence (not cluster-gated)

`AlphaRankMetaSolver` magnitude-invariance unit test: a strictly-dominant strategy
the unnormalized solver correctly concentrates on at unit scale (>0.9) degrades to
≈uniform (<0.6) at the `±700` scale; span normalization recovers >0.9. Plus the
real-env 3-iter trend comparison above.

## Notes for the reviewer

- **Remaining work gated on #134**: a documented PSRO run with *decreasing
  exploitability to a competitive `gap_closed_cell`* at a meaningful (cluster)
  budget. The local 3-iter/128-rollout run is an observability check, not a
  converged result; the BR side barely trains at that micro-budget (the deeper,
  #199-shared question).
- **α-rank perf (blocker #2) gated on convergence** per #215 — intentionally not
  optimized here.
- **Pre-existing, out-of-scope clippy**: `cargo clippy --features
  "training,env-bucket-brigade"` fails on `src/env/games/bucket_brigade/env.rs:213`
  (`iter_cloned_collect`), last touched in #126 — unrelated to this PR and not in
  the CI-gated feature set (`--features training`). Left untouched per scope
  discipline; worth a separate cleanup issue.

Closes #215