### PR TITLE
test(nfsp): gate heavy in-trainer η-mixing concentration test behind #[ignore]

### DIFF
--- a/src/multi_agent/nfsp.rs
+++ b/src/multi_agent/nfsp.rs
@@ -1379,7 +1379,87 @@ mod tests {
         assert_eq!(trainer.cumulative_br_pushes(), 128);
     }
 
+    /// Fast always-on smoke for the in-trainer η-mixing wiring. Drives a
+    /// single iteration with η = 0.5 over a *small* rollout and asserts
+    /// directionality: the BR path actually pushes to the reservoir and the
+    /// empirical BR-fraction lands in a loose-but-non-vacuous band around η.
+    ///
+    /// This keeps default-lane coverage of the trainer-side η flip while the
+    /// rigorous statistical-concentration proof
+    /// (`test_nfsp_eta_mixing_rate_concentration_in_trainer`) is `#[ignore]`d
+    /// per the #208/#209 convention — its 4096-step rollout costs ~11 min in
+    /// the default debug test lane and dominated CI Tests jobs (#224).
     #[test]
+    fn test_nfsp_eta_mixing_rate_smoke_in_trainer() {
+        let device: NdArrayDevice = Default::default();
+        let eta = 0.5f32;
+        // Small rollout: enough flips to expect both paths to fire, cheap
+        // enough to finish in well under a second in debug.
+        let rollout_steps = 256usize;
+        let nfsp_config = NfspConfig {
+            max_iterations: 1,
+            anticipatory_param: eta,
+            reservoir_capacity: 100_000,
+            br_train_steps_per_iteration: 1,
+            avg_policy_train_steps_per_iteration: 0,
+            avg_policy_minibatch_size: 32,
+            avg_policy_lr: 1e-3,
+            avg_policy_min_reservoir_coverage: 0.0,
+            br_reward_scale: 1.0,
+            seed: 7,
+        };
+        let joint_config = JointTrainerConfig {
+            num_agents: 2,
+            rollout_steps,
+            n_epochs: 1,
+            minibatch_size: 32,
+            ..Default::default()
+        };
+        let mut trainer = NfspTrainer::new(
+            nfsp_config,
+            joint_config,
+            device,
+            |dev: &NdArrayDevice, seed: u64| {
+                MlpBurnPolicy::<B>::new_seeded(
+                    MatchingPennies::OBS_DIM,
+                    MatchingPennies::ACTION_DIM,
+                    16,
+                    seed,
+                    dev,
+                )
+            },
+            || BurnOptimizer::new(AdamConfig::new().init(), 1e-3),
+            MatchingPennies::new,
+        )
+        .expect("NfspTrainer::new should succeed");
+        let _ = trainer.run_silent().expect("NFSP run should not error");
+        let br_pushes = trainer.cumulative_br_pushes() as f64;
+        let total_steps = (rollout_steps * 2) as f64;
+        let p_emp = br_pushes / total_steps;
+        // Directionality, not concentration: with η = 0.5 over 512 flips the
+        // empirical BR-fraction is overwhelmingly inside [0.25, 0.75]. Also
+        // require that the BR path fired at all (the wiring is live).
+        assert!(
+            br_pushes > 0.0,
+            "η-mixing BR path must push to the reservoir (br_pushes={br_pushes})"
+        );
+        assert!(
+            (0.25..=0.75).contains(&p_emp),
+            "η-mixing BR-fraction should be near 0.5: p_emp={p_emp:.4}"
+        );
+    }
+
+    /// Rigorous statistical-concentration proof for the in-trainer η flip:
+    /// a single iteration with η = 0.1 over a large rollout, asserting the
+    /// empirical BR-fraction across the 2 agents is within ~4σ of 0.1.
+    ///
+    /// `#[ignore]`d per the #208/#209 convention: the 4096-step rollout costs
+    /// ~11 min in the default debug test lane and dominated CI Tests jobs
+    /// (#224). The fast `test_nfsp_eta_mixing_rate_smoke_in_trainer` keeps
+    /// always-on coverage of the wiring; run this full proof on demand with
+    /// `cargo test --features training -- --ignored` (prefer `--release`).
+    #[test]
+    #[ignore = "multi-iteration NFSP η-mixing concentration run; opt in with --ignored (prefer --release)"]
     fn test_nfsp_eta_mixing_rate_concentration_in_trainer() {
         // Drive a single iteration with η = 0.1 over a large rollout
         // and check the empirical BR-fraction across the 2 agents is


### PR DESCRIPTION
## Summary

The default `cargo test --features training` nfsp lib lane was ~824s (~13.7 min), almost entirely consumed by one heavy statistical-concentration test, dominating CI Tests jobs (#224). This gates that test behind `#[ignore]` per the #208/#209 convention and adds a fast always-on smoke so the mechanism keeps default-lane coverage.

## Approach: (B) `#[ignore]` the heavy proof + add a fast always-on smoke

I chose approach **B** (gate + smoke). But the heavy test was **not** the one the issue named.

**Measurement (debug, NdArray CPU — same mode CI runs):**

| Test | Time |
|------|------|
| `test_nfsp_multi_discrete_ap_loss_drops_below_uniform_floor` (named in #224) | **~1.5s** — already fast |
| `test_nfsp_eta_mixing_rate_concentration_in_trainer` (pre-existing, from #110) | **~671s** — the real bottleneck |
| full `multi_agent::nfsp` lib suite (before) | **~824s** |

The test #224 named (`..._ap_loss_drops_below_uniform_floor`) runs in ~1.5s and already provides meaningful, fast always-on coverage of the adaptive AP-coverage mechanism — so it needs no change and is left untouched. The actual ~11 min cost is `test_nfsp_eta_mixing_rate_concentration_in_trainer`: a single iteration over a **4096-step** rollout asserting the empirical BR-fraction is within 4σ of η. That is exactly the heavy statistical-convergence category #208/#209 targets, so this PR gates it.

## Changes

- `#[ignore]` the full 4096-step η-mixing concentration proof **verbatim** (budget and 4σ bound unchanged), with the standard reason string `"multi-iteration NFSP η-mixing concentration run; opt in with --ignored (prefer --release)"`. Still runnable via `cargo test --features training -- --ignored`.
- Add a fast always-on smoke `test_nfsp_eta_mixing_rate_smoke_in_trainer` (256-step rollout, η=0.5) asserting **directionality**, not concentration: the BR path actually pushes to the reservoir and the empirical BR-fraction lands in a loose-but-non-vacuous `[0.25, 0.75]` band around η. Runs in ~3.4s.

## Before / after timing (full `multi_agent::nfsp` lib suite, debug)

- **Before:** ~824s (19 passed) — 671s in the η-mixing concentration test alone.
- **After:** **~17s** (19 passed, **1 ignored**) — a ~48x reduction in the default lane.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Default `cargo test --features training` nfsp lane fast again | ✅ | 824s -> 17s |
| Rigorous proof preserved, not deleted | ✅ | Full 4096-step / 4σ test kept verbatim, only `#[ignore]` added |
| Rigorous proof still runnable | ✅ | `cargo test --features training -- --ignored` passes (1 passed) |
| Always-on coverage of the mechanism kept (non-vacuous) | ✅ | New smoke asserts BR-path pushes + BR-fraction in [0.25,0.75] around η |
| Matches #208/#209 `#[ignore]` style/reason-string convention | ✅ | Reason string mirrors the existing matching-pennies gated tests |
| clippy clean | ✅ | `cargo clippy --all-targets --features training -- -D warnings` passes |
| `cargo fmt` clean | ✅ | Ran `cargo fmt` |

## Test Plan

- `cargo test --features training --lib multi_agent::nfsp` — 19 passed, 1 ignored, finished in 16.98s.
- `cargo test --features training --lib test_nfsp_eta_mixing_rate_smoke_in_trainer` — passes in ~3.4s.
- `cargo test --features training --lib test_nfsp_eta_mixing_rate_concentration_in_trainer -- --ignored` — 1 passed (rigorous proof intact).
- `cargo clippy --all-targets --features training -- -D warnings` — clean.

Closes #224