### PR TITLE
docs(nfsp): correct stale 3σ comment to 4σ in eta-mixing concentration test

### DIFF
--- a/src/multi_agent/nfsp.rs
+++ b/src/multi_agent/nfsp.rs
@@ -1463,7 +1463,7 @@ mod tests {
     fn test_nfsp_eta_mixing_rate_concentration_in_trainer() {
         // Drive a single iteration with η = 0.1 over a large rollout
         // and check the empirical BR-fraction across the 2 agents is
-        // within ~3σ of 0.1.
+        // within ~4σ of 0.1.
         let device: NdArrayDevice = Default::default();
         let eta = 0.1f32;
         let rollout_steps = 4096usize;


### PR DESCRIPTION
## Summary
Comment-only fix. The inline body comment in `test_nfsp_eta_mixing_rate_concentration_in_trainer` (`src/multi_agent/nfsp.rs`) said the empirical BR-fraction is checked "within ~3σ of 0.1", but the assertion uses `let tol = 4.0 * std; // 4σ for resilience to the small N`. The test's doc comment already correctly says "~4σ". This brings the inline comment in line with the existing 4σ assertion.

## Changes
- `src/multi_agent/nfsp.rs`: update the single inline comment from "within ~3σ of 0.1" to "within ~4σ of 0.1". No code or assertion changes.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Update stale "~3σ" comment to "~4σ" to match the assertion | ✅ | One-line edit at line 1466; `git diff` shows only the comment text changed |
| No code or assertion changes | ✅ | Diff is +1/-1, comment-only; assertion `tol = 4.0 * std` left verbatim |
| No other stale "3σ" references in this test | ✅ | `grep` for "3σ" — remaining hits (lines 1058, 1154) are in different tests (`test_eta_anticipatory_mixing_rate_concentration` genuinely uses 3σ; another uses "~3 SEM"), left untouched |

## Test Plan
- `cargo build --features training` — passes
- `cargo test --features training --lib --no-run` — compiles (the test is `#[ignore]`d per #224; full proof run takes ~11min, skipped given comment-only change)
- `cargo clippy --all-targets --features training -- -D warnings` — clean
- `cargo fmt -- --check` — clean

Closes #227