### PR TITLE
fix: clear env-bucket-brigade clippy lints and gate them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
         run: cargo fmt -- --check
 
   # Lint with clippy, denying all warnings, across the full training build
-  # (lib, tests, examples). Keeps clippy debt from accumulating silently.
+  # (lib, tests, examples) and the env-bucket-brigade feature combo. Keeps
+  # clippy debt from accumulating silently on either feature set.
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -42,6 +43,12 @@ jobs:
           components: clippy
       - name: cargo clippy --all-targets --features training -- -D warnings
         run: cargo clippy --all-targets --features training -- -D warnings
+      # Also lint the optional env-bucket-brigade feature, which pulls in the
+      # bucket-brigade-core submodule (initialised by submodules: recursive
+      # above). Keeps this feature combo's clippy debt from accumulating
+      # silently the way the base gate does for `training`.
+      - name: cargo clippy --all-targets --features "training,env-bucket-brigade" -- -D warnings
+        run: cargo clippy --all-targets --features "training,env-bucket-brigade" -- -D warnings
 
   # Cheap "does it parse" check without the training stack.
   # `--no-default-features` drops the `training` feature (and thus `burn`).

--- a/examples/games/bucket_brigade/train_nfsp.rs
+++ b/examples/games/bucket_brigade/train_nfsp.rs
@@ -257,7 +257,7 @@ fn main() -> Result<()> {
     >::new(
         nfsp_config,
         joint_config,
-        device.clone(),
+        device,
         policy_factory,
         optimizer_factory,
         env_factory,

--- a/examples/games/bucket_brigade/train_psro.rs
+++ b/examples/games/bucket_brigade/train_psro.rs
@@ -336,7 +336,7 @@ fn main() -> Result<()> {
         psro_config,
         joint_config,
         meta_solver,
-        device.clone(),
+        device,
         policy_factory,
         optimizer_factory,
         env_factory,

--- a/src/env/games/bucket_brigade/env.rs
+++ b/src/env/games/bucket_brigade/env.rs
@@ -210,7 +210,7 @@ impl BucketBrigadeMaEnv {
             actions.len()
         );
 
-        let rust_actions: Vec<Action> = actions.iter().copied().collect();
+        let rust_actions: Vec<Action> = actions.to_vec();
         let result = self.inner.step(&rust_actions);
 
         let observations = self.collect_observations();

--- a/tests/test_nfsp_bucket_brigade.rs
+++ b/tests/test_nfsp_bucket_brigade.rs
@@ -152,8 +152,7 @@ where
         // training-time rollout protocol and is what the workshop
         // paper's `gap_closed` baseline is computed against.
         let mut joint_actions: Vec<Vec<i64>> = Vec::with_capacity(NUM_AGENTS);
-        for i in 0..NUM_AGENTS {
-            let obs_row = &last_obs[i];
+        for (i, obs_row) in last_obs.iter().enumerate().take(NUM_AGENTS) {
             assert_eq!(obs_row.len(), obs_dim);
             let obs_tensor =
                 Tensor::<B, 2>::from_data(TensorData::new(obs_row.clone(), [1, obs_dim]), device);
@@ -309,7 +308,7 @@ fn test_nfsp_beats_ppo_on_canonical_no_convergence_cell() {
     >::new(
         nfsp_config,
         joint_config,
-        device.clone(),
+        device,
         policy_factory,
         optimizer_factory,
         env_factory,

--- a/tests/test_psro_bucket_brigade.rs
+++ b/tests/test_psro_bucket_brigade.rs
@@ -236,8 +236,7 @@ where
         // the protocol the workshop paper's `gap_closed` baseline is
         // computed against.
         let mut joint_actions: Vec<Vec<i64>> = Vec::with_capacity(NUM_AGENTS);
-        for i in 0..NUM_AGENTS {
-            let obs_row = &last_obs[i];
+        for (i, obs_row) in last_obs.iter().enumerate().take(NUM_AGENTS) {
             assert_eq!(obs_row.len(), obs_dim);
             let obs_tensor =
                 Tensor::<B, 2>::from_data(TensorData::new(obs_row.clone(), [1, obs_dim]), device);
@@ -422,7 +421,7 @@ fn test_psro_beats_ppo_on_no_convergence_cells() {
             psro_config,
             joint_config,
             meta_solver,
-            device.clone(),
+            device,
             policy_factory,
             optimizer_factory,
             env_factory,


### PR DESCRIPTION
## Summary

The CI clippy gate added in #217 only ran `cargo clippy --all-targets --features training -- -D warnings`, leaving the optional `env-bucket-brigade` feature combo uncovered — and that combo was red. This PR fixes every clippy lint that surfaces under `training,env-bucket-brigade` and extends the CI clippy job to lint that combo so the debt can't silently re-accumulate.

## Changes

### Lints fixed (all under `-D warnings`)
- `iter_cloned_collect` — `actions.iter().copied().collect()` -> `actions.to_vec()` in `src/env/games/bucket_brigade/env.rs` (the original error from the issue).
- `clone_on_copy` — `device.clone()` -> `device` on the `Copy` `NdArrayDevice` in `examples/games/bucket_brigade/train_nfsp.rs`, `examples/games/bucket_brigade/train_psro.rs`, `tests/test_nfsp_bucket_brigade.rs`, and `tests/test_psro_bucket_brigade.rs`. `device` is still used after each call site, so it's a copy (not a move).
- `needless_range_loop` — `for i in 0..NUM_AGENTS { let obs_row = &last_obs[i]; ... }` -> `for (i, obs_row) in last_obs.iter().enumerate().take(NUM_AGENTS)` in `tests/test_nfsp_bucket_brigade.rs` and `tests/test_psro_bucket_brigade.rs`. `i` is retained because the loop also calls `policies(i)`.

(clippy surfaces lints progressively per compiling target, so the example/test lints only appeared once the lib lint was fixed — hence more than the single error quoted in the issue.)

### CI
- Added a second step to the existing `clippy` job: `cargo clippy --all-targets --features "training,env-bucket-brigade" -- -D warnings`.
- No new submodule handling needed: the `clippy` job already checks out with `submodules: recursive`, which initialises `bucket-brigade-core` so the feature compiles. Updated the job's doc comment to note the broader coverage.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `cargo clippy --all-targets --features "training,env-bucket-brigade" -- -D warnings` exits 0 | done | Ran locally in the worktree, exit code 0 |
| CI clippy job covers the env-bucket-brigade combo and passes | done | Added the step to the `clippy` job (already has `submodules: recursive`); YAML validated with `yaml.safe_load` |

## Test Plan

Verified locally in the worktree:
- `cargo clippy --all-targets --features "training,env-bucket-brigade" -- -D warnings` -> exit 0
- `cargo clippy --all-targets --features training -- -D warnings` (the original gate) -> still exit 0
- `cargo fmt -- --check` -> clean

Closes #229