### PR TITLE
feat: add off-by-default blas-threaded feature for threaded NdArray matmul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,17 @@ crate-type = ["cdylib", "rlib"]
 # GPU backends.
 burn = { version = "0.21", default-features = false, features = ["std", "ndarray", "autodiff"], optional = true }
 
+# Direct handle on the NdArray backend crate that `burn` already pulls in. The
+# `burn` umbrella crate re-exports the BLAS backends (`accelerate`/`openblas`/
+# ...) but does NOT re-export the pure-Rust `multi-threads` feature, which is the
+# only threaded-matmul option that needs no system BLAS library. We declare the
+# crate here (same version, off by default) purely so the `blas-threaded`
+# feature can flip `burn-ndarray/multi-threads` on. Cargo unifies features
+# across the two dependency paths, so this toggles threading on the *same*
+# compiled `NdArray` backend the rest of the code already uses via
+# `burn::backend::NdArray` — no source changes required.
+burn-ndarray = { version = "0.21", default-features = false, optional = true }
+
 # Async runtime for vectorization (not available in WASM)
 tokio = { version = "1", features = ["full", "rt-multi-thread"], optional = true }
 
@@ -125,6 +136,24 @@ default = ["training"]
 # without any external system libraries. GPU backends are opt-in via
 # additional feature flags below.
 training = ["dep:burn", "tokio", "rayon", "tracing", "tracing-subscriber", "crossbeam-channel", "chrono"]
+# Threaded matmul for the CPU NdArray backend (OFF by default). Enables
+# `burn-ndarray/multi-threads`, which turns on `matrixmultiply/threading` +
+# `ndarray/rayon` — both PURE RUST (matrixmultiply pulls in `thread-tree` +
+# `num_cpus`). No system BLAS library is required, so this links cleanly on a
+# bare Ubuntu 24.04 node (no apt install) as well as macOS. Intended for the
+# batched phases: the PPO update (src/multi_agent/joint.rs) and the average-
+# policy supervised training (src/multi_agent/nfsp.rs), where matmuls are large
+# enough to amortize thread dispatch.
+#
+# Compose with `training`, e.g. `--features "training,blas-threaded"`. Tune the
+# worker count with RAYON_NUM_THREADS / matrixmultiply's pool sizing.
+#
+# REPRODUCIBILITY CAVEAT: threaded matmul changes the order of floating-point
+# reductions, so bit-exact results may differ run-to-run and from the single-
+# threaded path. CI and the default build stay on the deterministic pure-Rust
+# single-threaded path; only enable this for throughput-oriented runs where
+# bit-reproducibility is not required.
+blas-threaded = ["dep:burn-ndarray", "burn-ndarray/multi-threads"]
 # Burn wgpu backend — cross-platform GPU (Vulkan/Metal/DX12/WebGPU).
 # Compose with `training`, e.g. `--features "training,wgpu"`.
 wgpu = ["burn?/wgpu"]


### PR DESCRIPTION
## Summary

Adds an **off-by-default** cargo feature, `blas-threaded`, that enables a threaded matmul path for Burn's CPU `NdArray` backend. The goal (per #233) is to let the batched phases — the PPO update (`src/multi_agent/joint.rs:710-851`) and average-policy supervised training (`src/multi_agent/nfsp.rs:957-964`) — spread their large matmuls across multiple cores, while leaving the default build single-threaded and bit-deterministic for CI.

## Which feature, and why

Investigation of the pinned Burn 0.21 (`cargo metadata` on `burn-ndarray` 0.21.0) showed these matmul-threading options:

| `burn-ndarray` feature | Mechanism | System lib needed? |
|---|---|---|
| `multi-threads` | `matrixmultiply/threading` + `ndarray/rayon` (pure Rust) | **No** |
| `blas-openblas` | vendored openblas-src (builds from source) | needs a Fortran toolchain to build |
| `blas-accelerate` | macOS Accelerate framework | macOS only |
| `blas-netlib` / `blas-openblas-system` | system BLAS | yes (apt) |

I chose **`multi-threads`** because it is the only fully pure-Rust option: `matrixmultiply 0.3.10`'s `threading` feature pulls in `thread-tree` + `num_cpus` and `ndarray/rayon` uses the existing rayon dep. It links with **no system BLAS library**, so it works on a bare Ubuntu 24.04 alc node (no apt install) and on macOS, exactly as the issue prefers.

The `burn` umbrella crate re-exports the BLAS backends but **not** `multi-threads`, so `burn-ndarray` is added as a direct optional dependency at the same pinned version. Cargo unifies features across the two paths, so the flag toggles threading on the *same* compiled `NdArray` backend already used via `burn::backend::NdArray` — **no source changes required**.

## Changes

- `Cargo.toml`: add `burn-ndarray = { version = "0.21", default-features = false, optional = true }` (direct handle, off by default).
- `Cargo.toml`: add `blas-threaded = ["dep:burn-ndarray", "burn-ndarray/multi-threads"]`, off by default, with inline docs covering the no-system-lib property and the reproducibility caveat.

## How to enable

```bash
cargo build --release --features "training,blas-threaded"
# Tune workers with RAYON_NUM_THREADS (and matrixmultiply's pool sizing).
```

## Reproducibility caveat

Threaded matmul changes the order of floating-point reductions, so bit-exact results may differ run-to-run and from the single-threaded path. **CI and the default build stay on the deterministic pure-Rust single-threaded path.** The feature is intended only for throughput-oriented runs where bit-reproducibility is not required.

## Measured effect

`feature-resolution` proof (`cargo tree -e features`):
- default `training`: `matrixmultiply` present, `threading` **not** enabled (single-threaded).
- `training,blas-threaded`: `matrixmultiply feature "threading"` **enabled**.

Microbench on a 28-core host (1024×1024 f32 matmul ×30, `/usr/bin/time -l`):

| Config | wall | user CPU | sys CPU | total CPU | CPU/wall |
|---|---|---|---|---|---|
| single-threaded (default) | 0.96s | 0.64s | 0.01s | 0.65s | ~0.68 (1 core) |
| `blas-threaded` | 1.20s | 1.48s | 0.41s | 1.89s | **~1.58 (>1 core)** |

Checksums identical across both. The >1-core utilization (the acceptance criterion) is unambiguous. On this tiny all-ones workload the dispatch overhead slightly exceeds the gain; real PPO/AP batches with mixed data amortize it better. (The microbench was run from a throwaway example that is not committed.)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| A cargo feature enabling a threaded matmul/BLAS NdArray backend, off by default | ✅ | `blas-threaded` added; `default = ["training"]` does not include it; `cargo tree` confirms threading off by default |
| With the feature on, batched PPO/AP phases use >1 core | ✅ | Microbench: CPU/wall ratio ~1.58 with feature vs ~0.68 without; threading flips on the same `NdArray` backend used by joint.rs/nfsp.rs |
| CI default (pure-Rust) unchanged and still deterministic | ✅ | Default `cargo build`/`cargo test --features training` pass incl. bit-identical reproducibility tests; clippy `-D warnings` clean; `cargo fmt --check` clean; no system lib pulled in |

## Test Plan

- `cargo build --features training` — pass
- `cargo build --features "training,blas-threaded"` — pass (pulls pure-Rust matrixmultiply/thread-tree/num_cpus, no system lib)
- `cargo test --features training` — all suites pass, including `test_seeded_reproducibility` bit-identical traces
- `cargo clippy --all-targets --features training -- -D warnings` — clean
- `cargo clippy --all-targets --features "training,blas-threaded" -- -D warnings` — clean
- `cargo fmt -- --check` — clean

Closes #233