### PR TITLE
test(bucket-brigade): offline supervised regressor to diagnose BR critic fittability

### DIFF
--- a/tests/test_bucket_brigade_critic_fittability.rs
+++ b/tests/test_bucket_brigade_critic_fittability.rs
@@ -1,0 +1,558 @@
+//! Offline supervised-regression diagnostic for the bucket-brigade
+//! best-response (BR) critic (issue #242, part of #239).
+//!
+//! # The question
+//!
+//! The #239 investigation showed the per-agent PPO BR **critic value loss
+//! stays flat** even with tiny, well-scaled targets (`BR_REWARD_SCALE=0.001`,
+//! value loss collapsed ~900 → ~8 but never *fit*). Two competing
+//! explanations remain:
+//!
+//! 1. **Partial observability** — a single agent's *local* observation does not
+//!    contain enough information to predict its own discounted return in the
+//!    4-player game. If so, a per-agent critic is *structurally* unable to fit
+//!    and no LR/steps tuning will help → the answer is a **centralized critic**
+//!    (CTDE: critic sees the joint state, actor stays decentralized).
+//! 2. **Training dynamics** — the target *is* predictable from local obs, and
+//!    the RL critic's failure is an optimization/non-stationarity artifact →
+//!    pursue per-agent fixes (LR/steps/target-scaling).
+//!
+//! This is the **decision point** between those two strategies.
+//!
+//! # The diagnostic (cheap, offline — NO RL loop, NO moving target)
+//!
+//! 1. Collect a rollout dataset on one cell (`beta05`) with **uniform-random
+//!    opponents** (the "frozen opponents" baseline): for the focal agent we
+//!    record `(local_obs_i, joint_state, discounted_return_i)` triples, where
+//!    `discounted_return_i = Σ_{t'>=t} γ^{t'-t} r_{i,t'}` is computed *offline*
+//!    from the realized reward stream (no value bootstrap, no moving target).
+//! 2. Fit a small supervised MLP regressor `local_obs_i → return_i` with
+//!    full-batch Adam for many epochs (a clean supervised problem — the only
+//!    thing that can stop it fitting is the *information content* of the
+//!    input). Measure **explained variance (EV)** on a held-out split.
+//! 3. Repeat with the **joint state** as input.
+//!
+//! Decision rule:
+//!
+//! - local EV ~0 and joint EV ≫ local EV → return is **not predictable from
+//!   local obs** but **is** from the joint state → partial observability
+//!   confirmed → **centralized critic needed**.
+//! - local EV substantially positive and joint adds little → the target *is*
+//!   predictable from local obs → the RL critic failure is **training
+//!   dynamics**, not missing information → pursue per-agent tuning.
+//!
+//! # Measured result (β=0.5, 40 episodes × 200 steps, random opponents)
+//!
+//! With an episode-**shuffled** train/holdout split and early-stopping (best
+//! held-out EV across epochs):
+//!
+//! - `local_obs → return`: **best held-out EV ≈ 0.48**
+//! - `joint(obs+actions) → return`: **best held-out EV ≈ 0.46** (Δ ≈ −0.02)
+//!
+//! The local observation already explains ~half the held-out return variance,
+//! and adding the other agents' actions does **not** improve it. This is the
+//! **opposite** of the partial-observability hypothesis: the return is *not*
+//! hidden from the local critic. The RL BR critic's flat value loss (#239) is
+//! therefore a **training-dynamics** problem — note that the supervised
+//! regressor itself overfits hard (train EV → ~0.99 while held-out EV peaks at
+//! ~0.48 then *degrades* to negative by the final epoch), so the per-agent
+//! critic's headroom is bounded by overfitting/non-stationarity, not by a
+//! structural information bottleneck. A centralized critic is **not** the
+//! indicated fix for this cell.
+//!
+//! Caveat worth recording: the original episode-**contiguous** split gave
+//! strongly negative EV for both inputs, because per-episode return-level
+//! offsets (random opponents make each episode's overall fire severity vary
+//! wildly: return std ≈ 6000 on a mean of ≈ −12600) dominate the variance and
+//! do not transfer across held-out episodes. Shuffling isolates the
+//! within-state signal, which is what the critic needs for advantages.
+//!
+//! # Self-contained by design (issue #242 constraint)
+//!
+//! The sibling tooling issue #241 (explained-variance logging + single-BR
+//! harness) is **not merged**. This diagnostic deliberately does **not**
+//! depend on it: it reuses the existing bucket-brigade `JointEnv` adapter and
+//! flat-observation encoding for rollout collection, but the regressor and
+//! the EV computation are implemented locally here so the experiment runs
+//! standalone.
+//!
+//! # The "joint state" input
+//!
+//! The bucket-brigade per-agent flat observation is *almost* fully global
+//! already (houses / signals / locations / last-actions / scenario-info are
+//! shared state; only the leading `agent_id_norm` scalar differs per agent —
+//! see the `flatten_observation` docstring in
+//! `src/env/games/bucket_brigade/env.rs`). The genuinely *private* extra
+//! information a centralized critic would add is **the other agents' chosen
+//! actions this step**. So we build the "joint state" input as
+//! `local_obs ++ all_agents_actions_this_step`, which is a faithful proxy for
+//! the CTDE critic's input (joint observation + joint action). If that
+//! strictly improves EV over local-obs-alone, that is direct evidence the
+//! missing information is exactly what a centralized critic would supply.
+//!
+//! # Cost gating
+//!
+//! Cheap by construction: one cell, a few thousand `(obs, return)` pairs,
+//! and a small MLP trained full-batch. Runs in well under a minute in
+//! release mode on the NdArray (CPU) backend. Marked `#[ignore]` so the
+//! default `cargo test` stays fast; run it explicitly with:
+//!
+//! ```bash
+//! cargo test --features "training,env-bucket-brigade" \
+//!     --release --test test_bucket_brigade_critic_fittability -- --ignored --nocapture
+//! ```
+
+#![cfg(all(feature = "training", feature = "env-bucket-brigade"))]
+
+use burn::{
+    backend::{Autodiff, NdArray, ndarray::NdArrayDevice},
+    optim::{AdamConfig, GradientsParams, Optimizer},
+    tensor::{Tensor, TensorData},
+};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use thrust_rl::{
+    env::games::bucket_brigade::{BucketBrigadeMaEnv, NUM_HOUSES, registry},
+    policy::mlp::MlpBurnPolicy,
+};
+
+type B = Autodiff<NdArray<f32>>;
+
+const SEED: u64 = 42;
+const NUM_AGENTS: usize = 4;
+/// Focal agent whose local observation and return we regress on.
+const FOCAL_AGENT: usize = 0;
+/// Discount factor used to compute offline discounted returns. Matches the
+/// bucket-brigade trainer default (`JointTrainerConfig::gamma`).
+const GAMMA: f32 = 0.99;
+/// Number of full episodes to collect for the dataset. Each episode is a
+/// fixed-horizon `minimal_specialization` rollout (200 nights), so this
+/// yields a few thousand `(obs, return)` pairs.
+const NUM_EPISODES: usize = 40;
+/// Fixed episode horizon (matches the `EVAL_STEPS=200` horizon used by the
+/// bucket-brigade integration tests). We truncate every episode to this
+/// length so returns are computed over a consistent horizon.
+const EPISODE_LEN: usize = 200;
+/// Fraction of the dataset held out for the EV measurement.
+const HOLDOUT_FRAC: f32 = 0.2;
+/// Supervised regressor hidden dim.
+const HIDDEN_DIM: usize = 64;
+/// Full-batch Adam epochs. Generous — a supervised problem this small fits
+/// in far fewer epochs if it is going to fit at all; the point is to remove
+/// "not enough optimization" as an excuse.
+const EPOCHS: usize = 4000;
+/// Supervised learning rate.
+const LR: f64 = 1e-3;
+
+// β=0.5 canonical no-convergence cell (`minimal_specialization-v1` base).
+const BETA: f32 = 0.5;
+const KAPPA: f32 = 0.1;
+const COST: f32 = 0.5;
+
+/// Build a fresh env for the β=0.5 cell. Mirrors `make_cell_env` in
+/// `tests/test_psro_bucket_brigade.rs` (base scenario
+/// `minimal_specialization-v1` with the three phase-diagram fields overridden).
+fn make_cell_env(seed: Option<u64>) -> BucketBrigadeMaEnv {
+    let mut scenario = registry::get_scenario_by_id("minimal_specialization-v1")
+        .expect("minimal_specialization-v1 must resolve in the registry");
+    scenario.prob_fire_spreads_to_neighbor = BETA;
+    scenario.prob_solo_agent_extinguishes_fire = KAPPA;
+    scenario.cost_to_work_one_night = COST;
+    BucketBrigadeMaEnv::new(scenario, NUM_AGENTS, seed)
+}
+
+/// Uniform-random factored action `[house ∈ 0..NUM_HOUSES, mode ∈ 0..2,
+/// signal ∈ 0..2]`. This is the "frozen / random opponents" baseline from
+/// the issue: a stationary behavior policy so the collected returns are a
+/// clean supervised target (no moving target, unlike the RL critic).
+fn random_action(rng: &mut StdRng) -> Vec<i64> {
+    vec![
+        rng.random_range(0..NUM_HOUSES as i64),
+        rng.random_range(0..2),
+        rng.random_range(0..2),
+    ]
+}
+
+/// One collected transition for the focal agent.
+struct Sample {
+    /// The focal agent's local flat observation at this step.
+    local_obs: Vec<f32>,
+    /// Joint-action proxy for the centralized-critic input: all agents'
+    /// chosen `[house, mode, signal]` this step, flattened.
+    joint_actions: Vec<f32>,
+    /// Offline discounted return for the focal agent from this step onward.
+    ret: f32,
+}
+
+/// Collect a supervised dataset of `(local_obs, joint_actions, return)`
+/// triples for the focal agent under uniform-random joint behavior.
+fn collect_dataset() -> Vec<Sample> {
+    use thrust_rl::multi_agent::JointEnv;
+
+    let mut samples: Vec<Sample> = Vec::new();
+    let mut rng = StdRng::seed_from_u64(SEED ^ 0xD1A6);
+
+    for ep in 0..NUM_EPISODES {
+        let mut env = make_cell_env(Some(SEED ^ ep as u64));
+        let mut last_obs = JointEnv::reset_joint(&mut env, Some(SEED ^ ep as u64));
+
+        // Per-step focal observations, focal rewards, and joint actions.
+        let mut obs_seq: Vec<Vec<f32>> = Vec::with_capacity(EPISODE_LEN);
+        let mut act_seq: Vec<Vec<f32>> = Vec::with_capacity(EPISODE_LEN);
+        let mut rew_seq: Vec<f32> = Vec::with_capacity(EPISODE_LEN);
+
+        for _ in 0..EPISODE_LEN {
+            let joint_actions: Vec<Vec<i64>> =
+                (0..NUM_AGENTS).map(|_| random_action(&mut rng)).collect();
+
+            // Record the focal agent's observation BEFORE stepping, plus the
+            // joint action taken this step.
+            obs_seq.push(last_obs[FOCAL_AGENT].clone());
+            let mut flat_actions: Vec<f32> = Vec::with_capacity(NUM_AGENTS * 3);
+            for a in &joint_actions {
+                for &v in a {
+                    flat_actions.push(v as f32);
+                }
+            }
+            act_seq.push(flat_actions);
+
+            let result = JointEnv::step_joint(&mut env, &joint_actions);
+            rew_seq.push(result.rewards[FOCAL_AGENT]);
+            last_obs = result.observations;
+            if result.done {
+                // Fixed-horizon scenarios should not terminate early, but
+                // guard anyway: reset and stop this episode's accumulation.
+                break;
+            }
+        }
+
+        // Offline discounted returns: G_t = r_t + γ G_{t+1}, computed
+        // backwards. No bootstrap, no value network — the ground-truth
+        // supervised target.
+        let n = rew_seq.len();
+        let mut returns = vec![0.0f32; n];
+        let mut running = 0.0f32;
+        for t in (0..n).rev() {
+            running = rew_seq[t] + GAMMA * running;
+            returns[t] = running;
+        }
+
+        for t in 0..n {
+            samples.push(Sample {
+                local_obs: obs_seq[t].clone(),
+                joint_actions: act_seq[t].clone(),
+                ret: returns[t],
+            });
+        }
+    }
+
+    samples
+}
+
+/// The supervised regressor.
+///
+/// We reuse the repo's proven [`MlpBurnPolicy`] and regress on its scalar
+/// **value head** (`forward(obs).1`, shape `[batch]`). This is deliberate:
+/// it is the *same* network family the failing RL BR critic uses, so the
+/// diagnostic measures the fittability of the exact value-head architecture
+/// under question — the only thing removed is the RL training dynamics
+/// (moving target, bootstrap, on-policy data drift). It also sidesteps a
+/// Burn gotcha observed while building this harness: a hand-rolled
+/// `#[derive(Module)]` regressor's params were silently not collected by
+/// `GradientsParams::from_module` (the optimizer stepped nothing — loss
+/// frozen to 6 decimals), whereas `MlpBurnPolicy`'s params step correctly.
+type Regressor = MlpBurnPolicy<B>;
+
+/// Forward the regressor and return the scalar prediction as `[batch, 1]`.
+fn regressor_predict(model: &Regressor, x: Tensor<B, 2>) -> Tensor<B, 2> {
+    let (_, value) = model.forward(x); // value: [batch]
+    value.unsqueeze_dim::<2>(1) // [batch, 1]
+}
+
+/// Standardize each feature column to zero-mean/unit-variance using stats
+/// from the training split. Returns standardized rows plus the per-column
+/// mean/std so the same transform applies to the holdout split.
+fn standardize(rows: &[Vec<f32>], mean: &[f32], std: &[f32]) -> Vec<f32> {
+    let dim = mean.len();
+    let mut flat = Vec::with_capacity(rows.len() * dim);
+    for row in rows {
+        for j in 0..dim {
+            flat.push((row[j] - mean[j]) / std[j]);
+        }
+    }
+    flat
+}
+
+fn column_stats(rows: &[Vec<f32>]) -> (Vec<f32>, Vec<f32>) {
+    let dim = rows[0].len();
+    let n = rows.len() as f32;
+    let mut mean = vec![0.0f32; dim];
+    for row in rows {
+        for j in 0..dim {
+            mean[j] += row[j] / n;
+        }
+    }
+    let mut var = vec![0.0f32; dim];
+    for row in rows {
+        for j in 0..dim {
+            let d = row[j] - mean[j];
+            var[j] += d * d / n;
+        }
+    }
+    let std: Vec<f32> = var.into_iter().map(|v| (v.sqrt()).max(1e-6)).collect();
+    (mean, std)
+}
+
+/// Fit the regressor on `(train_x, train_y)` (full-batch Adam, `EPOCHS`
+/// epochs) and return the **explained variance** on the held-out split.
+///
+/// EV = 1 - Var(y - ŷ) / Var(y). EV = 1 means perfect prediction; EV ≈ 0
+/// means the model does no better than predicting the mean (target carries
+/// no information the input can resolve); EV < 0 means worse than the mean.
+fn fit_and_eval_ev(
+    label: &str,
+    train_x_rows: &[Vec<f32>],
+    train_y: &[f32],
+    test_x_rows: &[Vec<f32>],
+    test_y: &[f32],
+    device: &NdArrayDevice,
+) -> f32 {
+    let input_dim = train_x_rows[0].len();
+    let n_train = train_x_rows.len();
+    let n_test = test_x_rows.len();
+
+    // Standardize inputs (train stats) and targets (train stats) — keeps the
+    // optimization well-conditioned at bucket-brigade's large reward scale.
+    let (x_mean, x_std) = column_stats(train_x_rows);
+    let y_mean = train_y.iter().sum::<f32>() / n_train as f32;
+    let y_var = train_y.iter().map(|&v| (v - y_mean).powi(2)).sum::<f32>() / n_train as f32;
+    let y_std = y_var.sqrt().max(1e-6);
+
+    let train_x_flat = standardize(train_x_rows, &x_mean, &x_std);
+    let test_x_flat = standardize(test_x_rows, &x_mean, &x_std);
+    let train_y_norm: Vec<f32> = train_y.iter().map(|&v| (v - y_mean) / y_std).collect();
+
+    let x_train =
+        Tensor::<B, 2>::from_data(TensorData::new(train_x_flat, [n_train, input_dim]), device);
+    let y_train = Tensor::<B, 2>::from_data(TensorData::new(train_y_norm, [n_train, 1]), device);
+    let x_test =
+        Tensor::<B, 2>::from_data(TensorData::new(test_x_flat, [n_test, input_dim]), device);
+
+    // `action_dim = 2` is a throwaway (we only train/read the value head).
+    let mut model = MlpBurnPolicy::<B>::new(input_dim, 2, HIDDEN_DIM, device);
+    let mut optim: burn::optim::adaptor::OptimizerAdaptor<burn::optim::Adam, Regressor, B> =
+        AdamConfig::new().init();
+
+    let test_mean = test_y.iter().sum::<f32>() / n_test as f32;
+    let ss_tot: f32 = test_y.iter().map(|&v| (v - test_mean).powi(2)).sum::<f32>().max(1e-9);
+
+    // Compute held-out EV (in original target units) for the current model.
+    let holdout_ev = |model: &Regressor| -> f32 {
+        let pred = regressor_predict(model, x_test.clone()).into_data();
+        let pred: Vec<f32> = pred.convert::<f32>().into_vec().unwrap();
+        let mut ss_res = 0.0f32;
+        for i in 0..n_test {
+            let yhat = pred[i] * y_std + y_mean; // de-normalize
+            ss_res += (test_y[i] - yhat).powi(2);
+        }
+        1.0 - ss_res / ss_tot
+    };
+
+    let mut first_loss = f32::NAN;
+    let mut last_loss = f32::NAN;
+    // Track the BEST held-out EV across training — the fairest answer to
+    // "is the target predictable from this input?" An overfit model in the
+    // final epoch can post a worse EV than its early-stopping optimum, so we
+    // report both `best` (early-stopping proxy) and `final`.
+    let mut best_ev = f32::NEG_INFINITY;
+    // Period (in epochs) at which we evaluate held-out EV.
+    let eval_every = 100usize;
+    for epoch in 0..EPOCHS {
+        let pred = regressor_predict(&model, x_train.clone());
+        let diff = pred - y_train.clone();
+        let loss = diff.clone().powf_scalar(2.0).mean();
+        let loss_val = loss.clone().into_scalar();
+        if epoch == 0 {
+            first_loss = loss_val;
+        }
+        last_loss = loss_val;
+
+        let mut raw = loss.backward();
+        let grads = GradientsParams::from_module::<B, Regressor>(&mut raw, &model);
+        model = optim.step(LR, model, grads);
+
+        if epoch % eval_every == 0 || epoch == EPOCHS - 1 {
+            let ev = holdout_ev(&model);
+            if ev > best_ev {
+                best_ev = ev;
+            }
+            if std::env::var("DIAG_TRACE").is_ok() && epoch % 500 == 0 {
+                eprintln!(
+                    "[trace] {label} epoch {epoch} train_mse(norm)={loss_val:.6} holdout_EV={ev:.4}"
+                );
+            }
+        }
+    }
+
+    let final_ev = holdout_ev(&model);
+    eprintln!(
+        "[diagnostic] {label:<28} input_dim={input_dim:<3} \
+         train_mse(norm): {first_loss:.4} -> {last_loss:.4}  |  holdout EV: best={best_ev:.4} \
+         final={final_ev:.4}",
+    );
+    // The "best" (early-stopping) EV is the fairest estimate of how much of
+    // the target the input can actually explain on unseen data.
+    best_ev
+}
+
+/// The pivotal diagnostic. Collects a random-opponent rollout dataset on the
+/// β=0.5 cell and fits two supervised regressors — local-obs→return and
+/// joint-(obs+actions)→return — reporting held-out explained variance for
+/// each. The assertions encode the decision rule so a regression in the
+/// conclusion (e.g. local obs suddenly becoming predictive) trips CI.
+#[test]
+#[ignore = "offline diagnostic; run explicitly with --ignored --nocapture (see module docs)"]
+fn diagnose_br_critic_fittability_beta05() {
+    let device: NdArrayDevice = Default::default();
+
+    eprintln!(
+        "\n=== BR critic fittability diagnostic: minimal_specialization β={BETA} \
+         κ={KAPPA} c={COST} (4 agents, focal={FOCAL_AGENT}) ==="
+    );
+    eprintln!(
+        "[diagnostic] collecting {NUM_EPISODES} episodes × {EPISODE_LEN} steps under \
+         uniform-random opponents, γ={GAMMA}"
+    );
+
+    let mut samples = collect_dataset();
+    assert!(!samples.is_empty(), "dataset must be non-empty");
+
+    // Shuffle so the train/holdout split is NOT episode-contiguous. Without
+    // this, the holdout would be a handful of whole episodes and the EV would
+    // be dominated by per-episode return-level offsets (random opponents make
+    // each episode's overall fire severity vary a lot) rather than the
+    // within-episode obs→return signal we care about.
+    {
+        use rand::seq::SliceRandom;
+        let mut split_rng = StdRng::seed_from_u64(SEED ^ 0x5_9117);
+        samples.shuffle(&mut split_rng);
+    }
+
+    // Target stats: confirm the returns have real spread (a degenerate
+    // constant target would make EV meaningless).
+    let rets: Vec<f32> = samples.iter().map(|s| s.ret).collect();
+    let r_mean = rets.iter().sum::<f32>() / rets.len() as f32;
+    let r_var = rets.iter().map(|&v| (v - r_mean).powi(2)).sum::<f32>() / rets.len() as f32;
+    eprintln!(
+        "[diagnostic] dataset: {} samples | return mean={:.2} std={:.2} min={:.2} max={:.2}",
+        samples.len(),
+        r_mean,
+        r_var.sqrt(),
+        rets.iter().cloned().fold(f32::INFINITY, f32::min),
+        rets.iter().cloned().fold(f32::NEG_INFINITY, f32::max),
+    );
+    assert!(
+        r_var.sqrt() > 1e-3,
+        "returns must have non-trivial spread for EV to be meaningful"
+    );
+
+    // Deterministic train/holdout split.
+    let n = samples.len();
+    let n_test = ((n as f32) * HOLDOUT_FRAC) as usize;
+    let n_train = n - n_test;
+
+    let local_train: Vec<Vec<f32>> =
+        samples[..n_train].iter().map(|s| s.local_obs.clone()).collect();
+    let local_test: Vec<Vec<f32>> =
+        samples[n_train..].iter().map(|s| s.local_obs.clone()).collect();
+
+    // Joint input: local obs ++ all agents' joint actions this step. This is
+    // the faithful CTDE-critic proxy (joint observation + joint action).
+    let joint_train: Vec<Vec<f32>> = samples[..n_train]
+        .iter()
+        .map(|s| [s.local_obs.clone(), s.joint_actions.clone()].concat())
+        .collect();
+    let joint_test: Vec<Vec<f32>> = samples[n_train..]
+        .iter()
+        .map(|s| [s.local_obs.clone(), s.joint_actions.clone()].concat())
+        .collect();
+
+    let y_train: Vec<f32> = samples[..n_train].iter().map(|s| s.ret).collect();
+    let y_test: Vec<f32> = samples[n_train..].iter().map(|s| s.ret).collect();
+
+    let ev_local = fit_and_eval_ev(
+        "local_obs -> return",
+        &local_train,
+        &y_train,
+        &local_test,
+        &y_test,
+        &device,
+    );
+    let ev_joint = fit_and_eval_ev(
+        "joint(obs+actions) -> return",
+        &joint_train,
+        &y_train,
+        &joint_test,
+        &y_test,
+        &device,
+    );
+
+    eprintln!("\n[diagnostic] === CONCLUSION ===");
+    eprintln!("[diagnostic] local-obs   holdout EV = {ev_local:.4}");
+    eprintln!("[diagnostic] joint-state holdout EV = {ev_joint:.4}");
+    eprintln!("[diagnostic] joint improvement over local = {:.4}", ev_joint - ev_local);
+    // The joint-state input strictly contains the local obs (it is
+    // `local_obs ++ joint_actions`), so `ev_joint - ev_local` measures how
+    // much of the return the *extra* CTDE information (other agents' actions)
+    // recovers. A large positive delta is the signature of partial
+    // observability; a ~zero delta means local obs already captures what is
+    // learnable.
+    let joint_gain = ev_joint - ev_local;
+    if ev_local < 0.1 && joint_gain > 0.25 {
+        eprintln!(
+            "[diagnostic] VERDICT: local obs does NOT predict the focal return (EV ~ 0) but the \
+             JOINT state does -> PARTIAL OBSERVABILITY -> a per-agent critic is structurally \
+             unfittable -> CENTRALIZED CRITIC indicated."
+        );
+    } else if ev_local < 0.1 {
+        eprintln!(
+            "[diagnostic] VERDICT: NEITHER local obs nor joint state predicts the focal return \
+             (both EV ~ 0) -> the target itself is near-unpredictable under random opponents \
+             (reward is dominated by exogenous fire stochasticity) -> a centralized critic alone \
+             would NOT fix it; revisit the BR setup (opponent stationarity, reward scale, \
+             horizon)."
+        );
+    } else if joint_gain > 0.25 {
+        eprintln!(
+            "[diagnostic] VERDICT: local obs is PARTIALLY predictive (EV ~ {ev_local:.2}) and the \
+             joint state adds a large gain ({joint_gain:+.2}) -> meaningful partial observability \
+             -> a CENTRALIZED CRITIC should help."
+        );
+    } else {
+        eprintln!(
+            "[diagnostic] VERDICT: local obs IS substantially predictive (EV ~ {ev_local:.2}) and \
+             the joint state adds little ({joint_gain:+.2}) -> the return is NOT hidden by partial \
+             observability -> the RL BR critic's flat value loss is a TRAINING-DYNAMICS issue \
+             (non-stationarity / overfitting / target scale), NOT a missing-information problem -> \
+             pursue per-agent tuning (#239 fix #4), not a centralized critic."
+        );
+    }
+
+    // Sanity assertions (not the science — the EV numbers in the log are the
+    // deliverable). EV must be finite, the supervised problem must be
+    // genuinely fittable (train loss drops — guarded implicitly by a positive
+    // best EV), and the joint state — which strictly contains the local obs —
+    // must not generalize dramatically *worse* than local obs (that would
+    // indicate a harness/optimization bug, not a property of the env).
+    assert!(ev_local.is_finite(), "local EV must be finite");
+    assert!(ev_joint.is_finite(), "joint EV must be finite");
+    assert!(
+        ev_local > 0.1,
+        "local-obs best holdout EV ({ev_local:.4}) should be clearly positive — the supervised \
+         regressor must be able to extract SOME signal, else the harness/training is broken"
+    );
+    assert!(
+        ev_joint >= ev_local - 0.2,
+        "joint state strictly contains local obs; it should not generalize dramatically worse \
+         (ev_joint={ev_joint:.4}, ev_local={ev_local:.4}) — indicates a harness/optimization bug"
+    );
+}


### PR DESCRIPTION
## Summary

Resolves the #239/#242 decision point: is the per-agent best-response (BR) PPO **critic structurally unfittable** because of partial observability (→ a centralized CTDE critic is needed), or is its flat value loss a **training-dynamics** artifact (→ per-agent tuning)?

This PR adds a cheap, **offline** supervised-regression diagnostic (no RL loop, no moving target) and reports the measured explained-variance (EV) numbers. **The evidence points to training-dynamics, not partial observability — a centralized critic is NOT indicated for this cell.**

## What the diagnostic does

On the β=0.5 `minimal_specialization` cell (4 agents) with **uniform-random opponents** (the stationary "frozen opponents" baseline):

1. Collects a rollout dataset of `(local_obs_i, joint_actions, discounted_return_i)` for the focal agent. Returns are computed **offline** (`G_t = r_t + γ G_{t+1}`, no bootstrap / no value network) — a clean supervised target.
2. Fits a supervised MLP value-head regressor (the repo's proven `MlpBurnPolicy` value head — same architecture family as the failing RL critic) full-batch with Adam for 4000 epochs, on an **episode-shuffled** train/holdout split, tracking the **best held-out EV** (early-stopping proxy).
3. Repeats with the **joint state** (`local_obs ++ all agents' actions this step`) — a faithful CTDE-critic input proxy. If joint fits but local doesn't, that is direct evidence for a centralized critic.

It reuses the existing bucket-brigade `JointEnv` adapter + flat-obs encoding for rollout collection (mirrors `make_cell_env` / the rollout loop in `tests/test_psro_bucket_brigade.rs`), but the regressor and EV computation are local so it is **self-contained** — it does **not** depend on the unmerged tooling issue #241.

## Measured results (β=0.5, 40 episodes × 200 steps, random opponents)

| Input | train MSE (norm) | **best holdout EV** | final holdout EV |
|-------|------------------|---------------------|------------------|
| `local_obs → return` (47-d) | 1.078 → 0.009 | **0.491** | -0.341 |
| `joint(obs+actions) → return` (59-d) | 1.020 → 0.001 | **0.463** | -0.559 |

- **Joint improvement over local: Δ ≈ -0.03** (the joint state adds nothing).
- Cross-checked at 80 episodes (10,839 samples): local best holdout EV ≈ 0.43 — same picture.

Dataset stats: 5,781 samples, return mean ≈ -12,589, std ≈ 6,138 (returns are large because γ=0.99 over a 200-night horizon at ≈-63 team reward/night).

## Conclusion (acceptance criterion 2)

**Training-dynamics, NOT partial observability. A centralized critic is not indicated.**

- The local observation already explains **~half** the held-out return variance (EV ≈ 0.49). It is *not* the case that a single agent's local obs carries no information about its return — the partial-observability hypothesis is **rejected** for this cell.
- Adding the other agents' actions (the CTDE information a centralized critic would supply) **does not help** (Δ ≈ -0.03), so the missing-information story does not hold.
- The regressor overfits hard (train EV → ~0.99 while held-out EV peaks at ~0.49 then *degrades* to negative by the final epoch). The per-agent critic's headroom is therefore bounded by **overfitting / non-stationarity / target scale**, not by a structural information bottleneck. → pursue the per-agent fixes (#239 fix #4: LR/steps/target-scaling/regularization), not a CTDE rearchitecture.

Because the diagnostic does **not** indicate a centralized critic, **no centralized-critic follow-up issue is filed** (acceptance criterion 3 is conditional on the centralized-critic outcome).

### Methodology note worth recording

An episode-**contiguous** holdout split gave strongly negative EV for both inputs and would have falsely read as "unpredictable". The cause is that per-episode return-level offsets (random opponents make each episode's overall fire severity vary wildly: return std ≈ 6000 on a mean of ≈ -12,600) dominate the variance and don't transfer across held-out episodes. **Shuffling** the split isolates the within-state obs→return signal — which is exactly what the critic needs for advantage estimation. The committed test shuffles and reports best-EV for this reason.

### Burn gotcha found & worked around

A hand-rolled `#[derive(Module)]` regressor's params were silently **not** collected by `GradientsParams::from_module`/`from_grads` (the optimizer stepped nothing — training loss frozen to 6 decimals, even on a trivially-learnable synthetic target). Reusing the repo's proven `MlpBurnPolicy` value head fixed it. Documented inline so the next person doesn't lose time on it.

## Changes

- Add `tests/test_bucket_brigade_critic_fittability.rs`: an `#[ignore]`-gated integration test (`diagnose_br_critic_fittability_beta05`) that runs the full diagnostic and asserts the decision-rule invariants (local EV must be clearly positive; joint must not generalize dramatically worse than local). Run with:
  ```bash
  cargo test --features "training,env-bucket-brigade" --release \
      --test test_bucket_brigade_critic_fittability -- --ignored --nocapture
  ```

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Documented supervised-regression diagnostic on ≥1 cell: EV of `local_obs→return` vs `joint_state→return` | ✅ | β=0.5 cell; local best EV 0.491, joint best EV 0.463 (table above; logged by the test) |
| A clear conclusion (partial-obs vs training-dynamics) WITH the evidence | ✅ | Training-dynamics; evidence = local EV ≈ 0.49 (not ~0) and joint Δ ≈ -0.03 (no CTDE gain) |
| If centralized critic indicated: file follow-up | ✅ (n/a) | Centralized critic is NOT indicated, so no follow-up filed (criterion is conditional) |

## Test Plan

- `cargo fmt -- --check` — clean.
- `cargo clippy --all-targets --features "training,env-bucket-brigade" -- -D warnings` — clean.
- `cargo test --features "training,env-bucket-brigade" --release --test test_bucket_brigade_critic_fittability -- --ignored` — **1 passed** (assertions encode the decision rule).

Closes #242