### PR TITLE
feat(bucket-brigade): surface critic explained-variance + add single-BR A/B probe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,3 +288,11 @@ required-features = ["training", "env-bucket-brigade"]
 name = "train_nfsp"
 path = "examples/games/bucket_brigade/train_nfsp.rs"
 required-features = ["training", "env-bucket-brigade"]
+
+# Standalone single-best-response A/B probe (issue #241): freeze N-1
+# opponents, train ONE PPO best-response on one cell, log per-iteration
+# val-loss / explained-variance / entropy / mean-return.
+[[example]]
+name = "train_br_probe"
+path = "examples/games/bucket_brigade/train_br_probe.rs"
+required-features = ["training", "env-bucket-brigade"]

--- a/examples/games/bucket_brigade/train_br_probe.rs
+++ b/examples/games/bucket_brigade/train_br_probe.rs
@@ -1,0 +1,286 @@
+//! Standalone single-best-response (BR) A/B probe for bucket-brigade.
+//!
+//! Issue #241. Investigating why the PPO best-response does not learn on
+//! bucket-brigade (#239) is slow when the only signal is the per-iteration
+//! `br[...]` line from a full NFSP/PSRO run. This harness isolates ONE
+//! best-response:
+//!
+//! - freezes `N−1` opponents (uniform-random policies) for one cell,
+//! - trains a single PPO best-response agent for `ITERATIONS` iterations
+//!   against those frozen opponents,
+//! - logs per iteration: value loss, **explained variance**, policy entropy,
+//!   and mean episode return.
+//!
+//! The explained variance (`ev = 1 − Var(returns − values) / Var(returns)`)
+//! is computed inside the joint PPO update (`src/multi_agent/joint.rs`) and
+//! surfaced here. `ev` near 0 or negative = critic not fitting; `ev → 1` =
+//! critic fits. That single metric is the most informative signal for the
+//! #239 "BR does not learn" investigation, and this harness lets you A/B a
+//! single BR in ~1 minute instead of via a full NFSP/PSRO run.
+//!
+//! The "opponents" are freshly-initialized policies (uniform-ish random at
+//! init) held frozen via the joint trainer's freeze-N−1 primitive
+//! (`update_with_active_agents` with an active mask selecting only the BR
+//! agent). They are NOT updated — only the single BR agent's optimizer steps.
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Default A/B probe (cell β=0.5, 20 iters, ndarray CPU backend):
+//! cargo run --release --example train_br_probe \
+//!     --features "training,env-bucket-brigade"
+//!
+//! # A/B the #240 knobs on one cell in ~1 min:
+//! CELL=beta05 ITERATIONS=20 ROLLOUT_STEPS=2048 \
+//!     VF_COEF=0.05 BR_TRAIN_STEPS=4 BR_REWARD_SCALE=0.01 \
+//!     cargo run --release --example train_br_probe \
+//!         --features "training,env-bucket-brigade"
+//! ```
+//!
+//! # Env-var knobs
+//!
+//! - `CELL` — one of `beta01|beta05|beta09` (default `beta05`).
+//! - `ITERATIONS` — number of BR rollout/update iterations (default 20).
+//! - `ROLLOUT_STEPS` — env steps collected per iteration (default 2048).
+//! - `VF_COEF` — value-loss weight in the joint loss (#240, default 0.05).
+//! - `BR_TRAIN_STEPS` — PPO updates per iteration (#240, default 1).
+//! - `BR_REWARD_SCALE` — affine reward rescale before the update (#240/#199,
+//!   default 0.01). Does not change the optimal policy; keeps the `[−700, 0]`
+//!   payoff band in a critic-friendly range.
+//!
+//! All of these reuse the exact same plumbing the NFSP/PSRO trainers use;
+//! this example introduces no new training knobs.
+
+use anyhow::Result;
+use burn::{backend::Autodiff, optim::AdamConfig};
+use rand::SeedableRng;
+use thrust_rl::{
+    env::games::bucket_brigade::{BucketBrigadeMaEnv, NUM_HOUSES, registry},
+    multi_agent::{
+        JointTrainerConfig,
+        bucket_brigade_baselines::BucketBrigadeCell,
+        joint::{JointEnv, JointMultiAgentTrainer},
+    },
+    policy::multi_discrete_mlp::MultiDiscreteMlpBurnPolicy,
+    train::optimizer::BurnOptimizer,
+};
+
+#[cfg(not(feature = "wgpu"))]
+type InnerBackend = burn::backend::NdArray<f32>;
+#[cfg(feature = "wgpu")]
+type InnerBackend = burn::backend::Wgpu<f32, i32>;
+type B = Autodiff<InnerBackend>;
+
+#[cfg(not(feature = "wgpu"))]
+const BACKEND_LABEL: &str = "NdArray<f32> + Autodiff (CPU)";
+#[cfg(feature = "wgpu")]
+const BACKEND_LABEL: &str = "Wgpu<f32, i32> + Autodiff (GPU: Vulkan/Metal/DX12/WebGPU)";
+
+const NUM_AGENTS: usize = 4;
+const HIDDEN_DIM: usize = 64;
+const SEED: u64 = 42;
+const DEFAULT_ITERATIONS: usize = 20;
+const DEFAULT_ROLLOUT_STEPS: usize = 2048;
+const DEFAULT_CELL: &str = "beta05";
+/// The single agent we train a best-response for. The other
+/// `NUM_AGENTS − 1` agents are frozen opponents.
+const BR_AGENT: usize = 0;
+
+/// Per-agent factored action cardinalities `[house, mode, signal]`.
+fn action_dims() -> Vec<usize> {
+    vec![NUM_HOUSES, 2, 2]
+}
+
+fn cell_params(cell: &str) -> (f32, f32, f32) {
+    cell_enum(cell).parameters()
+}
+
+/// Map the `CELL` env-var string to the corresponding [`BucketBrigadeCell`].
+fn cell_enum(cell: &str) -> BucketBrigadeCell {
+    match cell {
+        "beta01" => BucketBrigadeCell::Beta01,
+        "beta05" => BucketBrigadeCell::Beta05,
+        "beta09" => BucketBrigadeCell::Beta09,
+        other => panic!("Unknown CELL '{other}'; expected one of beta01|beta05|beta09"),
+    }
+}
+
+fn make_cell_env(beta: f32, kappa: f32, cost: f32, seed: Option<u64>) -> BucketBrigadeMaEnv {
+    let mut scenario = registry::get_scenario_by_id("minimal_specialization-v1")
+        .expect("minimal_specialization-v1 must resolve in the registry");
+    scenario.prob_fire_spreads_to_neighbor = beta;
+    scenario.prob_solo_agent_extinguishes_fire = kappa;
+    scenario.cost_to_work_one_night = cost;
+    BucketBrigadeMaEnv::new(scenario, NUM_AGENTS, seed)
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt().with_env_filter("info").init();
+
+    let iterations: usize = std::env::var("ITERATIONS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_ITERATIONS);
+    let rollout_steps: usize = std::env::var("ROLLOUT_STEPS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_ROLLOUT_STEPS);
+    let cell = std::env::var("CELL").unwrap_or_else(|_| DEFAULT_CELL.to_string());
+    let (beta, kappa, cost) = cell_params(&cell);
+
+    // #240 knobs — identical semantics and defaults to train_nfsp.rs so the
+    // probe and the full trainer can be A/B'd against each other directly.
+    let vf_coef: f64 = std::env::var("VF_COEF").ok().and_then(|s| s.parse().ok()).unwrap_or(0.05);
+    let br_train_steps: usize =
+        std::env::var("BR_TRAIN_STEPS").ok().and_then(|s| s.parse().ok()).unwrap_or(1);
+    let br_reward_scale: f32 = std::env::var("BR_REWARD_SCALE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.01);
+
+    tracing::info!("Single-BR probe (issue #241) — Burn backend: {BACKEND_LABEL}");
+    tracing::info!("  cell             = {cell} (β={beta}, κ={kappa}, c={cost})");
+    tracing::info!("  br_agent         = {BR_AGENT} ({} opponents frozen)", NUM_AGENTS - 1);
+    tracing::info!("  iterations       = {iterations}");
+    tracing::info!("  rollout_steps    = {rollout_steps}");
+    tracing::info!("  vf_coef          = {vf_coef} (#240 value-loss weight)");
+    tracing::info!("  br_train_steps   = {br_train_steps} (#240 PPO updates/iter)");
+    tracing::info!("  br_reward_scale  = {br_reward_scale} (#240/#199 payoff rescale)");
+
+    let device: burn::tensor::Device<InnerBackend> = Default::default();
+
+    let probe = make_cell_env(beta, kappa, cost, Some(SEED));
+    let obs_dim = probe.obs_dim();
+    drop(probe);
+    tracing::info!("  obs_dim          = {obs_dim}");
+    tracing::info!("  action_dims      = {:?} (factored multi-discrete)", action_dims());
+
+    // Build N policies: the BR agent is freshly initialized and trained;
+    // the rest are freshly-initialized frozen opponents (random at init).
+    let policies: Vec<MultiDiscreteMlpBurnPolicy<B>> = (0..NUM_AGENTS)
+        .map(|i| {
+            MultiDiscreteMlpBurnPolicy::<B>::new_seeded(
+                obs_dim,
+                action_dims(),
+                HIDDEN_DIM,
+                SEED ^ (i as u64).wrapping_add(1),
+                &device,
+            )
+        })
+        .collect();
+    let optimizers: Vec<_> = (0..NUM_AGENTS)
+        .map(|_| {
+            let inner = AdamConfig::new().init();
+            BurnOptimizer::new(inner, 3e-4)
+        })
+        .collect();
+
+    let joint_config = JointTrainerConfig {
+        num_agents: NUM_AGENTS,
+        rollout_steps,
+        n_epochs: 4,
+        minibatch_size: 256,
+        vf_coef,
+        // #240: consume the full rollout instead of one 256-sample draw.
+        iterate_all_minibatches: true,
+        ..Default::default()
+    };
+
+    let mut trainer =
+        JointMultiAgentTrainer::<B, _, _>::new(policies, optimizers, joint_config, device)?;
+
+    // Freeze-N−1: only BR_AGENT's optimizer steps; opponents stay fixed.
+    let active_mask: Vec<bool> = (0..NUM_AGENTS).map(|i| i == BR_AGENT).collect();
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(SEED);
+    let mut env = make_cell_env(beta, kappa, cost, Some(SEED));
+    let mut last_obs = env.reset_joint(Some(SEED));
+
+    tracing::info!("------------------------------------------------------------");
+    let training_start = std::time::Instant::now();
+
+    for iter in 1..=iterations {
+        let mut last_stats = None;
+        // Track the BR agent's mean per-episode return in ORIGINAL (unscaled)
+        // reward units, accumulated across this iteration's update steps.
+        let mut ep_return_sum = 0.0_f64;
+        let mut ep_count = 0_usize;
+
+        for _ in 0..br_train_steps {
+            let mut rollout = trainer.collect_rollout(&mut env, &mut last_obs, &mut rng);
+
+            // Mean episode return for the BR agent, computed from the raw
+            // (pre-scale) rollout rewards so the logged value is in the
+            // game's native payoff units regardless of BR_REWARD_SCALE.
+            let br_rewards = &rollout.rewards[BR_AGENT];
+            let mut running = 0.0_f64;
+            for (t, &r) in br_rewards.iter().enumerate() {
+                running += r as f64;
+                if rollout.dones[t] != 0.0 {
+                    ep_return_sum += running;
+                    ep_count += 1;
+                    running = 0.0;
+                }
+            }
+            // Partial trailing episode: count it so short runs still report.
+            if running != 0.0 && ep_count == 0 {
+                ep_return_sum += running;
+                ep_count += 1;
+            }
+
+            // Affine reward rescale (#240/#199) before the PPO update. Mirrors
+            // the PSRO/NFSP path: uniform scaling is return-invariant but keeps
+            // the large-magnitude band numerically friendly for the critic.
+            if br_reward_scale != 1.0 {
+                for agent_rewards in rollout.rewards.iter_mut() {
+                    for r in agent_rewards.iter_mut() {
+                        *r *= br_reward_scale;
+                    }
+                }
+            }
+
+            let stats = trainer.update_with_active_agents(
+                &rollout,
+                &active_mask,
+                &mut rng,
+                |_features: &[burn::tensor::Tensor<B, 2>]| -> Option<burn::tensor::Tensor<B, 1>> {
+                    None
+                },
+            )?;
+            last_stats = Some(stats);
+        }
+
+        let stats = last_stats.expect("br_train_steps >= 1");
+        let val_loss = stats.value_loss[BR_AGENT];
+        let ev = stats.explained_var[BR_AGENT];
+        let entropy = stats.entropy[BR_AGENT];
+        let mean_return = if ep_count > 0 {
+            ep_return_sum / ep_count as f64
+        } else {
+            f64::NAN
+        };
+
+        tracing::info!(
+            "iter {:>3}/{}  br[val={:.4} ev={:.4} ent={:.4}]  mean_ep_return={:.2} ({} eps)",
+            iter,
+            iterations,
+            val_loss,
+            ev,
+            entropy,
+            mean_return,
+            ep_count
+        );
+    }
+
+    tracing::info!("------------------------------------------------------------");
+    tracing::info!(
+        "Probe complete.  iterations={}  time={:.1}s",
+        iterations,
+        training_start.elapsed().as_secs_f64()
+    );
+    tracing::info!(
+        "Read the per-iter `ev` column: near 0/negative = critic not fitting; → 1 = critic fits."
+    );
+
+    Ok(())
+}

--- a/examples/games/bucket_brigade/train_nfsp.rs
+++ b/examples/games/bucket_brigade/train_nfsp.rs
@@ -308,20 +308,27 @@ fn main() -> Result<()> {
         // BR-side diagnostic (issue #199): a weak best-response starves
         // the AP target. Surface the BR policy/value loss + entropy each
         // iteration so it is clear whether the RL side is learning.
-        let (br_pol, br_val, br_ent) = match &iter_stats.br_stats {
+        //
+        // Issue #241: also surface the critic explained-variance
+        // (`ev = 1 − Var(returns − values) / Var(returns)`, computed in the
+        // joint PPO update). EV near 0 or negative = critic not fitting;
+        // EV → 1 = critic fits. This is the most informative signal for the
+        // #239 "BR does not learn" investigation.
+        let (br_pol, br_val, br_ent, br_ev) = match &iter_stats.br_stats {
             Some(s) => {
                 let n = s.policy_loss.len().max(1) as f64;
                 (
                     s.policy_loss.iter().sum::<f64>() / n,
                     s.value_loss.iter().sum::<f64>() / n,
                     s.entropy.iter().sum::<f64>() / n,
+                    s.explained_var.iter().sum::<f64>() / n,
                 )
             }
-            None => (f64::NAN, f64::NAN, f64::NAN),
+            None => (f64::NAN, f64::NAN, f64::NAN, f64::NAN),
         };
         tracing::info!(
             "iter {:>3}/{}  reservoir_sizes={:?}  avg_ap_loss={:.4} (Δfloor={:+.4})  \
-             br[pol={:.4} val={:.4} ent={:.4}]  cum_br_pushes={}",
+             br[pol={:.4} val={:.4} ev={:.4} ent={:.4}]  cum_br_pushes={}",
             iter_stats.iteration,
             total_iterations,
             res_sizes,
@@ -329,6 +336,7 @@ fn main() -> Result<()> {
             ap_delta,
             br_pol,
             br_val,
+            br_ev,
             br_ent,
             iter_stats.cumulative_br_pushes
         );


### PR DESCRIPTION
## Summary

Tooling for the #239 "PPO best-response does not learn on bucket-brigade" investigation. Two additive deliverables, no behavior change to existing trainers:

1. **Critic explained-variance surfaced.** The BR critic explained-variance (`ev = 1 − Var(returns − values) / Var(returns)`) is already computed inside the joint PPO update (`compute_value_loss` returns it; `JointStats.explained_var` accumulates it per update). This PR surfaces it in the bucket-brigade `train_nfsp` example's per-iteration `br[...]` diagnostic line. EV near 0 / negative = critic not fitting; EV → 1 = fits.

2. **Standalone single-BR A/B probe** (`examples/games/bucket_brigade/train_br_probe.rs`). Freezes N−1 opponents for one cell, trains ONE PPO best-response for K iterations via the joint trainer's freeze-N−1 primitive (`update_with_active_agents`), and logs per-iteration value loss / explained variance / policy entropy / mean episode return. Lets a single BR be A/B'd in ~1 min instead of via a full NFSP/PSRO run.

## Changes

- `examples/games/bucket_brigade/train_nfsp.rs`: add `ev=` to the `br[...]` log line, averaging `JointStats.explained_var` across agents alongside the existing val/ent diagnostics.
- `examples/games/bucket_brigade/train_br_probe.rs` (new): single-BR probe. Env-configurable via `CELL`, `ITERATIONS`, `ROLLOUT_STEPS`, and the #240 knobs `VF_COEF` / `BR_TRAIN_STEPS` / `BR_REWARD_SCALE`. Reuses the existing `collect_rollout` + `update_with_active_agents` plumbing and the PSRO reward-scaling pattern; introduces no new training knobs.
- `Cargo.toml`: register the `train_br_probe` example (`required-features = ["training", "env-bucket-brigade"]`).

## One-line A/B command

```bash
CELL=beta05 ITERATIONS=20 ROLLOUT_STEPS=2048 VF_COEF=0.05 BR_TRAIN_STEPS=4 BR_REWARD_SCALE=0.01 \
  cargo run --release --example train_br_probe --features "training,env-bucket-brigade"
```

Change `VF_COEF` / `BR_TRAIN_STEPS` / `BR_REWARD_SCALE` between two invocations to A/B a single best-response.

## Sample harness output

Captured from an actual run (`CELL=beta05 ITERATIONS=10 ROLLOUT_STEPS=2048 VF_COEF=0.05 BR_TRAIN_STEPS=1 BR_REWARD_SCALE=0.01`):

```
Single-BR probe (issue #241) — Burn backend: NdArray<f32> + Autodiff (CPU)
  cell             = beta05 (β=0.5, κ=0.1, c=0.5)
  br_agent         = 0 (3 opponents frozen)
  iterations       = 10
  rollout_steps    = 2048
  vf_coef          = 0.05 (#240 value-loss weight)
  br_train_steps   = 1 (#240 PPO updates/iter)
  br_reward_scale  = 0.01 (#240/#199 payoff rescale)
  obs_dim          = 47
  action_dims      = [10, 2, 2] (factored multi-discrete)
------------------------------------------------------------
iter   1/10  br[val=1091.3815 ev=-0.0001 ent=1.2274]  mean_ep_return=-23537.56 (16 eps)
iter   2/10  br[val=1192.1418 ev=-0.0000 ent=1.2245]  mean_ep_return=-23755.22 (16 eps)
iter   3/10  br[val=1114.8244 ev=-0.0001 ent=1.2250]  mean_ep_return=-28126.43 (14 eps)
iter   4/10  br[val=1213.8687 ev=-0.0001 ent=1.2194]  mean_ep_return=-26620.27 (15 eps)
iter   5/10  br[val=1280.5556 ev=-0.0000 ent=1.2205]  mean_ep_return=-25378.66 (16 eps)
iter   6/10  br[val=1669.5657 ev=-0.0000 ent=1.2182]  mean_ep_return=-37659.15 (13 eps)
iter   7/10  br[val=1099.2073 ev=-0.0000 ent=1.2136]  mean_ep_return=-22949.88 (17 eps)
iter   8/10  br[val=1314.5082 ev=-0.0000 ent=1.2116]  mean_ep_return=-23613.37 (19 eps)
iter   9/10  br[val=1340.8437 ev=-0.0000 ent=1.2028]  mean_ep_return=-33545.00 (12 eps)
iter  10/10  br[val=1224.3911 ev=-0.0000 ent=1.2123]  mean_ep_return=-29330.18 (14 eps)
------------------------------------------------------------
Probe complete.  iterations=10  time=150.9s
```

Note the `ev` column pinned near 0 — exactly the critic-not-fitting signal the #239 investigation needs to surface and A/B against.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| EV computed and logged in the BR update, surfaced in bucket-brigade examples | ✅ | `compute_value_loss`/`JointStats.explained_var` already compute it; `train_nfsp.rs` now prints `ev=` in the per-iter `br[...]` line |
| Standalone single-BR harness, runs on one cell, logs val-loss / EV / entropy / mean-return per iteration | ✅ | New `train_br_probe.rs`; ran it (sample output above) |
| Documented one-line A/B command | ✅ | In this PR body + the example's `//!` doc-comment |
| No behavior change to existing trainers (additive logging + new example) | ✅ | Diff touches only the nfsp example log line, a new example, and Cargo.toml registration |
| Existing tests pass; clippy/fmt clean on both feature sets | ✅ | `cargo test --features "training,env-bucket-brigade"` → 417+ passed, 0 failed; `cargo clippy --all-targets` clean on both `training` and `training,env-bucket-brigade` with `-D warnings`; `cargo fmt --check` clean |

## Test Plan

- `cargo clippy --all-targets --features training -- -D warnings` → exit 0
- `cargo clippy --all-targets --features "training,env-bucket-brigade" -- -D warnings` → exit 0
- `cargo fmt --check` → exit 0
- `RAYON_NUM_THREADS=1 cargo test --features "training,env-bucket-brigade"` → all pass (417 in the main binary, 0 failed)
- Ran the probe end-to-end on the `beta05` cell (sample output above)

Closes #241