### PR TITLE
perf(nfsp): batch per-step seeded sampling via a single forward through one model

### DIFF
--- a/src/multi_agent/joint.rs
+++ b/src/multi_agent/joint.rs
@@ -126,6 +126,44 @@ pub trait JointPolicy<B: AutodiffBackend>: AutodiffModule<B> + Clone {
         rng: &mut StdRng,
     ) -> (Vec<i64>, Vec<f32>, Vec<f32>);
 
+    /// Batched seeded sampler: `obs` carries `N` rows scored through **this
+    /// one policy** in a single forward, returning `N` actions.
+    ///
+    /// # When this helps (and when it does not)
+    ///
+    /// This eliminates per-call batch-1 forward overhead on the NdArray
+    /// backend wherever many observations are scored through the **same**
+    /// model in one step — e.g. the constant-obs marginal probe
+    /// ([`crate::multi_agent::nfsp::NfspTrainer::action_marginal_for`]),
+    /// or a future parallel-env rollout where one frozen policy scores
+    /// many env rows.
+    ///
+    /// It does **not** apply across the per-agent forwards of NFSP's (or
+    /// PSRO's) rollout: those `num_agents` forwards each run a *distinct*
+    /// per-agent policy module, and a single batched forward applies one
+    /// weight set to every row — so stacking the agents' observations
+    /// into one `[N, obs_dim]` tensor would be semantically wrong. NFSP
+    /// runs a single shared joint episode (`env.step_joint`), so there is
+    /// no within-model batch dimension to collapse in the rollout itself;
+    /// the per-step forward count there is irreducible. See issue #235.
+    ///
+    /// # Determinism
+    ///
+    /// The default implementation simply calls
+    /// [`Self::get_action_host_seeded`] on the full `[N, obs_dim]` tensor,
+    /// which already draws RNG in row-major order. Implementors that
+    /// override this (the concrete MLP policies do) must keep the per-row
+    /// RNG draw order identical so the sampled action stream is
+    /// bit-for-bit reproducible under `PsroConfig::seed` / `NfspConfig::seed`
+    /// (issue #114).
+    fn get_actions_host_seeded_batched(
+        &self,
+        obs: Tensor<B, 2>,
+        rng: &mut StdRng,
+    ) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
+        self.get_action_host_seeded(obs, rng)
+    }
+
     /// Re-evaluate the policy on previously-sampled actions.
     ///
     /// `actions` is shape `[batch, num_dims]`. For scalar discrete policies
@@ -178,6 +216,16 @@ where
         (actions, log_probs, values)
     }
 
+    fn get_actions_host_seeded_batched(
+        &self,
+        obs: Tensor<B, 2>,
+        rng: &mut StdRng,
+    ) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
+        // One forward over all rows (same model) instead of per-row
+        // batch-1 forwards; RNG draw order unchanged (issue #235).
+        self.get_actions_host_seeded_batched(obs, rng)
+    }
+
     fn evaluate_actions_joint(
         &self,
         obs: Tensor<B, 2>,
@@ -212,6 +260,16 @@ where
         rng: &mut StdRng,
     ) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
         self.get_action_host_seeded(obs, rng)
+    }
+
+    fn get_actions_host_seeded_batched(
+        &self,
+        obs: Tensor<B, 2>,
+        rng: &mut StdRng,
+    ) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
+        // One forward over all rows (same model) instead of per-row
+        // batch-1 forwards; RNG draw order unchanged (issue #235).
+        self.get_actions_host_seeded_batched(obs, rng)
     }
 
     fn evaluate_actions_joint(

--- a/src/multi_agent/nfsp.rs
+++ b/src/multi_agent/nfsp.rs
@@ -676,25 +676,35 @@ where
             .iter()
             .find_map(|r| r.items().first().map(|(obs, _)| obs.len()))
             .unwrap_or(1);
-        let obs_data: Vec<f32> = vec![0.0_f32; obs_dim];
-        let obs = Tensor::<B, 2>::from_data(TensorData::new(obs_data, [1, obs_dim]), &self.device);
         // Use a forward+softmax probe. Implementations of
         // `JointPolicy` for `MlpBurnPolicy` and
         // `MultiDiscreteMlpBurnPolicy` both implement the standard
         // policy-head structure; we don't have a direct `logits()`
-        // method on the trait, so we sample `get_action_host_seeded`
-        // repeatedly and take the empirical marginal as the diagnostic.
-        // For a single-row constant observation this is correct in
-        // expectation; it's a host-side probe with no autograd cost.
+        // method on the trait, so we sample the policy repeatedly and
+        // take the empirical marginal as the diagnostic. For a single-row
+        // constant observation this is correct in expectation; it's a
+        // host-side probe with no autograd cost.
+        //
+        // Issue #235: all `probes` rows are the **same constant
+        // observation** scored through the **same** policy, so we stack
+        // them into one `[probes, obs_dim]` tensor and do a *single*
+        // batched forward via `get_actions_host_seeded_batched` instead
+        // of `probes` batch-1 forwards. The batched sampler draws one
+        // `rng.random()` per row in ascending order — bit-identical to
+        // the old per-probe loop — so the seeded marginal trace is
+        // unchanged (guarded by `test_nfsp_avg_marginal_trace_is_bit_identical`).
         let probes = 128usize;
+        let obs_data: Vec<f32> = vec![0.0_f32; probes * obs_dim];
+        let obs =
+            Tensor::<B, 2>::from_data(TensorData::new(obs_data, [probes, obs_dim]), &self.device);
+        let (acts, _, _) = policy.get_actions_host_seeded_batched(obs, &mut self.rng);
         let mut counts = vec![0u32; action_dim];
-        for _ in 0..probes {
-            let (acts, _, _) = policy.get_action_host_seeded(obs.clone(), &mut self.rng);
-            if let Some(&a) = acts.first() {
-                let idx = a as usize;
-                if idx < action_dim {
-                    counts[idx] += 1;
-                }
+        // Scalar-discrete (`dims.len() == 1`) guaranteed above, so the
+        // batched action layout is one entry per row.
+        for &a in acts.iter().take(probes) {
+            let idx = a as usize;
+            if idx < action_dim {
+                counts[idx] += 1;
             }
         }
         Some(counts.iter().map(|&c| c as f32 / probes as f32).collect())

--- a/src/policy/mlp.rs
+++ b/src/policy/mlp.rs
@@ -553,8 +553,8 @@ impl<B: Backend> MlpBurnPolicy<B> {
     /// Batched seeded sampler: one forward over `[N, obs_dim]`, then N
     /// host-side categorical draws in row-major order.
     ///
-    /// Bit-identical to calling [`get_action_host_seeded`] once per row on
-    /// `[1, obs_dim]` slices **provided the rows are drawn from the same
+    /// Bit-identical to calling [`Self::get_action_host_seeded`] once per row
+    /// on `[1, obs_dim]` slices **provided the rows are drawn from the same
     /// policy** — the forward is a single matmul over all N rows (same
     /// weights), and the RNG is consumed one draw per row, ascending. This
     /// is the [`crate::multi_agent::joint::JointPolicy`]-trait batched

--- a/src/policy/mlp.rs
+++ b/src/policy/mlp.rs
@@ -142,6 +142,54 @@ pub enum BurnActivation {
     Tanh,
 }
 
+/// Host-side categorical distribution for one or more rows, produced by
+/// [`MlpBurnPolicy::forward_to_host_dist`].
+///
+/// Holds the flattened per-row `probs` / `log_probs` (`[batch, n_actions]`
+/// row-major) and per-row `values`. The seeded draw lives in
+/// [`HostCategoricalDist::sample_actions`] so the tensor forward and the
+/// RNG-consuming sample are cleanly separated — the precondition that lets
+/// the batched sampler do one `[N, obs_dim]` forward while keeping the
+/// per-row RNG draw order bit-identical (issue #235).
+struct HostCategoricalDist {
+    batch: usize,
+    n_actions: usize,
+    probs_flat: Vec<f32>,
+    log_probs_flat: Vec<f32>,
+    values_host: Vec<f32>,
+}
+
+impl HostCategoricalDist {
+    /// Draw one action per row from the categorical distribution, consuming
+    /// exactly one `rng.random()` per row in ascending row order. Returns
+    /// `(actions, log_probs_of_chosen, values)`.
+    ///
+    /// The draw is byte-for-byte the loop that
+    /// [`MlpBurnPolicy::get_action_host_seeded`] used before the
+    /// forward/sample split, so a same-seeded `rng` reproduces the exact
+    /// same action stream (issue #114 / #235).
+    fn sample_actions(&self, rng: &mut rand::rngs::StdRng) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
+        use rand::Rng;
+        let mut actions = Vec::with_capacity(self.batch);
+        let mut log_probs = Vec::with_capacity(self.batch);
+        for row in 0..self.batch {
+            let u: f32 = rng.random();
+            let mut cum = 0.0;
+            let mut chosen = (self.n_actions - 1) as i64;
+            for j in 0..self.n_actions {
+                cum += self.probs_flat[row * self.n_actions + j];
+                if u < cum {
+                    chosen = j as i64;
+                    break;
+                }
+            }
+            actions.push(chosen);
+            log_probs.push(self.log_probs_flat[row * self.n_actions + chosen as usize]);
+        }
+        (actions, log_probs, self.values_host.clone())
+    }
+}
+
 /// Configuration for [`MlpBurnPolicy`] architecture.
 ///
 /// Mirrors [`crate::policy::mlp::MlpBurnConfig`] on the tch path. Stored
@@ -460,7 +508,32 @@ impl<B: Backend> MlpBurnPolicy<B> {
         obs: Tensor<B, 2>,
         rng: &mut rand::rngs::StdRng,
     ) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
-        use rand::Rng;
+        // Decoupled into a pure-tensor forward (`forward_to_host_dist`,
+        // no RNG) followed by a host-side categorical draw
+        // (`sample_actions_from_host_dist`, the only RNG-consuming half).
+        // This split is what makes the **batched** entry point
+        // (`get_actions_host_seeded_batched`) possible without changing
+        // the per-row RNG draw order: a single forward over `[N, obs_dim]`
+        // produces N rows of host probs, then the per-row loop draws RNG in
+        // the exact same row-major sequence as N separate `[1, obs_dim]`
+        // calls would. Bit-exactness (issue #114 / #235) is therefore
+        // preserved by construction.
+        let dist = self.forward_to_host_dist(obs);
+        dist.sample_actions(rng)
+    }
+
+    /// Tensor half of [`get_action_host_seeded`]: run the policy forward
+    /// and pull the host-side categorical distribution (`probs`,
+    /// `log_probs`) plus values for every row. **Consumes no RNG.**
+    ///
+    /// Returns a [`HostCategoricalDist`] from which
+    /// [`HostCategoricalDist::sample_actions`] performs the seeded draw.
+    /// Splitting the forward (one batched tensor op over `[N, obs_dim]`)
+    /// from the sample (a row-major host loop) lets the batched sampler
+    /// replace N batch-1 forwards with a single `[N, obs_dim]` forward
+    /// while keeping the RNG draw order — and therefore the sampled
+    /// action stream — bit-identical (issue #235).
+    fn forward_to_host_dist(&self, obs: Tensor<B, 2>) -> HostCategoricalDist {
         let (logits, value) = self.forward(obs);
         let probs = activation::softmax(logits.clone(), 1);
         let log_probs_all = activation::log_softmax(logits, 1);
@@ -474,23 +547,26 @@ impl<B: Backend> MlpBurnPolicy<B> {
             log_probs_all.into_data().to_vec().expect("log_probs to_vec");
         let values_host: Vec<f32> = value.into_data().to_vec().expect("values to_vec");
 
-        let mut actions = Vec::with_capacity(batch);
-        let mut log_probs = Vec::with_capacity(batch);
-        for row in 0..batch {
-            let u: f32 = rng.random();
-            let mut cum = 0.0;
-            let mut chosen = (n_actions - 1) as i64;
-            for j in 0..n_actions {
-                cum += probs_flat[row * n_actions + j];
-                if u < cum {
-                    chosen = j as i64;
-                    break;
-                }
-            }
-            actions.push(chosen);
-            log_probs.push(log_probs_flat[row * n_actions + chosen as usize]);
-        }
-        (actions, log_probs, values_host)
+        HostCategoricalDist { batch, n_actions, probs_flat, log_probs_flat, values_host }
+    }
+
+    /// Batched seeded sampler: one forward over `[N, obs_dim]`, then N
+    /// host-side categorical draws in row-major order.
+    ///
+    /// Bit-identical to calling [`get_action_host_seeded`] once per row on
+    /// `[1, obs_dim]` slices **provided the rows are drawn from the same
+    /// policy** — the forward is a single matmul over all N rows (same
+    /// weights), and the RNG is consumed one draw per row, ascending. This
+    /// is the [`crate::multi_agent::joint::JointPolicy`]-trait batched
+    /// entry point that eliminates per-call batch-1 overhead on the
+    /// NdArray backend wherever many observations are scored through the
+    /// **same** model in one step (issue #235).
+    pub fn get_actions_host_seeded_batched(
+        &self,
+        obs: Tensor<B, 2>,
+        rng: &mut rand::rngs::StdRng,
+    ) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
+        self.forward_to_host_dist(obs).sample_actions(rng)
     }
 
     /// Evaluate a batch of `(obs, actions)` pairs.

--- a/src/policy/multi_discrete_mlp.rs
+++ b/src/policy/multi_discrete_mlp.rs
@@ -334,8 +334,8 @@ impl<B: Backend> MultiDiscreteMlpBurnPolicy<B> {
     /// Batched seeded sampler: one forward over `[N, obs_dim]`, then N
     /// host-side categorical draws in `row major → dim major` order.
     ///
-    /// Bit-identical to calling [`get_action_host_seeded`] once per row on
-    /// `[1, obs_dim]` slices **provided the rows are drawn from the same
+    /// Bit-identical to calling [`Self::get_action_host_seeded`] once per row
+    /// on `[1, obs_dim]` slices **provided the rows are drawn from the same
     /// policy** (same weights in the single batched forward, RNG consumed
     /// one draw per dim per row, ascending). The
     /// [`crate::multi_agent::joint::JointPolicy`]-trait batched entry point

--- a/src/policy/multi_discrete_mlp.rs
+++ b/src/policy/multi_discrete_mlp.rs
@@ -16,6 +16,60 @@ use super::mlp::{
     seeded_layer_weights,
 };
 
+/// Host-side per-dim categorical distributions for one or more rows,
+/// produced by [`MultiDiscreteMlpBurnPolicy::forward_to_host_dist`].
+///
+/// `probs_per_dim[d] = (n_actions_d, probs_flat_d, log_probs_flat_d)`
+/// where the flats are `[batch, n_actions_d]` row-major. The seeded draw
+/// lives in [`MultiDiscreteHostDist::sample_actions`] so the tensor
+/// forward and the RNG-consuming sample are cleanly separated — the
+/// precondition that lets the batched sampler do one `[N, obs_dim]`
+/// forward while keeping the per-row/per-dim RNG draw order bit-identical
+/// (issue #235).
+struct MultiDiscreteHostDist {
+    batch: usize,
+    num_dims: usize,
+    probs_per_dim: Vec<(usize, Vec<f32>, Vec<f32>)>,
+    values_host: Vec<f32>,
+}
+
+impl MultiDiscreteHostDist {
+    /// Draw one action per dim per row, consuming exactly one
+    /// `rng.random()` per (row, dim) in `row major → dim major` order.
+    /// Returns `(actions [batch*num_dims], joint_log_probs [batch],
+    /// values [batch])`.
+    ///
+    /// Byte-for-byte the loop `get_action_host_seeded` used before the
+    /// forward/sample split, so a same-seeded `rng` reproduces the exact
+    /// same action stream (issue #114 / #235).
+    fn sample_actions(&self, rng: &mut rand::rngs::StdRng) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
+        use rand::Rng;
+        let mut actions = vec![0_i64; self.batch * self.num_dims];
+        let mut log_probs = vec![0.0_f32; self.batch];
+        for row in 0..self.batch {
+            let mut joint_lp = 0.0_f32;
+            for (d, (n_actions, probs_flat, log_probs_flat)) in
+                self.probs_per_dim.iter().enumerate()
+            {
+                let u: f32 = rng.random();
+                let mut cum = 0.0;
+                let mut chosen = (*n_actions - 1) as i64;
+                for j in 0..*n_actions {
+                    cum += probs_flat[row * n_actions + j];
+                    if u < cum {
+                        chosen = j as i64;
+                        break;
+                    }
+                }
+                actions[row * self.num_dims + d] = chosen;
+                joint_lp += log_probs_flat[row * n_actions + chosen as usize];
+            }
+            log_probs[row] = joint_lp;
+        }
+        (actions, log_probs, self.values_host.clone())
+    }
+}
+
 /// Multi-discrete MLP actor-critic policy on Burn.
 ///
 /// Shared trunk built from the same `MlpBurnConfig` knobs the
@@ -237,7 +291,20 @@ impl<B: Backend> MultiDiscreteMlpBurnPolicy<B> {
         obs: Tensor<B, 2>,
         rng: &mut rand::rngs::StdRng,
     ) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
-        use rand::Rng;
+        // Decoupled into a pure-tensor forward (`forward_to_host_dist`, no
+        // RNG) and a host-side categorical draw
+        // (`MultiDiscreteHostDist::sample_actions`, the only RNG-consuming
+        // half). See the analogous split on `MlpBurnPolicy`: it preserves
+        // the per-row `row major → dim major` RNG draw order while letting
+        // the batched entry point replace N batch-1 forwards with a single
+        // `[N, obs_dim]` forward (issue #235).
+        self.forward_to_host_dist(obs).sample_actions(rng)
+    }
+
+    /// Tensor half of [`get_action_host_seeded`]: run the policy forward
+    /// and extract the per-dim host-side categorical distributions for
+    /// every row. **Consumes no RNG.**
+    fn forward_to_host_dist(&self, obs: Tensor<B, 2>) -> MultiDiscreteHostDist {
         let (logits_per_dim, value) = self.forward(obs);
         let num_dims = logits_per_dim.len();
         assert!(num_dims > 0, "at least one action dim");
@@ -261,29 +328,26 @@ impl<B: Backend> MultiDiscreteMlpBurnPolicy<B> {
         let batch = batch_opt.unwrap_or(0);
         let values_host: Vec<f32> = value.into_data().to_vec().expect("values to_vec");
 
-        let mut actions = vec![0_i64; batch * num_dims];
-        let mut log_probs = vec![0.0_f32; batch];
+        MultiDiscreteHostDist { batch, num_dims, probs_per_dim, values_host }
+    }
 
-        for row in 0..batch {
-            let mut joint_lp = 0.0_f32;
-            for (d, (n_actions, probs_flat, log_probs_flat)) in probs_per_dim.iter().enumerate() {
-                let u: f32 = rng.random();
-                let mut cum = 0.0;
-                let mut chosen = (*n_actions - 1) as i64;
-                for j in 0..*n_actions {
-                    cum += probs_flat[row * n_actions + j];
-                    if u < cum {
-                        chosen = j as i64;
-                        break;
-                    }
-                }
-                actions[row * num_dims + d] = chosen;
-                joint_lp += log_probs_flat[row * n_actions + chosen as usize];
-            }
-            log_probs[row] = joint_lp;
-        }
-
-        (actions, log_probs, values_host)
+    /// Batched seeded sampler: one forward over `[N, obs_dim]`, then N
+    /// host-side categorical draws in `row major → dim major` order.
+    ///
+    /// Bit-identical to calling [`get_action_host_seeded`] once per row on
+    /// `[1, obs_dim]` slices **provided the rows are drawn from the same
+    /// policy** (same weights in the single batched forward, RNG consumed
+    /// one draw per dim per row, ascending). The
+    /// [`crate::multi_agent::joint::JointPolicy`]-trait batched entry point
+    /// that eliminates per-call batch-1 overhead wherever many
+    /// observations are scored through the **same** model in one step
+    /// (issue #235).
+    pub fn get_actions_host_seeded_batched(
+        &self,
+        obs: Tensor<B, 2>,
+        rng: &mut rand::rngs::StdRng,
+    ) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
+        self.forward_to_host_dist(obs).sample_actions(rng)
     }
 
     /// Evaluate given actions: per-step summed log-prob, per-step mean

--- a/tests/test_seeded_reproducibility.rs
+++ b/tests/test_seeded_reproducibility.rs
@@ -159,3 +159,46 @@ fn test_nfsp_avg_marginal_trace_is_bit_identical() {
     let c = nfsp_avg_marginal_trace(8);
     assert_ne!(a, c, "different seed should change the trace");
 }
+
+/// Golden-reference pin for the NFSP avg-policy action stream (issue #235).
+///
+/// The marginal trace is the empirical action distribution accumulated by
+/// `NfspTrainer::action_marginal_for`'s seeded probe loop, which flows
+/// through the **batched** seeded sampler
+/// (`JointPolicy::get_actions_host_seeded_batched`) introduced in #235.
+/// Pinning it to a literal captured from `main` *before* the batching
+/// refactor proves the forward/sample decoupling + single-batched-forward
+/// probe is **bit-for-bit** identical to the previous per-row batch-1
+/// loop — the load-bearing determinism guarantee the issue requires.
+///
+/// Whereas `test_nfsp_avg_marginal_trace_is_bit_identical` only checks
+/// run-vs-run equality at a fixed seed (which a *consistent* RNG-reordering
+/// would still pass), this test would fail if the batched path changed the
+/// action stream at all. If a future change intentionally alters the
+/// stream, re-capture the literal and document the change.
+#[test]
+fn test_nfsp_avg_marginal_stream_matches_golden_reference() {
+    // Reference captured on `main` @ 5beae49 (pre-#235) by running
+    // `nfsp_avg_marginal_trace(7)` with the *old* per-probe batch-1
+    // sampler. The #235 batched sampler reproduces it exactly.
+    let golden: Vec<f32> = vec![
+        0.46875_f32,
+        0.53125_f32,
+        0.5625_f32,
+        0.4375_f32,
+        0.5703125_f32,
+        0.4296875_f32,
+        0.625_f32,
+        0.375_f32,
+        0.5234375_f32,
+        0.4765625_f32,
+        0.5390625_f32,
+        0.4609375_f32,
+    ];
+    let trace = nfsp_avg_marginal_trace(7);
+    assert_eq!(
+        trace, golden,
+        "NFSP avg-marginal action stream (seed 7) must be bit-identical to the pre-#235 \
+         reference; the batched seeded sampler must not change the RNG draw order"
+    );
+}


### PR DESCRIPTION
## Summary

Implements issue #235's batched seeded-sampling refactor for NFSP. The headline win is a **bit-identical** ~5.7x speedup on the scalar-discrete NFSP per-iteration time, achieved by collapsing the per-step batch-1 forwards in the seeded action-marginal probe into a single batched forward through one model.

**Important determinism note (this is the crux of the issue):** the new action stream is **bit-for-bit identical** to `main` for a fixed seed. The RNG draw order is preserved exactly; a golden-reference test pins it.

**Correction to the issue's premise:** the issue body proposes "stack the `num_agents` agents' observations into one `[N, obs_dim]` tensor and do a single forward per step." This is **structurally impossible** for NFSP's rollout: each of the `num_agents` agents has a *distinct* policy module, and a single Burn forward applies one weight set to every row. NFSP also runs a single shared joint episode (`env.step_joint`), so there is no within-model batch dimension to collapse in the rollout itself — the per-step rollout forward count is irreducible without parallel envs (the EnvPool approach the issue explicitly defers). PSRO's `collect_rollout` has the identical distinct-model batch-1 structure. The batched trait method therefore targets the within-model multi-row paths (the marginal probe today; future frozen-model / parallel-env scoring), and the code/PR document why naive cross-agent batching was rejected.

## Changes

- **`JointPolicy` trait** (`src/multi_agent/joint.rs`): add `get_actions_host_seeded_batched(obs: [N, obs_dim], rng)` with a **default impl** that falls back to the existing per-row `get_action_host_seeded` (backward-compatible — no other implementor breaks). Override on both concrete `JointPolicy` impls.
- **MLP + multi-discrete policies** (`src/policy/mlp.rs`, `src/policy/multi_discrete_mlp.rs`): decouple the host sampler into a pure tensor forward (`forward_to_host_dist`, no RNG) and a host-side seeded draw (`HostCategoricalDist` / `MultiDiscreteHostDist`). One batched forward + per-row draws in the exact original row-major (and dim-major) order. `get_action_host_seeded` now composes the two halves, unchanged externally.
- **NFSP probe** (`src/multi_agent/nfsp.rs`): `action_marginal_for` now stacks all 128 constant-obs probes into one `[128, obs_dim]` batched forward instead of 128 batch-1 calls. RNG order unchanged.
- **Determinism test** (`tests/test_seeded_reproducibility.rs`): new `test_nfsp_avg_marginal_stream_matches_golden_reference` pins the seed-7 avg-marginal action stream to a literal captured from `main` @ 5beae49 *before* the refactor.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Batched per-step forward path for NFSP rollout (reuse PSRO BR rollout if clean) | ✅ (with documented decision) | Batched trait method added + used on the within-model probe path. Cross-agent rollout batching is **infeasible** (distinct per-agent models, single shared episode) — documented in code + this PR. PSRO `collect_rollout` has the same distinct-model structure; the trait method is available there for any future within-model batch. |
| Measurable per-iteration speedup on a short NFSP run (report before/after s/iter) | ✅ | Scalar-discrete (matching-pennies, 2 agents, probe path active): **~0.102 s/iter → ~0.018 s/iter (~5.7x)**, RAYON_NUM_THREADS=1, mean of 3×200-iter runs. Bucket-brigade (multi-discrete): **neutral by construction** — `action_marginal_for` early-returns for `dims.len() != 1`, so the probe loop never runs and the rollout forwards are untouched (`cumulative_br_pushes=1643` identical before/after; 2-iter wall-clock ~101 vs ~118 s/iter is machine noise on a busy box, not a code path difference). |
| Determinism: test pins action stream (bit-identical reference) OR documented change | ✅ **bit-identical** | Golden literal `[0.46875, 0.53125, 0.5625, 0.4375, 0.5703125, 0.4296875, 0.625, 0.375, 0.5234375, 0.4765625, 0.5390625, 0.4609375]` captured on `main` reproduced exactly. New golden test passes; existing `test_nfsp_avg_marginal_trace_is_bit_identical` + `test_psro_exploitability_trace_is_bit_identical` pass. |
| Existing NFSP/joint tests pass | ✅ | `--lib` 399 passed; matching-pennies / n-player / multi-discrete-smoke / seeded-reproducibility all pass (RAYON_NUM_THREADS=1). |

## Determinism approach

**Bit-identical.** The forward (tensor op) is separated from the categorical sample (the only RNG-consuming half). Batching only changes *when the forward runs* (one `[N, obs_dim]` matmul vs N `[1, obs_dim]` matmuls through the same weights); the host RNG is still consumed one `rng.random()` per row (per dim) in ascending order, so the sampled stream is unchanged. Verified against a pre-refactor literal.

## Test Plan

- `cargo test --features training --lib` → 399 passed.
- `cargo test --features training --test test_seeded_reproducibility` → 3 passed (incl. new golden test).
- `cargo test --features training` matching-pennies / n-player / multi-discrete-smoke → pass.
- `cargo clippy --all-targets --features training -- -D warnings` and `... --features "training,env-bucket-brigade" ...` → clean.
- `cargo fmt -- --check` → clean.
- Before/after timing measured by building an isolated release timing harness on both `main` and this branch (harness removed before commit).

Closes #235