### PR TITLE
docs: distinguish final-epoch vs best held-out EV in contiguous-split caveat

### DIFF
--- a/tests/test_bucket_brigade_critic_fittability.rs
+++ b/tests/test_bucket_brigade_critic_fittability.rs
@@ -61,11 +61,18 @@
 //! indicated fix for this cell.
 //!
 //! Caveat worth recording: the original episode-**contiguous** split gave
-//! strongly negative EV for both inputs, because per-episode return-level
-//! offsets (random opponents make each episode's overall fire severity vary
-//! wildly: return std ≈ 6000 on a mean of ≈ −12600) dominate the variance and
-//! do not transfer across held-out episodes. Shuffling isolates the
-//! within-state signal, which is what the critic needs for advantages.
+//! strongly negative *final-epoch* EV for both inputs, because per-episode
+//! return-level offsets (random opponents make each episode's overall fire
+//! severity vary wildly: return std ≈ 6000 on a mean of ≈ −12600) dominate the
+//! variance and do not transfer across held-out episodes. The harness tracks
+//! **best** held-out EV (early-stopping proxy) separately from **final**-epoch
+//! EV (see `best_ev`/`final_ev` below), and the tracked *best* EV stays mildly
+//! positive even under the contiguous split (≈ 0.23 local / ≈ 0.30 joint, a
+//! joint gain of ≈ +0.066 — still well under the 0.25 "meaningful partial
+//! observability" threshold); only the *final*-epoch EV goes strongly negative.
+//! Shuffling isolates the within-state obs→return signal, which is what the
+//! critic needs for advantages. Either way the conclusion is robust: partial
+//! observability is rejected under **both** the shuffled and contiguous splits.
 //!
 //! # Self-contained by design (issue #242 constraint)
 //!


### PR DESCRIPTION
## Summary
Tightens the methodology wording in the module-level doc comment of the BR critic fittability diagnostic. The contiguous-split caveat claimed the split gave "strongly negative EV for both inputs," which is accurate only for **final-epoch** EV. The harness actually tracks **best** held-out EV (early-stopping proxy) separately from final-epoch EV, and under the contiguous split the best EV stays mildly positive. This is a documentation-accuracy fix only — no behavioral change.

## Changes
- Rewrote the contiguous-split caveat block (around lines 63-76) to:
  - Attribute "strongly negative EV" specifically to **final-epoch** EV.
  - Note the tracked **best** held-out EV stays mildly positive even under the contiguous split (≈ 0.23 local / ≈ 0.30 joint, joint gain ≈ +0.066, still under the 0.25 meaningful-partial-observability threshold).
  - Reference the `best_ev`/`final_ev` distinction the harness already computes.
  - Preserve the shuffling rationale (isolating the within-state obs→return signal the critic needs for advantages) and record that partial observability is rejected under **both** shuffled and contiguous splits.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| "strongly negative EV" clarified as final-epoch EV | done | Caveat now reads "strongly negative *final-epoch* EV" |
| Best held-out EV noted as mildly positive (~0.23/~0.30) | done | Added "(≈ 0.23 local / ≈ 0.30 joint, joint gain ≈ +0.066 …)" |
| Shuffling rationale preserved; conclusion intact/strengthened | done | Rationale retained; added explicit "rejected under both shuffled and contiguous splits" |
| No logic, assertions, or thresholds changed | done | `git diff` shows only doc-comment lines changed |
| Test still passes unchanged | done | Test is `#[ignore]`-gated; crate + test target compile clean |

## Test Plan
- Verified the harness distinguishes best vs final held-out EV (`best_ev` tracked across epochs at lines 362-365; `final_ev` reported at lines 396-401) so the corrected wording is accurate.
- `cargo fmt --check`: clean.
- `cargo test --no-run --test test_bucket_brigade_critic_fittability --features training,env-bucket-brigade`: compiles.
- `cargo clippy --test test_bucket_brigade_critic_fittability --features training,env-bucket-brigade -- -D warnings`: clean.
- Comment-only change; no test assertions or thresholds touched.

Closes #246