### PR TITLE
docs(research): #134 re-run #2 — #239 BR fix is weak/slow at cluster scale

### DIFF
--- a/docs/research/2026-06-bucket-brigade-validation.md
+++ b/docs/research/2026-06-bucket-brigade-validation.md
@@ -238,3 +238,120 @@ NFSP (`examples/games/bucket_brigade/train_nfsp.rs`):
 3. **NFSP learning investigation** — [#199](https://github.com/rjwalters/thrust/issues/199): raise average-policy training steps, diagnose the BR side, revisit reward scaling. **Root-caused + code-level fixes landed** — see [`2026-06-nfsp-avg-policy-undertraining.md`](./2026-06-nfsp-avg-policy-undertraining.md): `NfspConfig` gained an adaptive `avg_policy_min_reservoir_coverage` AP-step floor and a `br_reward_scale` knob (the unscaled `[−700, 0]` band drove the BR critic's `value_loss` to ~9.8M; ×0.01 fixes it). The AP demonstrably fits a factored `[10,2,2]` target to ~0.003 (well below `ln(40)`) when given enough gradient steps. The **full cluster re-run** at the ~9,800-entry reservoir scale remains gated on #134.
 4. **PSRO convergence investigation** — [#215](https://github.com/rjwalters/thrust/issues/215): root-cause the exploitability divergence. **Root-caused + code-level fixes landed** — see [`2026-06-psro-alpha-rank-payoff-magnitude.md`](./2026-06-psro-alpha-rank-payoff-magnitude.md): the α-rank Moran fixation probability saturates on the `[−700, 0]` band (`AlphaRankMetaSolver::with_payoff_span_normalization` restores magnitude invariance), and `PsroConfig` gained `br_reward_scale` mirroring #199. The α-rank-solve **perf** work (blocker #2) stays gated on a demonstrated convergence. The **full cluster re-run** remains gated on #134.
 5. Once #212 + #199 + #215 land, re-run both at a feasible, observable budget and recompute **cell-specific** `gap_closed_cell`.
+
+---
+
+# Re-run #2 — after the #239 best-response fix (2026-06-24)
+
+**Date:** 2026-06-24
+**HEAD:** `669692b` (current `main`, includes #239 BR fix, #241 EV-logging + `train_br_probe`, #235 batched-sampling, #236/#238 rayon parallelism)
+**Hardware:** alcubierro cluster — alc-2 / alc-6 / alc-8 (i9-14900K, 32 threads), Burn NdArray (CPU)
+**Status:** **Inconclusive-to-weak.** The [#239](https://github.com/rjwalters/thrust/issues/239)
+best-response fix *does* move the BR off the uniform floor at cluster scale, but **weakly,
+slowly, and cell-dependently** — and the full validation is now **performance-gated** by the
+same fix's training cost. No full 48-iteration run was completed; no canonical artifact promoted.
+
+## Why a re-run
+
+The original (2026-06-23) re-run with the #199/#215 knobs reproduced non-convergence and was
+root-caused to **[#239](https://github.com/rjwalters/thrust/issues/239)**: the PPO best-response
+does not learn (critic `value_loss` flat, policy entropy pinned at the `ln(40)` uniform floor).
+The #239 fix (apply grad-clip, `vf_coef 0.5`, **all-minibatch iteration**, `BR_TRAIN_STEPS=8`,
+`BR_REWARD_SCALE=0.001`) merged in PR #248 with a **local** result of critic EV `0.00 → 0.33`
+and entropy `1.22 → 0.99` on beta05. This re-run tests whether that reproduces at cluster scale.
+
+## Method
+
+A short smoke, not the full job. Per cell (beta01/05/09, one per node):
+
+- **BR-learning probe** — the #241 `train_br_probe` harness (freeze N−1 opponents, train one BR),
+  12 iterations × 2048 rollout, `BR_REWARD_SCALE=0.001 VF_COEF=0.5 BR_TRAIN_STEPS=8`,
+  `RAYON_NUM_THREADS=16`. This is the purpose-built fast A/B tool for the pivotal
+  "does the BR fit?" question, decoupled from the slow NFSP/PSRO outer loop.
+- **PSRO** — `train_psro` at 6×2048 with the #215 knobs (`ALPHA_RANK_NORMALIZE_SPAN=1`,
+  `MAX_PAYOFF_EVALS_PER_ITER=64`) + the #239 BR knobs.
+- **NFSP outer loop** — attempted at 6×2048 but **abandoned**: see "Performance wall" below.
+
+## Result 1 — the BR fix reproduces, but weakly (critic EV)
+
+Full 12-iteration `train_br_probe` trajectories (EV = critic explained variance; entropy floor ≈ `ln(40)/dim` per-dim ≈ 1.23 uniform):
+
+| Cell | EV iter 1–8 | EV iter 9–12 | Entropy 1 → 12 (min) | Verdict |
+|------|-------------|--------------|----------------------|---------|
+| **beta05** | ~0.00 | 0.011, **0.129, 0.126, 0.169** | 1.22 → 1.05 (**0.99 @ iter 8**) | reproduces #239 (EV up, entropy crosses 1.0) |
+| beta09 | ~0.00 | 0.035, 0.042, **0.132, 0.080** | 1.19 → 1.12 (1.10) | partial (EV up; entropy stays ≥ 1.0) |
+| beta01 | ~0.00 | 0.034, 0.072, **0.128** | 1.19 → 1.17 (1.13) | weakest (EV only starts climbing at iter 10) |
+
+**Reading:**
+
+- The fix **is real**: EV is genuinely > 0 by the end on all three cells, where the prior
+  run had it pinned at exactly 0. The mechanism #239 identified is correct.
+- But it is **much weaker than the local PR claimed**: EV reaches only **~0.1–0.17**, not 0.33,
+  and only **beta05** drops entropy below 1.0. The critic stays at EV 0 for the first **~8
+  iterations** before moving — the fit is slow to start.
+- **`mean_ep_return` does not improve** on any cell (flat ~−25k to −30k throughout). The policy
+  drifts off uniform but that has not yet translated into a stronger best response. This is the
+  crux: a marginally-fitting critic is not yet producing a useful BR.
+
+## Result 2 — PSRO exploitability (incomplete)
+
+Only **beta09** produced PSRO iterations before the co-scheduled probe contended for cores:
+
+| Cell | iters done | exploitability | note |
+|------|-----------|----------------|------|
+| beta09 | 2 / 6 | 11320 → **10498** (decreasing) | the desired direction, but only 2 points |
+| beta01 | 0 / 6 | — | **did not complete iteration 1 in ~67 min** of full-core time |
+| beta05 | 0 / 6 | — | same — iteration 1 incomplete at kill |
+
+beta09's two-point downward trend is encouraging versus the prior run's oscillation, but two
+points are not a convergence claim, and the other two cells produced no data at all.
+
+## Performance wall (the load-bearing finding)
+
+The #239 fix that makes the BR learn — `BR_TRAIN_STEPS=8` **× all-minibatch iteration per epoch**
+— multiplies BR-training cost per outer iteration, and that work runs over the bucket-brigade
+rollout that **[#235](https://github.com/rjwalters/thrust/issues/235) proved cannot be batched**
+(distinct per-agent policy modules in a shared joint episode). Measured on current `main` at the
+**reduced** 2048 rollout:
+
+- **`train_br_probe`** (single BR, frozen opponents): **~1.5 min/iter** — fast, this is why the probe was usable.
+- **NFSP outer loop**: **> 1 h/iter** — *no* NFSP iteration completed in ~1 h on any node. Abandoned in favor of the probe.
+- **PSRO outer loop**: **~25–65+ min/iter**, cell-dependent (beta09 ~23–33 min with full cores; beta01/05 > 67 min for iteration 1).
+
+The earlier "~150 s/iter at 48×2048" figure was **pre-#239** (the old, non-learning BR). The fix
+trades non-convergence for a throughput wall: a full 48-iteration × 6-run validation at this cost
+is **days-to-weeks** of cluster time for what the probe suggests is a **marginal** signal. Running
+it blind is not justified by the smoke.
+
+## Conclusion
+
+The #239 fix is **directionally correct but under-delivers at scale**: the BR critic begins to fit
+(EV 0 → ~0.1–0.17) where it previously did not, but the effect is weak, slow (~8 iters to onset),
+fails to lower entropy below the uniform floor on 2 of 3 cells, and does not yet improve
+best-response return. Combined with the new per-iteration cost, this does **not** clear the #134
+bar (`gap_closed_cell > 0` on ≥ 1 cell), and the full run is not currently worth its cluster cost.
+The result is logged as **inconclusive/weak**, superseding neither the original negative finding
+nor establishing a positive one.
+
+## Follow-ups filed
+
+- **BR-training throughput** — [#251](https://github.com/rjwalters/thrust/issues/251): the
+  all-minibatch × `BR_TRAIN_STEPS=8` cost over the un-batchable rollout makes the NFSP/PSRO outer
+  loops infeasible at validation budget. The cheapest tractability lever is reducing per-iter BR
+  cost (e.g. subsample minibatches, or parallel-env rollouts per #235's deferred EnvPool note).
+- **#239 efficacy gap at scale** — [#252](https://github.com/rjwalters/thrust/issues/252): local
+  probe gave EV → 0.33 / entropy → 0.99; cluster gives EV → ~0.15 / entropy ≥ 1.0 on 2/3 cells,
+  no return improvement. The fix needs strengthening (more BR iters? critic LR? the gated
+  separate-critic-optimizer?) before another full attempt.
+
+## Reproduction
+
+```bash
+# BR-learning probe (the fast A/B used here), per cell:
+CELL=beta05 ITERATIONS=12 ROLLOUT_STEPS=2048 \
+  BR_REWARD_SCALE=0.001 VF_COEF=0.5 BR_TRAIN_STEPS=8 \
+  cargo run --release --example train_br_probe --features "training,env-bucket-brigade"
+```
+
+Logs for this re-run: `run134-out/probe_{beta01,beta05,beta09}.log` and
+`run134-out/smoke_psro_{beta01,beta05,beta09}.log` on alc-2/6/8 (and pulled locally during the session).


### PR DESCRIPTION
## Summary

Documents the operator-run #134 re-run after the #239 best-response fix merged (PR #248). Appends a dated "Re-run #2 (2026-06-24)" section to `docs/research/2026-06-bucket-brigade-validation.md`. **Docs-only — no code changes.**

## What was run

A short cluster smoke on alc-2/6/8 (current `main` `669692b`, NdArray CPU), one cell per node:
- **BR-learning probe** (`train_br_probe`, #241) — 12×2048, the fast A/B for "does the BR critic fit?"
- **PSRO** — 6×2048 with the #215 + #239 knobs
- **NFSP outer loop** — attempted, abandoned (perf wall, see below)

## Findings

1. **The #239 fix reproduces directionally but weakly.** Critic EV climbs `0 → ~0.1–0.17` across the 3 cells (vs `0.33` local), crosses entropy < 1.0 on **only beta05**, onsets slowly (~iter 8), and **does not improve mean episode return** on any cell.
2. **PSRO incomplete** — only beta09 produced iters (exploitability 11320 → 10498, 2 points); beta01/05 did not finish iteration 1.
3. **Performance wall (load-bearing).** #239's all-minibatch × `BR_TRAIN_STEPS=8` over the un-batchable (#235) rollout makes the NFSP outer loop **>1 h/iter even at 2048** — a full 48×6 validation is days-to-weeks. Running it blind is not justified by the smoke.

**Net:** #134 stays **inconclusive/weak** — the BR fix is correct in mechanism but under-delivers at scale, and the full run is perf-gated.

## Follow-ups filed

- #251 — BR-training throughput (the outer-loop perf wall)
- #252 — #239 efficacy gap at cluster scale (EV plateaus ~0.15, no return gain)

## Note on #134 / #230 / #219

- **#134** remains `loom:blocked` (operator-gated) — not closed; this documents a second negative-leaning data point and routes the real blockers to #251/#252.
- **#230** (α-rank perf) stays gated — its unblock condition (demonstrated PSRO convergence) is **not** met.
- **#219** (CUDA benchmark) remains blocked on CUDA-toolkit hardware, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)