### PR TITLE
build(cargo): drop `linker = "clang"` pin, keep lld

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,9 @@
+# Use the fast lld linker. We pass it via `-fuse-ld=lld` rather than also
+# pinning `linker = "clang"`: the default gcc/cc driver (present on every Linux
+# box) honors `-fuse-ld=lld` too, so requiring clang added a dependency without
+# benefit — fresh machines failed with an opaque "linker `clang` not found".
+# Only `lld` itself is needed now (sudo apt install -y lld).
 [target.x86_64-unknown-linux-gnu]
-linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 [target.x86_64-apple-darwin]


### PR DESCRIPTION
## Summary
The Linux target in `.cargo/config.toml` pinned `linker = "clang"` to get the fast **lld** linker. But `-fuse-ld=lld` (already in `rustflags`) is what actually selects lld, and the default **gcc/cc** driver — present on every Linux box — honors that flag just as well. So the clang pin added a dependency with **no benefit**: fresh Linux machines without clang failed with an opaque ``linker `clang` not found``.

This surgically drops the `linker = "clang"` line and keeps the lld rustflag. The only remaining requirement is `lld` itself (`sudo apt install -y lld`) — the half that actually pays off.

## Motivation
Hit this on 4 alcubierre cluster nodes (alc-0/3/9/10) during the #134 run setup — all failed to build until clang was installed. This removes the papercut for any fresh Linux machine.

## Verification
On a Linux node (gcc-13, clang isolated): `cc -fuse-ld=lld <prog>` links successfully — exactly the operation cargo performs when `linker` is unset. macOS target (`-fuse-ld=lld` via brew LLVM) is unchanged.

## Scope
One-line config change, kept separate from the #134 research-run PR (#256).

🤖 Generated with [Claude Code](https://claude.com/claude-code)