### PR TITLE
docs(burn-backends): #219 fill cuda column in CPU-vs-GPU throughput table

### DIFF
--- a/docs/BURN_BACKENDS.md
+++ b/docs/BURN_BACKENDS.md
@@ -236,10 +236,41 @@ Median per-iteration wall-clock, lower is better. "CPU faster ×" is `wgpu / nda
 | `dqn_cartpole_steps_per_sec` (full loop) | 43.4 ms | 188.7 ms | 4.4× |
 | `sac_pendulum_steps_per_sec` (full loop) | 10.7 ms | 65.8 ms | 6.2× |
 
-(`cuda` was not run — the alc-2 host has the NVIDIA driver but no CUDA toolkit /
-`nvcc`, which `cubecl-cuda` needs to compile. The `wgpu` → Vulkan path drives the
-same 4090 and is the portable GPU backend; the cuda column is left for a future
-toolkit-equipped run.)
+#### cuda column (issue #219, measured 2026-06-28)
+
+The original #184 run left `cuda` blank — alc-2 had the NVIDIA driver but no CUDA
+toolkit. After installing `nvidia-cuda-toolkit` (nvcc 12.0.140) on the same host,
+the cuda backend was benched with
+`cargo bench --features "training,cuda" --bench trainer_throughput -- --warm-up-time 2 --measurement-time 10`.
+Because this is a **separate run**, its own `/ndarray` baseline (measured in the
+same invocation, slightly higher than #184's — normal run-to-run variance under
+host load) is shown alongside so the cuda/CPU ratio is apples-to-apples:
+
+| Benchmark group | NdArray (CPU, same run) | cuda (RTX 4090) | CPU faster × |
+| --- | --- | --- | --- |
+| `a2c_train_step` (per update) | 341 µs | 11.96 ms † | ~35× † |
+| `ppo_train_step` (per update) | 384 µs | 1.024 ms | 2.7× |
+| `dqn_train_step` (per update) | 46.0 ms | 150.2 ms | 3.3× |
+| `sac_train_step` (per update) | 840 µs | 2.633 ms | 3.1× |
+| `a2c_cartpole_steps_per_sec` (full loop) | 618 µs | 1.641 ms | 2.7× |
+| `ppo_cartpole_steps_per_sec` (full loop) | 805 µs | 2.930 ms | 3.6× |
+| `dqn_cartpole_steps_per_sec` (full loop) | 53.7 ms | 160.5 ms | 3.0× |
+| `sac_pendulum_steps_per_sec` (full loop) | 14.1 ms | 44.76 ms | 3.2× |
+
+† `a2c_train_step/cuda` did not stabilize — criterion reported a [0.77 ms, 11.96 ms,
+34.3 ms] spread, the signature of JIT-kernel / autotune contamination on the
+smallest workload. The stable lower bound (~0.77 ms ≈ 2.3× CPU) is in line with the
+other groups; treat the 35× median as an artifact, not a real regression.
+
+**Two findings.** (1) **cuda also trails the CPU NdArray backend** at these
+small-MLP sizes — by ~2.7–3.6×, exactly the #184 prediction. The dispatch-overhead
+story is identical: there isn't enough arithmetic per launch to amortize host↔device
+cost. (2) **cuda is consistently faster than wgpu** on the same 4090 (e.g. PPO full
+loop 2.93 ms vs wgpu 5.88 ms; SAC Pendulum 44.8 ms vs 65.8 ms; DQN per-update 150 ms
+vs 173 ms) — the native CUDA path has lower per-kernel launch overhead than wgpu →
+Vulkan, so it closes some of the gap to CPU but does not overturn the conclusion.
+**NdArray (CPU) remains the right default**; cuda is the better GPU choice over wgpu
+on Linux+NVIDIA when a workload is large enough to want a GPU at all.
 
 ### Interpretation
 

--- a/docs/research/data/2026-06-cuda-trainer-throughput-219.txt
+++ b/docs/research/data/2026-06-cuda-trainer-throughput-219.txt
@@ -1,0 +1,33 @@
+a2c_train_step/ndarray/synthetic_batch
+                        time:   [340.45 µs 340.63 µs 340.76 µs]
+ppo_train_step/ndarray/synthetic_batch
+                        time:   [384.16 µs 384.30 µs 384.42 µs]
+a2c_cartpole_steps_per_sec/ndarray/rollout_plus_update
+                        time:   [617.97 µs 618.30 µs 618.65 µs]
+ppo_cartpole_steps_per_sec/ndarray/rollout_plus_update
+                        time:   [805.15 µs 805.42 µs 805.66 µs]
+dqn_train_step/ndarray/replay_minibatch
+                        time:   [45.911 ms 45.984 ms 46.067 ms]
+dqn_cartpole_steps_per_sec/ndarray/env_step_plus_update
+                        time:   [53.636 ms 53.701 ms 53.771 ms]
+sac_train_step/ndarray/replay_minibatch
+                        time:   [839.32 µs 840.48 µs 841.53 µs]
+sac_pendulum_steps_per_sec/ndarray/env_step_plus_update
+                        time:   [14.046 ms 14.051 ms 14.056 ms]
+a2c_train_step/cuda/synthetic_batch
+                        time:   [765.74 µs 11.956 ms 34.335 ms]
+ppo_train_step/cuda/synthetic_batch
+                        time:   [1.0205 ms 1.0239 ms 1.0276 ms]
+a2c_cartpole_steps_per_sec/cuda/rollout_plus_update
+                        time:   [1.6298 ms 1.6410 ms 1.6549 ms]
+ppo_cartpole_steps_per_sec/cuda/rollout_plus_update
+                        time:   [2.9180 ms 2.9297 ms 2.9445 ms]
+dqn_train_step/cuda/replay_minibatch
+                        time:   [149.24 ms 150.17 ms 151.73 ms]
+dqn_cartpole_steps_per_sec/cuda/env_step_plus_update
+                        time:   [160.11 ms 160.53 ms 160.97 ms]
+sac_train_step/cuda/replay_minibatch
+                        time:   [2.6269 ms 2.6330 ms 2.6396 ms]
+sac_pendulum_steps_per_sec/cuda/env_step_plus_update
+                        time:   [44.682 ms 44.762 ms 44.856 ms]
+EXIT=0


### PR DESCRIPTION
Closes #219.

## Summary
The #184 throughput table left the `cuda` column blank — alc-2 had the NVIDIA driver but no CUDA toolkit. I installed `nvidia-cuda-toolkit` (nvcc 12.0.140) on alc-2 and ran the cuda bench:
```
cargo bench --features "training,cuda" --bench trainer_throughput -- --warm-up-time 2 --measurement-time 10
```

## Findings
1. **cuda also trails CPU NdArray** at these small-MLP sizes (~2.7–3.6×) — exactly the #184 dispatch-overhead prediction. Not enough arithmetic per launch to amortize host↔device cost.
2. **cuda consistently beats wgpu** on the same 4090 (e.g. PPO full loop 2.93 ms vs wgpu 5.88 ms; SAC Pendulum 44.8 ms vs 65.8 ms) — native CUDA has lower per-kernel launch overhead than wgpu→Vulkan. It closes part of the gap to CPU but doesn't overturn the conclusion.
3. `a2c_train_step/cuda` didn't stabilize (JIT/autotune contamination on the smallest workload; [0.77 ms … 34 ms] spread) — flagged in the table with the stable lower bound.

**NdArray (CPU) remains the right default; cuda is the better GPU choice over wgpu on Linux+NVIDIA** when a workload is large enough to want a GPU at all.

## Host
alc-2: i9-14900K / RTX 4090, Ubuntu 24.04, driver 580, nvcc 12.0.140, Burn 0.21. Raw criterion output committed under `docs/research/data/`.

## Acceptance criteria
- [x] `cuda` column added to the `docs/BURN_BACKENDS.md` CPU-vs-GPU table, with host spec.
- [x] One-line note comparing cuda vs wgpu vs CPU at the harness sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)