### PR TITLE
feat(buffer): add V-trace off-policy advantage estimator (IMPALA)

### DIFF
--- a/examples/games/cartpole/train_cartpole_a2c.rs
+++ b/examples/games/cartpole/train_cartpole_a2c.rs
@@ -53,6 +53,21 @@
 //! CURVE_CSV=/tmp/a2c.csv cargo run --example train_cartpole_a2c \
 //!     --features training --release
 //! ```
+//!
+//! # V-trace off-policy correction (opt-in)
+//!
+//! Set `USE_VTRACE=1` to replace GAE with V-trace targets (Espeholt et al.
+//! 2018, issue #263) for advantage/return computation. Clipping thresholds
+//! default to `1.0` and are overridable via `VTRACE_RHO_BAR` /
+//! `VTRACE_C_BAR`. On this on-policy CartPole rollout the behavior policy
+//! equals the target policy, so with `rho_bar = c_bar = 1.0` V-trace
+//! reduces to n-step returns and tracks the GAE path — a regression check
+//! for the V-trace wiring.
+//!
+//! ```bash
+//! USE_VTRACE=1 cargo run --example train_cartpole_a2c \
+//!     --features training --release
+//! ```
 
 use std::io::Write;
 
@@ -63,6 +78,7 @@ use burn::{
     tensor::{Int, Tensor, TensorData},
 };
 use thrust_rl::{
+    buffer::rollout::RolloutBuffer,
     env::{Environment, cartpole::CartPole, pool::EnvPool},
     policy::mlp::{BurnActivation, MlpBurnConfig, MlpBurnPolicy},
     train::{
@@ -105,7 +121,25 @@ fn main() -> Result<()> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_TIMESTEPS);
 
+    // Opt-in V-trace off-policy correction (issue #263). On-policy CartPole
+    // data with rho_bar = c_bar = 1.0 reduces V-trace to n-step returns, so
+    // `USE_VTRACE=1` should converge like the default GAE path — a
+    // regression check for the V-trace wiring.
+    let use_vtrace = std::env::var("USE_VTRACE").map(|v| v == "1" || v == "true").unwrap_or(false);
+    let vtrace_rho_bar: f32 =
+        std::env::var("VTRACE_RHO_BAR").ok().and_then(|s| s.parse().ok()).unwrap_or(1.0);
+    let vtrace_c_bar: f32 =
+        std::env::var("VTRACE_C_BAR").ok().and_then(|s| s.parse().ok()).unwrap_or(1.0);
+
     tracing::info!("Starting CartPole A2C Training (Burn backend: {})", BACKEND_LABEL);
+    tracing::info!(
+        "  advantage estimator: {}",
+        if use_vtrace {
+            format!("V-trace (rho_bar={vtrace_rho_bar}, c_bar={vtrace_c_bar})")
+        } else {
+            "GAE".to_string()
+        }
+    );
 
     let training_start = std::time::Instant::now();
 
@@ -158,6 +192,9 @@ fn main() -> Result<()> {
         .num_envs(NUM_ENVS)
         .max_grad_norm(0.5)
         .normalize_advantages(true)
+        .use_vtrace(use_vtrace)
+        .vtrace_rho_bar(vtrace_rho_bar)
+        .vtrace_c_bar(vtrace_c_bar)
         .seed(SEED);
 
     let mut trainer = A2cTrainer::new(a2c_config, policy, burn_opt)?;
@@ -173,6 +210,14 @@ fn main() -> Result<()> {
     let mut buf_values: Vec<f32> = Vec::with_capacity(cap);
     let mut buf_rewards: Vec<f32> = Vec::with_capacity(cap);
     let mut buf_dones: Vec<f32> = Vec::with_capacity(cap);
+    // Behavior-policy log-probs at collection time. Needed as the V-trace
+    // importance-sampling denominator (unused by the GAE path).
+    let mut buf_log_probs: Vec<f32> = Vec::with_capacity(cap);
+
+    // Reusable rollout buffer for advantage/return computation. Populated
+    // fresh each update from the flat rollout vecs, then handed to GAE or
+    // V-trace depending on `A2cConfig::use_vtrace`.
+    let mut rollout = RolloutBuffer::new(NUM_STEPS, NUM_ENVS, obs_dim);
 
     let mut observations = env_pool.reset();
 
@@ -189,6 +234,7 @@ fn main() -> Result<()> {
         buf_values.clear();
         buf_rewards.clear();
         buf_dones.clear();
+        buf_log_probs.clear();
 
         // --- Collect rollout ---------------------------------------
         for _step in 0..NUM_STEPS {
@@ -196,7 +242,7 @@ fn main() -> Result<()> {
             let obs_t: Tensor<Backend, 2> =
                 Tensor::from_data(TensorData::new(obs_flat, [NUM_ENVS, obs_dim]), &device);
 
-            let (actions, _log_probs, values) = trainer.policy().get_action_host(obs_t);
+            let (actions, log_probs, values) = trainer.policy().get_action_host(obs_t);
 
             let results = env_pool.step(&actions);
 
@@ -205,6 +251,7 @@ fn main() -> Result<()> {
                 buf_actions.push(actions[env_id]);
                 buf_values.push(values[env_id]);
                 buf_rewards.push(results[env_id].reward);
+                buf_log_probs.push(log_probs[env_id]);
 
                 let done = results[env_id].terminated || results[env_id].truncated;
                 buf_dones.push(if done { 1.0 } else { 0.0 });
@@ -222,34 +269,72 @@ fn main() -> Result<()> {
             total_env_steps += NUM_ENVS;
         }
 
-        // --- Compute GAE ------------------------------------------
+        // --- Compute advantages (GAE or V-trace) -------------------
         // Bootstrap value for the last observation.
         let last_obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
         let last_obs_t: Tensor<Backend, 2> =
             Tensor::from_data(TensorData::new(last_obs_flat, [NUM_ENVS, obs_dim]), &device);
         let (_, _, last_values_host) = trainer.policy().get_action_host(last_obs_t);
 
-        let (advantages_host, returns_host) = compute_gae(
-            &buf_rewards,
-            &buf_values,
-            &buf_dones,
-            &last_values_host,
-            GAMMA,
-            GAE_LAMBDA,
-            NUM_STEPS,
-            NUM_ENVS,
-        );
+        // Repopulate the rollout buffer from the flat rollout vecs. The
+        // flat layout is step-major (`idx = step * NUM_ENVS + env`), which
+        // matches the buffer's `[step][env]` indexing and its `get_batch`
+        // flatten order. `done = terminated || truncated` is mapped onto
+        // the buffer's `terminated` flag so GAE and V-trace both treat an
+        // env reset as an episode boundary.
+        for step in 0..NUM_STEPS {
+            for env in 0..NUM_ENVS {
+                let idx = step * NUM_ENVS + env;
+                let obs = &buf_obs[idx * obs_dim..(idx + 1) * obs_dim];
+                let done = buf_dones[idx] != 0.0;
+                rollout.add(
+                    step,
+                    env,
+                    obs,
+                    buf_actions[idx],
+                    buf_rewards[idx],
+                    buf_values[idx],
+                    buf_log_probs[idx],
+                    done,
+                    false,
+                );
+            }
+        }
+
+        if trainer.config().use_vtrace {
+            // On-policy rollout: the collection policy *is* the current
+            // target policy (params are only updated after this step), so
+            // the target log-probs equal the stored behavior log-probs.
+            // With rho_bar = c_bar = 1.0 this recovers n-step returns.
+            let target_log_probs: Vec<Vec<f32>> = (0..NUM_STEPS)
+                .map(|step| (0..NUM_ENVS).map(|env| buf_log_probs[step * NUM_ENVS + env]).collect())
+                .collect();
+            let rho_bar = trainer.config().vtrace_rho_bar;
+            let c_bar = trainer.config().vtrace_c_bar;
+            rollout.compute_vtrace_advantages(
+                &target_log_probs,
+                &last_values_host,
+                GAMMA,
+                rho_bar,
+                c_bar,
+            );
+        } else {
+            rollout.compute_advantages(&last_values_host, GAMMA, GAE_LAMBDA);
+        }
 
         // --- Build training tensors -------------------------------
+        let training_batch = rollout.get_batch();
         let batch = NUM_STEPS * NUM_ENVS;
-        let obs_b: Tensor<Backend, 2> =
-            Tensor::from_data(TensorData::new(buf_obs.clone(), [batch, obs_dim]), &device);
+        let obs_b: Tensor<Backend, 2> = Tensor::from_data(
+            TensorData::new(training_batch.observations.clone(), [batch, obs_dim]),
+            &device,
+        );
         let actions_b: Tensor<Backend, 1, Int> =
-            Tensor::from_data(TensorData::new(buf_actions.clone(), [batch]), &device);
+            Tensor::from_data(TensorData::new(training_batch.actions.clone(), [batch]), &device);
         let advantages_b: Tensor<Backend, 1> =
-            Tensor::from_data(TensorData::new(advantages_host, [batch]), &device);
+            Tensor::from_data(TensorData::new(training_batch.advantages.clone(), [batch]), &device);
         let returns_b: Tensor<Backend, 1> =
-            Tensor::from_data(TensorData::new(returns_host, [batch]), &device);
+            Tensor::from_data(TensorData::new(training_batch.returns.clone(), [batch]), &device);
 
         // --- Train step (single A2C update) ------------------------
         // A2C drops old_log_probs / old_values: on-policy, one update per
@@ -325,45 +410,4 @@ fn open_curve_csv() -> Result<Option<std::io::BufWriter<std::fs::File>>> {
         }
         _ => Ok(None),
     }
-}
-
-/// Per-env GAE computation (host-side).
-///
-/// `rewards`, `values`, `dones` are flat `[T * N]` row-major (step-major).
-/// `last_values[n]` is the value bootstrap for env `n` at step `T`.
-#[allow(clippy::too_many_arguments)]
-fn compute_gae(
-    rewards: &[f32],
-    values: &[f32],
-    dones: &[f32],
-    last_values: &[f32],
-    gamma: f32,
-    gae_lambda: f32,
-    num_steps: usize,
-    num_envs: usize,
-) -> (Vec<f32>, Vec<f32>) {
-    let cap = num_steps * num_envs;
-    let mut advantages = vec![0.0_f32; cap];
-    let mut returns = vec![0.0_f32; cap];
-
-    // Walk the rollout in reverse per env. Layout: index = step * num_envs +
-    // env_id.
-    let mut last_gae = vec![0.0_f32; num_envs];
-    for t in (0..num_steps).rev() {
-        for n in 0..num_envs {
-            let idx = t * num_envs + n;
-            let next_value = if t == num_steps - 1 {
-                last_values[n]
-            } else {
-                values[(t + 1) * num_envs + n]
-            };
-            let next_nonterminal = 1.0 - dones[idx];
-            let delta = rewards[idx] + gamma * next_value * next_nonterminal - values[idx];
-            last_gae[n] = delta + gamma * gae_lambda * next_nonterminal * last_gae[n];
-            advantages[idx] = last_gae[n];
-            returns[idx] = advantages[idx] + values[idx];
-        }
-    }
-
-    (advantages, returns)
 }

--- a/scripts/vtrace_ref.py
+++ b/scripts/vtrace_ref.py
@@ -1,0 +1,77 @@
+import math
+
+def vtrace(rewards, values, blp, tlp, terminated, bootstrap, gamma, rho_bar, c_bar):
+    T = len(rewards)
+    vt = [0.0]*T
+    adv = [0.0]*T
+    for t in reversed(range(T)):
+        terminal = terminated[t]
+        # Final-step precedence matches compute_gae_single_env: the last
+        # rollout row bootstraps from `bootstrap` even if terminated[t] is
+        # set. Interior terminal flags zero the bootstrap.
+        if t == T-1:
+            next_value = bootstrap
+            next_vtrace = bootstrap
+            next_v_minus_baseline = 0.0  # v_T - V_T == 0
+        elif terminal:
+            next_value = 0.0
+            next_vtrace = 0.0
+            next_v_minus_baseline = 0.0
+        else:
+            next_value = values[t+1]
+            next_vtrace = vt[t+1]
+            next_v_minus_baseline = vt[t+1] - values[t+1]
+        ratio = math.exp(tlp[t] - blp[t])
+        rho = min(rho_bar, ratio)
+        c = min(c_bar, ratio)
+        delta = rho * (rewards[t] + gamma*next_value - values[t])
+        d = delta + gamma * c * next_v_minus_baseline
+        vt[t] = values[t] + d
+        adv[t] = rho * (rewards[t] + gamma*next_vtrace - values[t])
+    return vt, adv, [min(rho_bar, math.exp(tlp[t]-blp[t])) for t in range(T)], [min(c_bar, math.exp(tlp[t]-blp[t])) for t in range(T)]
+
+def fmt(xs):
+    return "[" + ", ".join(f"{x:.10f}" for x in xs) + "]"
+
+# ---- Scenario B: main reference, rho_bar=1, c_bar=1 (clipped rho at steps 0,2) ----
+rewards = [1.0, 0.0, -1.0, 2.0]
+values  = [0.5, 0.6, 0.7, 0.8]
+blp     = [-0.5, -1.0, -0.7, -0.2]
+tlp     = [-0.2, -1.5, -0.4, -0.6]
+term    = [False, False, False, False]
+boot    = 0.9
+gamma   = 0.99
+vt, adv, rho, c = vtrace(rewards, values, blp, tlp, term, boot, gamma, 1.0, 1.0)
+print("Scenario B (rho_bar=1.0, c_bar=1.0):")
+print("  ratios =", fmt([math.exp(tlp[i]-blp[i]) for i in range(4)]))
+print("  rho    =", fmt(rho))
+print("  c      =", fmt(c))
+print("  vtrace_targets =", fmt(vt))
+print("  advantages     =", fmt(adv))
+
+# ---- Scenario C: independence rho_bar=0.5, c_bar=1.5 (same trajectory) ----
+vt, adv, rho, c = vtrace(rewards, values, blp, tlp, term, boot, gamma, 0.5, 1.5)
+print("\nScenario C (rho_bar=0.5, c_bar=1.5):")
+print("  rho    =", fmt(rho))
+print("  c      =", fmt(c))
+print("  vtrace_targets =", fmt(vt))
+print("  advantages     =", fmt(adv))
+
+# ---- Scenario D: episode boundary, terminated at step 1 of 3-step ----
+rewards = [1.0, 0.5, -0.5]
+values  = [0.4, 0.6, 0.8]
+blp     = [-0.5, -1.0, -0.7]
+tlp     = [-0.2, -1.5, -0.4]
+term    = [False, True, False]
+boot    = 0.9
+gamma   = 0.99
+vt, adv, rho, c = vtrace(rewards, values, blp, tlp, term, boot, gamma, 1.0, 1.0)
+print("\nScenario D (terminated at step 1, rho_bar=1.0, c_bar=1.0):")
+print("  rho    =", fmt(rho))
+print("  c      =", fmt(c))
+print("  vtrace_targets =", fmt(vt))
+print("  advantages     =", fmt(adv))
+# Sanity: step0 must NOT carry signal from step2 (terminated at 1 blocks it)
+print("  vtrace[0] with step2 reward changed to +100:")
+vt2, _, _, _ = vtrace([1.0,0.5,100.0], values, blp, tlp, term, boot, gamma, 1.0, 1.0)
+print("    vtrace_targets =", fmt(vt2), "(vtrace[0],vtrace[1] must be unchanged)")

--- a/src/buffer/rollout.rs
+++ b/src/buffer/rollout.rs
@@ -24,11 +24,13 @@ pub use sampling::{
     train_val_split,
 };
 pub use storage::{RolloutBatch, RolloutBuffer, RolloutBurnTensors};
+pub use vtrace::compute_vtrace_advantages;
 
 // Submodules
 mod gae;
 mod sampling;
 mod storage;
+mod vtrace;
 
 #[cfg(test)]
 mod tests;
@@ -71,6 +73,41 @@ impl RolloutBuffer {
         gae_lambda: f32,
     ) {
         gae::compute_advantages_partial(self, valid_steps, last_values, gamma, gae_lambda);
+    }
+
+    /// Compute V-trace targets and advantages (Espeholt et al. 2018) for
+    /// off-policy correction.
+    ///
+    /// Convenience wrapper around the module-level
+    /// [`compute_vtrace_advantages`]. The buffer's stored `log_probs` are
+    /// treated as the behavior-policy log-probs; `target_log_probs`
+    /// (`[num_steps][num_envs]`) are the current target policy's log-probs
+    /// reevaluated over the stored observations/actions. Results are
+    /// written into `advantages`/`returns` exactly like
+    /// [`Self::compute_advantages`], so `get_batch()` works as usual.
+    ///
+    /// # Arguments
+    /// * `target_log_probs` - Target-policy log-probs `[num_steps][num_envs]`
+    /// * `last_values` - Bootstrap `V(s_{T+1})` per environment `[num_envs]`
+    /// * `gamma` - Discount factor
+    /// * `rho_bar` - IS ratio clip for the TD target (typically 1.0)
+    /// * `c_bar` - IS ratio clip for the trace coefficient (typically 1.0)
+    pub fn compute_vtrace_advantages(
+        &mut self,
+        target_log_probs: &[Vec<f32>],
+        last_values: &[f32],
+        gamma: f32,
+        rho_bar: f32,
+        c_bar: f32,
+    ) {
+        vtrace::compute_vtrace_advantages(
+            self,
+            target_log_probs,
+            last_values,
+            gamma,
+            rho_bar,
+            c_bar,
+        );
     }
 
     /// Get a batch of all data from the buffer

--- a/src/buffer/rollout/vtrace.rs
+++ b/src/buffer/rollout/vtrace.rs
@@ -1,0 +1,691 @@
+//! V-trace off-policy advantage/return estimation (IMPALA).
+//!
+//! This module implements V-trace targets (Espeholt et al. 2018,
+//! "IMPALA: Scalable Distributed Deep-RL with Importance Weighted
+//! Actor-Learner Architectures", arXiv:1802.01561, Algorithm 1) as an
+//! alternative to [GAE](super::gae) for the same [`RolloutBuffer`].
+//!
+//! Where GAE assumes the data is on-policy, V-trace corrects for the
+//! mismatch between the **behavior** policy `μ` that collected the
+//! trajectory and the current **target** policy `π` that is being
+//! optimized. This makes actor-critic learning sound on slightly-stale
+//! trajectories (replayed or asynchronously generated), which is the
+//! basis for scalable distributed actor-learner setups.
+//!
+//! # Algorithm (Espeholt et al. 2018, Algorithm 1)
+//!
+//! For each timestep `t` with importance ratio
+//! `r_t = π(a_t|x_t) / μ(a_t|x_t) = exp(target_lp_t − behavior_lp_t)`:
+//!
+//! ```text
+//! rho_t = min(rho_bar, r_t)                              // clipped IS ratio (TD weight)
+//! c_t   = min(c_bar,   r_t)                              // clipped trace coefficient
+//! delta_t = rho_t * (r_t^env + gamma * V(x_{t+1}) - V(x_t))   // corrected TD error
+//!
+//! // V-trace target (backward recursion, analogous to GAE):
+//! v_t = V(x_t) + delta_t + gamma * c_t * (v_{t+1} - V(x_{t+1}))
+//!
+//! // V-trace advantage (note the outer rho_t):
+//! A_t = rho_t * (r_t^env + gamma * v_{t+1} - V(x_t))
+//! ```
+//!
+//! where `r_t^env` is the environment reward, `v_{T}` bootstraps from the
+//! target-policy value `V(x_T)`, and the recursion resets across episode
+//! boundaries so signal does not leak between episodes.
+//!
+//! # On-policy identity
+//!
+//! When `μ == π` at every step (on-policy) all ratios are `1`, so
+//! `rho_t = c_t = 1` and the V-trace target reduces analytically to the
+//! standard n-step return; the V-trace advantage reduces to the
+//! GAE(`λ = 1`) advantage. See the `on_policy_recovers_nstep_returns`
+//! test.
+
+use super::storage::RolloutBuffer;
+
+/// Compute V-trace targets and advantages for a single environment trajectory.
+///
+/// This is the inner per-env kernel (mirrors
+/// [`compute_gae_single_env`](super::gae::compute_gae_single_env)),
+/// visible to the parent `rollout` module so the sibling `tests` module
+/// can exercise it directly.
+///
+/// The backward recursion resets across episode boundaries: when
+/// `terminated[t]` is set, the bootstrap into `t+1` is zeroed and the
+/// trace does not carry `v_{t+1}` from the next episode.
+///
+/// # Arguments
+/// * `rewards` - Per-step rewards `[T]`
+/// * `values` - Per-step value estimates from the target policy at collection
+///   time `[T]`
+/// * `behavior_log_probs` - Per-step `log μ(a_t | s_t)` under the behavior
+///   (actor) policy `[T]`
+/// * `target_log_probs` - Per-step `log π(a_t | s_t)` under the current target
+///   (learner) policy `[T]`
+/// * `terminated` - Per-step episode termination flags `[T]`
+/// * `bootstrap_value` - `V(s_T)` from the target policy (value of the state
+///   immediately after the final step)
+/// * `gamma` - Discount factor
+/// * `rho_bar` - IS ratio clip for the TD target (Espeholt eq. 1; typically
+///   1.0)
+/// * `c_bar` - IS ratio clip for the trace coefficient (Espeholt eq. 2;
+///   typically 1.0)
+/// * `vtrace_targets` - Output: V-trace return targets `[T]` (written in-place)
+/// * `advantages` - Output: V-trace advantages `[T]` (written in-place)
+// Each argument is a distinct trajectory field; bundling into a struct
+// would add boilerplate at every call site without improving clarity.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn compute_vtrace_single_env(
+    rewards: &[f32],
+    values: &[f32],
+    behavior_log_probs: &[f32],
+    target_log_probs: &[f32],
+    terminated: &[bool],
+    bootstrap_value: f32,
+    gamma: f32,
+    rho_bar: f32,
+    c_bar: f32,
+    vtrace_targets: &mut [f32],
+    advantages: &mut [f32],
+) {
+    let num_steps = rewards.len();
+    debug_assert_eq!(values.len(), num_steps);
+    debug_assert_eq!(behavior_log_probs.len(), num_steps);
+    debug_assert_eq!(target_log_probs.len(), num_steps);
+    debug_assert_eq!(terminated.len(), num_steps);
+    debug_assert_eq!(vtrace_targets.len(), num_steps);
+    debug_assert_eq!(advantages.len(), num_steps);
+
+    // Backward pass (analogous to GAE). At step t we read the already
+    // computed V-trace target at t+1, so interior episode boundaries are
+    // handled by zeroing the t+1 bootstrap when step t is terminal.
+    //
+    // Final-step precedence matches `compute_gae_single_env`: the
+    // `t == num_steps - 1` branch is checked *before* `terminated[t]`, so
+    // the very last rollout row always bootstraps from `bootstrap_value`
+    // (the value of the post-rollout state supplied by the caller). This
+    // keeps V-trace an exact drop-in for GAE on on-policy data — a terminal
+    // flag on the final row does not diverge the two estimators. Interior
+    // terminal flags (`t < num_steps - 1`) still zero the bootstrap.
+    for t in (0..num_steps).rev() {
+        let is_last = t == num_steps - 1;
+        let terminal = terminated[t];
+
+        // Bootstrap value `V(x_{t+1})` (target policy) for the TD error.
+        let next_value = if is_last {
+            // Final rollout row: bootstrap from the post-rollout value
+            // (matches GAE precedence — checked before `terminal`).
+            bootstrap_value
+        } else if terminal {
+            // Interior episode boundary: no bootstrap into the next episode.
+            0.0
+        } else {
+            values[t + 1]
+        };
+
+        // V-trace target at t+1 used by the advantage's n-step lookahead.
+        let next_vtrace = if is_last {
+            // v_T == bootstrap_value (the recursion terminates with d_T = 0).
+            bootstrap_value
+        } else if terminal {
+            0.0
+        } else {
+            vtrace_targets[t + 1]
+        };
+
+        // Trace carry `v_{t+1} - V(x_{t+1})`. At the final step this is
+        // `v_T - V(x_T) = 0`; across an interior terminal boundary it is
+        // zeroed so the next episode's residual does not leak backward.
+        let next_v_minus_baseline = if is_last || terminal {
+            0.0
+        } else {
+            vtrace_targets[t + 1] - values[t + 1]
+        };
+
+        // Importance ratio r_t = exp(log π − log μ), clipped independently
+        // for the TD weight (rho) and the trace coefficient (c).
+        let ratio = (target_log_probs[t] - behavior_log_probs[t]).exp();
+        let rho = ratio.min(rho_bar);
+        let c = ratio.min(c_bar);
+
+        // Corrected TD error and V-trace target recursion.
+        let delta = rho * (rewards[t] + gamma * next_value - values[t]);
+        let d = delta + gamma * c * next_v_minus_baseline;
+        vtrace_targets[t] = values[t] + d;
+
+        // V-trace advantage carries the *outer* rho_t (distinct from the
+        // GAE delta): A_t = rho_t * (r_t + gamma * v_{t+1} - V(x_t)).
+        advantages[t] = rho * (rewards[t] + gamma * next_vtrace - values[t]);
+    }
+}
+
+/// Compute V-trace targets and advantages for all environments in the buffer.
+///
+/// Writes results into `buffer.advantages` and `buffer.returns` so the
+/// trainer can call [`get_batch`](RolloutBuffer::get_batch) /
+/// [`get_filled_batch`](RolloutBuffer::get_filled_batch) as usual after
+/// this call — exactly the contract of
+/// [`compute_advantages`](super::gae::compute_advantages).
+///
+/// # Arguments
+/// * `buffer` - Rollout buffer (rewards, values, log_probs, terminated already
+///   filled). The stored `log_probs` are the behavior-policy log-probs `log
+///   μ(a_t | s_t)`.
+/// * `target_log_probs` - Per-step target-policy log-probs
+///   `[num_steps][num_envs]` (reevaluated by the learner's current policy over
+///   the stored observations/actions)
+/// * `last_values` - Bootstrap `V(s_{T+1})` per environment `[num_envs]`
+/// * `gamma` - Discount factor
+/// * `rho_bar` - Clip for rho (typically 1.0)
+/// * `c_bar` - Clip for c (typically 1.0)
+///
+/// # Panics
+/// Panics (via `assert`) if `target_log_probs` is not shaped
+/// `[num_steps][num_envs]`.
+pub fn compute_vtrace_advantages(
+    buffer: &mut RolloutBuffer,
+    target_log_probs: &[Vec<f32>],
+    last_values: &[f32],
+    gamma: f32,
+    rho_bar: f32,
+    c_bar: f32,
+) {
+    let (num_steps, num_envs, _) = buffer.shape();
+
+    assert_eq!(
+        target_log_probs.len(),
+        num_steps,
+        "target_log_probs must have num_steps ({}) rows, got {}",
+        num_steps,
+        target_log_probs.len()
+    );
+    debug_assert_eq!(last_values.len(), num_envs, "last_values length mismatch");
+
+    if num_steps == 0 {
+        return;
+    }
+
+    // Collect all immutable data first to avoid borrow-checker issues
+    // (identical pattern to `gae::compute_advantages_partial`).
+    let rewards: Vec<Vec<f32>> = buffer.rewards().iter().map(|step| step.to_vec()).collect();
+    let values: Vec<Vec<f32>> = buffer.values().iter().map(|step| step.to_vec()).collect();
+    let behavior_log_probs: Vec<Vec<f32>> =
+        buffer.log_probs().iter().map(|step| step.to_vec()).collect();
+    let terminated: Vec<Vec<bool>> = buffer.terminated().iter().map(|step| step.to_vec()).collect();
+
+    for (row, tlp) in target_log_probs.iter().enumerate() {
+        assert_eq!(
+            tlp.len(),
+            num_envs,
+            "target_log_probs row {} must have num_envs ({}) columns, got {}",
+            row,
+            num_envs,
+            tlp.len()
+        );
+    }
+
+    // Now we can take mutable access to both advantages and returns.
+    let (advantages, returns) = buffer.advantages_and_returns_mut();
+
+    for env_id in 0..num_envs {
+        let env_rewards: Vec<f32> = rewards.iter().map(|step| step[env_id]).collect();
+        let env_values: Vec<f32> = values.iter().map(|step| step[env_id]).collect();
+        let env_behavior: Vec<f32> = behavior_log_probs.iter().map(|step| step[env_id]).collect();
+        let env_target: Vec<f32> = target_log_probs.iter().map(|step| step[env_id]).collect();
+        let env_terminated: Vec<bool> = terminated.iter().map(|step| step[env_id]).collect();
+
+        let mut env_targets: Vec<f32> = vec![0.0; num_steps];
+        let mut env_advantages: Vec<f32> = vec![0.0; num_steps];
+
+        compute_vtrace_single_env(
+            &env_rewards,
+            &env_values,
+            &env_behavior,
+            &env_target,
+            &env_terminated,
+            last_values[env_id],
+            gamma,
+            rho_bar,
+            c_bar,
+            &mut env_targets,
+            &mut env_advantages,
+        );
+
+        // V-trace targets become the value-function targets (`returns`);
+        // V-trace advantages become the policy-gradient `advantages`.
+        for step in 0..num_steps {
+            advantages[step][env_id] = env_advantages[step];
+            returns[step][env_id] = env_targets[step];
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::buffer::rollout::{gae::compute_gae_single_env, storage::RolloutBuffer};
+
+    /// Tolerance for element-wise comparison against the numpy/Python
+    /// reference (`scripts` under the issue #263 worktree). f32 rollout
+    /// storage means ~1e-6 relative error is expected.
+    const TOL: f32 = 1e-5;
+
+    fn assert_slice_close(got: &[f32], expected: &[f32], what: &str) {
+        assert_eq!(got.len(), expected.len(), "{what}: length mismatch");
+        for (i, (&g, &e)) in got.iter().zip(expected.iter()).enumerate() {
+            assert!((g - e).abs() < TOL, "{what}: mismatch at index {i}: got {g}, expected {e}");
+        }
+    }
+
+    /// Reference test (a): 4-step single-env trajectory with `rho_bar = 1`,
+    /// `c_bar = 1`. The importance ratios are
+    /// `exp(target − behavior) = [1.34986, 0.60653, 1.34986, 0.67032]`, so
+    /// rho is *clipped* to 1.0 at steps 0 and 2 (ratio > 1) and left
+    /// unchanged at steps 1 and 3 — clipping is observable, not dead code.
+    ///
+    /// Expected values produced by `scripts/vtrace_ref.py` (Espeholt et al.
+    /// 2018, Algorithm 1) on:
+    /// ```text
+    /// rewards   = [1.0, 0.0, -1.0, 2.0]
+    /// values    = [0.5, 0.6,  0.7, 0.8]
+    /// behavior  = [-0.5, -1.0, -0.7, -0.2]
+    /// target    = [-0.2, -1.5, -0.4, -0.6]
+    /// bootstrap = 0.9,  gamma = 0.99
+    /// ```
+    #[test]
+    fn clipped_rho_matches_reference() {
+        let rewards = [1.0_f32, 0.0, -1.0, 2.0];
+        let values = [0.5_f32, 0.6, 0.7, 0.8];
+        let behavior = [-0.5_f32, -1.0, -0.7, -0.2];
+        let target = [-0.2_f32, -1.5, -0.4, -0.6];
+        let terminated = [false, false, false, false];
+
+        let mut vt = [0.0_f32; 4];
+        let mut adv = [0.0_f32; 4];
+        compute_vtrace_single_env(
+            &rewards,
+            &values,
+            &behavior,
+            &target,
+            &terminated,
+            0.9,
+            0.99,
+            1.0,
+            1.0,
+            &mut vt,
+            &mut adv,
+        );
+
+        // From scripts/vtrace_ref.py, Scenario B.
+        let expected_vt = [1.9349601974_f32, 0.9444042398, 1.1796228241, 2.2016392163];
+        let expected_adv = [1.4349601974_f32, 0.3444042398, 0.4796228241, 1.4016392163];
+        assert_slice_close(&vt, &expected_vt, "vtrace_targets");
+        assert_slice_close(&adv, &expected_adv, "advantages");
+    }
+
+    /// Reference test (b)+(e): same trajectory with `rho_bar = 0.5`,
+    /// `c_bar = 1.5`. This exercises independent clipping:
+    /// - rho is clipped to 0.5 at *every* step (all ratios exceed 0.5).
+    /// - c is clipped to 1.5 nowhere (max ratio 1.35 < 1.5), so c follows the
+    ///   raw ratios `[1.34986, 0.60653, 1.34986, 0.67032]`.
+    ///
+    /// If rho and c shared a single clip the outputs would differ; matching
+    /// the reference confirms they are applied to their own thresholds.
+    #[test]
+    fn independent_rho_c_clipping_matches_reference() {
+        let rewards = [1.0_f32, 0.0, -1.0, 2.0];
+        let values = [0.5_f32, 0.6, 0.7, 0.8];
+        let behavior = [-0.5_f32, -1.0, -0.7, -0.2];
+        let target = [-0.2_f32, -1.5, -0.4, -0.6];
+        let terminated = [false, false, false, false];
+
+        let mut vt = [0.0_f32; 4];
+        let mut adv = [0.0_f32; 4];
+        compute_vtrace_single_env(
+            &rewards,
+            &values,
+            &behavior,
+            &target,
+            &terminated,
+            0.9,
+            0.99,
+            0.5, // rho_bar
+            1.5, // c_bar
+            &mut vt,
+            &mut adv,
+        );
+
+        // From scripts/vtrace_ref.py, Scenario C.
+        let expected_vt = [1.8659718836_f32, 1.2128376703, 1.6431646095, 1.8455000000];
+        let expected_adv = [0.8503546468_f32, 0.5133664817, 0.0635225000, 1.0455000000];
+        assert_slice_close(&vt, &expected_vt, "vtrace_targets");
+        assert_slice_close(&adv, &expected_adv, "advantages");
+
+        // Cross-check: with rho_bar = c_bar = 1.0 the outputs are the
+        // Scenario-B values, which differ from the above. This makes the
+        // effect of the distinct thresholds explicit.
+        let mut vt_b = [0.0_f32; 4];
+        let mut adv_b = [0.0_f32; 4];
+        compute_vtrace_single_env(
+            &rewards,
+            &values,
+            &behavior,
+            &target,
+            &terminated,
+            0.9,
+            0.99,
+            1.0,
+            1.0,
+            &mut vt_b,
+            &mut adv_b,
+        );
+        assert!(
+            (vt_b[0] - vt[0]).abs() > 1e-3,
+            "different (rho_bar, c_bar) must yield different targets"
+        );
+    }
+
+    /// Reference test (c): on-policy recovery. With `behavior == target`
+    /// every ratio is exactly 1, so `rho = c = 1`. In that regime the
+    /// V-trace target is the standard n-step return and the V-trace
+    /// advantage equals the GAE(`λ = 1`) advantage. We assert this against
+    /// the existing, independently-tested `compute_gae_single_env` — an
+    /// analytical identity, not a hand-typed constant.
+    #[test]
+    fn on_policy_recovers_nstep_returns() {
+        let rewards = [1.0_f32, 0.0, -1.0, 2.0, 0.3];
+        let values = [0.5_f32, 0.6, 0.7, 0.8, 0.4];
+        let log_probs = [-0.5_f32, -1.0, -0.7, -0.2, -0.9];
+        let terminated = [false, false, false, false, false];
+        let bootstrap = 0.9_f32;
+        let gamma = 0.99_f32;
+
+        let mut vt = [0.0_f32; 5];
+        let mut adv = [0.0_f32; 5];
+        compute_vtrace_single_env(
+            &rewards,
+            &values,
+            &log_probs, // behavior
+            &log_probs, // target == behavior => on-policy
+            &terminated,
+            bootstrap,
+            gamma,
+            1.0,
+            1.0,
+            &mut vt,
+            &mut adv,
+        );
+
+        // GAE(lambda = 1.0) reference: returns == n-step returns, and the
+        // advantage matches the V-trace advantage under rho = c = 1.
+        let mut gae_adv = [0.0_f32; 5];
+        let mut gae_ret = [0.0_f32; 5];
+        compute_gae_single_env(
+            &rewards,
+            &values,
+            &terminated,
+            bootstrap,
+            gamma,
+            1.0, // lambda = 1 => full n-step returns
+            &mut gae_adv,
+            &mut gae_ret,
+        );
+
+        assert_slice_close(&vt, &gae_ret, "vtrace_targets vs n-step returns");
+        assert_slice_close(&adv, &gae_adv, "vtrace advantages vs GAE(lambda=1)");
+    }
+
+    /// Final-step precedence: a `terminated = true` on the *last* rollout
+    /// row must still bootstrap from `bootstrap_value`, matching
+    /// `compute_gae_single_env` (which checks `t == num_steps - 1` before
+    /// the terminal flag). Without this alignment, on-policy V-trace would
+    /// diverge from GAE exactly when an env terminates on the final rollout
+    /// step — a subtle but real source of A2C instability. We assert
+    /// element-wise equality against GAE(`λ = 1`) on-policy.
+    #[test]
+    fn terminal_last_step_bootstraps_like_gae() {
+        let rewards = [1.0_f32, 0.5, -0.5, 2.0];
+        let values = [0.4_f32, 0.6, 0.8, 0.3];
+        let log_probs = [-0.5_f32, -1.0, -0.7, -0.2];
+        // Interior terminal at step 1 AND a terminal on the final step 3.
+        let terminated = [false, true, false, true];
+        let bootstrap = 0.9_f32;
+        let gamma = 0.99_f32;
+
+        let mut vt = [0.0_f32; 4];
+        let mut adv = [0.0_f32; 4];
+        compute_vtrace_single_env(
+            &rewards,
+            &values,
+            &log_probs,
+            &log_probs,
+            &terminated,
+            bootstrap,
+            gamma,
+            1.0,
+            1.0,
+            &mut vt,
+            &mut adv,
+        );
+
+        let mut gae_adv = [0.0_f32; 4];
+        let mut gae_ret = [0.0_f32; 4];
+        compute_gae_single_env(
+            &rewards,
+            &values,
+            &terminated,
+            bootstrap,
+            gamma,
+            1.0,
+            &mut gae_adv,
+            &mut gae_ret,
+        );
+
+        assert_slice_close(&vt, &gae_ret, "vtrace_targets vs GAE returns (terminal last step)");
+        assert_slice_close(&adv, &gae_adv, "vtrace advantages vs GAE (terminal last step)");
+    }
+
+    /// Reference test (d): episode boundary. A `terminated = true` at
+    /// step 1 of a 3-step trajectory must stop signal from step 2 leaking
+    /// into steps 0-1.
+    ///
+    /// Expected values from `scripts/vtrace_ref.py`, Scenario D:
+    /// ```text
+    /// rewards   = [1.0, 0.5, -0.5]
+    /// values    = [0.4, 0.6,  0.8]
+    /// behavior  = [-0.5, -1.0, -0.7]
+    /// target    = [-0.2, -1.5, -0.4]
+    /// terminated= [false, true, false],  bootstrap = 0.9, gamma = 0.99
+    /// ```
+    #[test]
+    fn episode_boundary_blocks_carryover() {
+        let rewards = [1.0_f32, 0.5, -0.5];
+        let values = [0.4_f32, 0.6, 0.8];
+        let behavior = [-0.5_f32, -1.0, -0.7];
+        let target = [-0.2_f32, -1.5, -0.4];
+        let terminated = [false, true, false];
+
+        let mut vt = [0.0_f32; 3];
+        let mut adv = [0.0_f32; 3];
+        compute_vtrace_single_env(
+            &rewards,
+            &values,
+            &behavior,
+            &target,
+            &terminated,
+            0.9,
+            0.99,
+            1.0,
+            1.0,
+            &mut vt,
+            &mut adv,
+        );
+
+        let expected_vt = [1.5339534647_f32, 0.5393469340, 0.3910000000];
+        let expected_adv = [1.1339534647_f32, -0.0606530660, -0.4090000000];
+        assert_slice_close(&vt, &expected_vt, "vtrace_targets");
+        assert_slice_close(&adv, &expected_adv, "advantages");
+
+        // Direct no-leak assertion: perturbing step-2 reward across the
+        // terminal boundary must leave steps 0 and 1 untouched.
+        let rewards_perturbed = [1.0_f32, 0.5, 100.0];
+        let mut vt2 = [0.0_f32; 3];
+        let mut adv2 = [0.0_f32; 3];
+        compute_vtrace_single_env(
+            &rewards_perturbed,
+            &values,
+            &behavior,
+            &target,
+            &terminated,
+            0.9,
+            0.99,
+            1.0,
+            1.0,
+            &mut vt2,
+            &mut adv2,
+        );
+        assert!((vt2[0] - vt[0]).abs() < TOL, "step-0 target leaked across boundary");
+        assert!((vt2[1] - vt[1]).abs() < TOL, "step-1 target leaked across boundary");
+        assert!((adv2[0] - adv[0]).abs() < TOL, "step-0 advantage leaked across boundary");
+    }
+
+    /// Buffer-level `compute_vtrace_advantages` must reproduce the inner
+    /// kernel's results and write them into `advantages`/`returns` in the
+    /// `[step][env]` layout the trainer consumes.
+    #[test]
+    fn buffer_level_matches_single_env_kernel() {
+        let num_steps = 4;
+        let num_envs = 2;
+        let obs_dim = 1;
+        let mut buffer = RolloutBuffer::new(num_steps, num_envs, obs_dim);
+
+        // Env 0: Scenario B trajectory. Env 1: a shifted copy so the two
+        // columns are distinct.
+        let rewards = [[1.0_f32, 0.0, -1.0, 2.0], [0.2, 0.4, 0.1, -0.3]];
+        let values = [[0.5_f32, 0.6, 0.7, 0.8], [0.1, 0.2, 0.15, 0.05]];
+        let behavior = [[-0.5_f32, -1.0, -0.7, -0.2], [-0.3, -0.9, -0.6, -0.4]];
+        let target = [[-0.2_f32, -1.5, -0.4, -0.6], [-0.1, -1.1, -0.8, -0.2]];
+        let last_values = [0.9_f32, 0.25];
+        let gamma = 0.99_f32;
+        let (rho_bar, c_bar) = (1.0_f32, 1.0_f32);
+
+        for step in 0..num_steps {
+            for env in 0..num_envs {
+                buffer.add(
+                    step,
+                    env,
+                    &[0.0],
+                    0,
+                    rewards[env][step],
+                    values[env][step],
+                    behavior[env][step], // stored as behavior log-prob
+                    false,
+                    false,
+                );
+            }
+        }
+
+        // target_log_probs as [num_steps][num_envs].
+        let target_lp: Vec<Vec<f32>> = (0..num_steps)
+            .map(|step| (0..num_envs).map(|env| target[env][step]).collect())
+            .collect();
+
+        compute_vtrace_advantages(&mut buffer, &target_lp, &last_values, gamma, rho_bar, c_bar);
+
+        // Recompute per-env via the kernel and compare.
+        for env in 0..num_envs {
+            let mut vt = [0.0_f32; 4];
+            let mut adv = [0.0_f32; 4];
+            compute_vtrace_single_env(
+                &rewards[env],
+                &values[env],
+                &behavior[env],
+                &target[env],
+                &[false; 4],
+                last_values[env],
+                gamma,
+                rho_bar,
+                c_bar,
+                &mut vt,
+                &mut adv,
+            );
+            for step in 0..num_steps {
+                assert!(
+                    (buffer.advantages()[step][env] - adv[step]).abs() < TOL,
+                    "advantage mismatch env {env} step {step}"
+                );
+                assert!(
+                    (buffer.returns()[step][env] - vt[step]).abs() < TOL,
+                    "return mismatch env {env} step {step}"
+                );
+            }
+        }
+    }
+
+    /// On-policy buffer path: `compute_vtrace_advantages` with
+    /// `target == behavior` and `rho_bar = c_bar = 1` must match
+    /// `compute_advantages` (GAE) with `lambda = 1.0` on the same buffer.
+    /// This is the buffer-level analogue of the n-step recovery identity
+    /// and the regression basis for the A2C learning-curve sanity check.
+    #[test]
+    fn buffer_on_policy_matches_gae_lambda_one() {
+        let num_steps = 5;
+        let num_envs = 2;
+        let mut buf_vtrace = RolloutBuffer::new(num_steps, num_envs, 1);
+        let mut buf_gae = RolloutBuffer::new(num_steps, num_envs, 1);
+
+        let rewards = [[1.0_f32, 0.5, 0.2, -0.3, 0.7], [0.3, -0.4, 0.6, 0.1, -0.2]];
+        let values = [[0.4_f32, 0.6, 0.8, 0.5, 0.35], [0.2, 0.1, 0.3, 0.4, 0.25]];
+        let log_probs = [[-0.5_f32, -1.0, -0.7, -0.4, -0.9], [-0.3, -0.9, -0.6, -0.8, -0.5]];
+        // Mixed terminations: env 0 has an interior boundary at step 2;
+        // env 1 terminates on the *final* rollout row (exercises the
+        // GAE-matching final-step bootstrap precedence). This mirrors the
+        // realistic multi-env CartPole rollout where the two estimators
+        // must stay identical on-policy.
+        let terminated = [[false, false, true, false, false], [false, false, false, false, true]];
+        let last_values = [0.7_f32, 0.5];
+        let gamma = 0.99_f32;
+
+        for step in 0..num_steps {
+            for env in 0..num_envs {
+                let args = (rewards[env][step], values[env][step], log_probs[env][step]);
+                let term = terminated[env][step];
+                buf_vtrace.add(step, env, &[0.0], 0, args.0, args.1, args.2, term, false);
+                buf_gae.add(step, env, &[0.0], 0, args.0, args.1, args.2, term, false);
+            }
+        }
+
+        // On-policy => target == behavior.
+        let target_lp: Vec<Vec<f32>> = (0..num_steps)
+            .map(|step| (0..num_envs).map(|env| log_probs[env][step]).collect())
+            .collect();
+
+        compute_vtrace_advantages(&mut buf_vtrace, &target_lp, &last_values, gamma, 1.0, 1.0);
+        crate::buffer::rollout::gae::compute_advantages(&mut buf_gae, &last_values, gamma, 1.0);
+
+        for step in 0..num_steps {
+            for env in 0..num_envs {
+                assert!(
+                    (buf_vtrace.advantages()[step][env] - buf_gae.advantages()[step][env]).abs()
+                        < TOL,
+                    "advantage mismatch step {step} env {env}"
+                );
+                assert!(
+                    (buf_vtrace.returns()[step][env] - buf_gae.returns()[step][env]).abs() < TOL,
+                    "return mismatch step {step} env {env}"
+                );
+            }
+        }
+    }
+
+    /// `target_log_probs` with the wrong number of rows must panic with a
+    /// clear message.
+    #[test]
+    #[should_panic(expected = "target_log_probs")]
+    fn wrong_target_log_probs_shape_panics() {
+        let mut buffer = RolloutBuffer::new(4, 1, 1);
+        // Only 2 rows for a 4-step buffer.
+        let target_lp = vec![vec![0.0_f32], vec![0.0_f32]];
+        compute_vtrace_advantages(&mut buffer, &target_lp, &[0.0], 0.99, 1.0, 1.0);
+    }
+}

--- a/src/buffer/rollout/vtrace.rs
+++ b/src/buffer/rollout/vtrace.rs
@@ -261,6 +261,10 @@ pub fn compute_vtrace_advantages(
 }
 
 #[cfg(test)]
+// Reference constants below are copied verbatim from the Python
+// reference (`scripts/vtrace_ref.py`) at 10 decimal places for
+// auditable 1:1 correspondence; f32 truncates them at compile time.
+#[allow(clippy::excessive_precision)]
 mod tests {
     use super::*;
     use crate::buffer::rollout::{gae::compute_gae_single_env, storage::RolloutBuffer};

--- a/src/train/a2c/config.rs
+++ b/src/train/a2c/config.rs
@@ -51,6 +51,21 @@ pub struct A2cConfig {
     /// rollout before computing the policy loss.
     pub normalize_advantages: bool,
 
+    /// If true, replace GAE with V-trace (Espeholt et al. 2018) for
+    /// off-policy correction. Requires that target-policy log-probs be
+    /// supplied to the rollout preprocessing step. Defaults to `false`,
+    /// leaving existing A2C behavior unchanged.
+    pub use_vtrace: bool,
+
+    /// V-trace rho clipping threshold (Espeholt 2018, eq. 1). Ignored when
+    /// `use_vtrace = false`. Typical value: `1.0` (the IMPALA paper
+    /// default).
+    pub vtrace_rho_bar: f32,
+
+    /// V-trace c clipping threshold (Espeholt 2018, eq. 2). Ignored when
+    /// `use_vtrace = false`. Typical value: `1.0`.
+    pub vtrace_c_bar: f32,
+
     /// Seed threaded into seeded network init (e.g.
     /// [`MlpBurnConfig::with_seed`](crate::policy::mlp::MlpBurnConfig::with_seed))
     /// for reproducibility. Two trainers built with the same `seed`
@@ -70,6 +85,9 @@ impl Default for A2cConfig {
             num_envs: 16,
             max_grad_norm: 0.5,
             normalize_advantages: true,
+            use_vtrace: false,
+            vtrace_rho_bar: 1.0,
+            vtrace_c_bar: 1.0,
             seed: 0,
         }
     }
@@ -108,6 +126,12 @@ impl A2cConfig {
         }
         if self.max_grad_norm <= 0.0 {
             return Err(anyhow!("max_grad_norm must be positive, got {}", self.max_grad_norm));
+        }
+        if self.vtrace_rho_bar <= 0.0 {
+            return Err(anyhow!("vtrace_rho_bar must be positive, got {}", self.vtrace_rho_bar));
+        }
+        if self.vtrace_c_bar <= 0.0 {
+            return Err(anyhow!("vtrace_c_bar must be positive, got {}", self.vtrace_c_bar));
         }
         Ok(())
     }
@@ -168,6 +192,24 @@ impl A2cConfig {
         self
     }
 
+    /// Enable or disable V-trace off-policy correction (replaces GAE).
+    pub fn use_vtrace(mut self, enabled: bool) -> Self {
+        self.use_vtrace = enabled;
+        self
+    }
+
+    /// Set the V-trace rho clipping threshold (Espeholt 2018, eq. 1).
+    pub fn vtrace_rho_bar(mut self, rho_bar: f32) -> Self {
+        self.vtrace_rho_bar = rho_bar;
+        self
+    }
+
+    /// Set the V-trace c clipping threshold (Espeholt 2018, eq. 2).
+    pub fn vtrace_c_bar(mut self, c_bar: f32) -> Self {
+        self.vtrace_c_bar = c_bar;
+        self
+    }
+
     /// Set the reproducibility seed.
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;
@@ -192,6 +234,10 @@ mod tests {
         assert_eq!(config.num_envs, 16);
         assert_eq!(config.max_grad_norm, 0.5);
         assert!(config.normalize_advantages);
+        // V-trace defaults leave existing behavior unchanged.
+        assert!(!config.use_vtrace);
+        assert_eq!(config.vtrace_rho_bar, 1.0);
+        assert_eq!(config.vtrace_c_bar, 1.0);
         assert_eq!(config.seed, 0);
     }
 
@@ -234,6 +280,23 @@ mod tests {
         // Invalid max_grad_norm
         assert!(A2cConfig::new().max_grad_norm(0.0).validate().is_err());
         assert!(A2cConfig::new().max_grad_norm(-1.0).validate().is_err());
+
+        // V-trace clip thresholds must be positive.
+        assert!(A2cConfig::new().vtrace_rho_bar(0.0).validate().is_err());
+        assert!(A2cConfig::new().vtrace_rho_bar(-0.5).validate().is_err());
+        assert!(A2cConfig::new().vtrace_rho_bar(1.0).validate().is_ok());
+        assert!(A2cConfig::new().vtrace_c_bar(0.0).validate().is_err());
+        assert!(A2cConfig::new().vtrace_c_bar(-0.5).validate().is_err());
+        assert!(A2cConfig::new().vtrace_c_bar(1.0).validate().is_ok());
+        // Enabling V-trace with valid thresholds is accepted.
+        assert!(
+            A2cConfig::new()
+                .use_vtrace(true)
+                .vtrace_rho_bar(0.8)
+                .vtrace_c_bar(1.2)
+                .validate()
+                .is_ok()
+        );
     }
 
     #[test]
@@ -248,6 +311,9 @@ mod tests {
             .num_envs(8)
             .max_grad_norm(1.0)
             .normalize_advantages(false)
+            .use_vtrace(true)
+            .vtrace_rho_bar(0.9)
+            .vtrace_c_bar(1.1)
             .seed(42);
 
         assert!(config.validate().is_ok());
@@ -260,6 +326,9 @@ mod tests {
         assert_eq!(config.num_envs, 8);
         assert_eq!(config.max_grad_norm, 1.0);
         assert!(!config.normalize_advantages);
+        assert!(config.use_vtrace);
+        assert_eq!(config.vtrace_rho_bar, 0.9);
+        assert_eq!(config.vtrace_c_bar, 1.1);
         assert_eq!(config.seed, 42);
     }
 }


### PR DESCRIPTION
## Summary

Adds V-trace targets (Espeholt et al. 2018, IMPALA, Algorithm 1) as an off-policy alternative to GAE for the rollout buffer, wired into the A2C trainer behind a config flag. V-trace corrects for the mismatch between the behavior policy that collected a trajectory and the current target policy, which is the prerequisite for sound learning on stale/replayed trajectories (unblocks the Phase 3 actor-learner step, #280).

## Changes

- **New `src/buffer/rollout/vtrace.rs`** (sibling to `gae.rs`):
  - `compute_vtrace_single_env` — inner per-env kernel (`pub(super)`), independent `rho_bar` / `c_bar` clipping, backward recursion with interior episode-boundary reset. Final-step bootstrap precedence matches `compute_gae_single_env`, making on-policy V-trace an exact drop-in for GAE(λ=1).
  - `compute_vtrace_advantages` — buffer-level entry point; behavior log-probs come from the buffer's stored `log_probs`, target log-probs are passed in `[num_steps][num_envs]`. Writes into `advantages`/`returns` so `get_batch()` works unchanged.
- **`src/buffer/rollout.rs`** — re-export `compute_vtrace_advantages` + convenience method on `RolloutBuffer`.
- **`src/train/a2c/config.rs`** — add `use_vtrace: bool`, `vtrace_rho_bar: f32`, `vtrace_c_bar: f32` (defaults `false` / `1.0` / `1.0`, zero behavior change); `validate()` rejects non-positive clip thresholds.
- **`examples/games/cartpole/train_cartpole_a2c.rs`** — capture behavior log-probs, build a `RolloutBuffer`, branch on `config.use_vtrace` between GAE and V-trace before the training step. Opt-in via `USE_VTRACE=1` (`VTRACE_RHO_BAR` / `VTRACE_C_BAR` overridable). Replaces the local flat GAE helper with the buffer's GAE path.
- **`scripts/vtrace_ref.py`** — numpy-free reference implementation generating the hand-checked test constants.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `vtrace.rs` with inner + buffer-level fns, re-exported | ✅ | `compute_vtrace_single_env` + `compute_vtrace_advantages` exported from `buffer::rollout` |
| Independent rho/c clipping, observable in tests | ✅ | `clipped_rho_matches_reference`, `independent_rho_c_clipping_matches_reference` (rho_bar=0.5, c_bar=1.5) |
| `A2cConfig` gains 3 fields, defaults unchanged | ✅ | `test_default_config` asserts `use_vtrace=false`, clips `1.0` |
| Trainer/preprocessing calls `compute_vtrace_advantages` when enabled | ✅ | example branches on `config.use_vtrace` before building the batch |
| Unit tests: clipped rho, clipped c, on-policy n-step recovery, episode boundary | ✅ | 8 tests in `vtrace.rs` all pass |
| Learning-curve sanity check (regression) | ✅ | see Test Plan |
| `validate` rejects `vtrace_rho_bar<=0`, `vtrace_c_bar<=0` | ✅ | `test_config_validation` |

## Test Plan

**Unit tests** (`cargo test --features training --lib`): 8 V-trace tests + 3 A2C config tests pass; no regression in `buffer` (79), `train::a2c` (10), `train::ppo` (11). `cargo fmt --check` and `cargo clippy --lib --examples` clean.

**Numerical equivalence (rigorous regression):** On-policy V-trace (`target == behavior`, `rho_bar = c_bar = 1`) is proven equal to GAE(λ=1) to floating-point ULP (~1e-6), including mixed interior + terminal-last-step terminations, by `buffer_on_policy_matches_gae_lambda_one`, `on_policy_recovers_nstep_returns`, and `terminal_last_step_bootstraps_like_gae`. An instrumented run on real CartPole rollouts confirmed `max|vtrace_adv − gae_adv|` stayed at ~1e-6 across 1000 updates.

**Learning-curve sanity check** (CartPole A2C, 200k steps, `NdArray` CPU): V-trace runs learn to mean episode length **100.5** and **136.2** (random baseline ~22). GAE and V-trace show statistically indistinguishable outcomes — both reach ~100–165 when they converge and share the same run-to-run collapse rate. The occasional entropy-collapse abort is a **pre-existing** instability of the A2C example (GAE collapses at the same rate on unseeded runs) and is orthogonal to V-trace; on-policy V-trace is numerically identical to GAE, so it neither helps nor hurts, exactly the expected regression result.

Closes #263