### PR TITLE
feat(oracle): raw (beta,kappa,c) k* sweep mode + full 75-cell phase-diagram artifact

### DIFF
--- a/docs/research/2026-07-kstar-phase-diagram.md
+++ b/docs/research/2026-07-kstar-phase-diagram.md
@@ -1,0 +1,184 @@
+# k\* Coordination-Threshold Sweep Across the Full (β, κ, c) Phase-Diagram Grid
+
+**Date:** 2026-07-04
+**Issue:** [#269](https://github.com/rjwalters/thrust/issues/269) (gate: [#268](https://github.com/rjwalters/thrust/issues/268), infrastructure: PR [#271](https://github.com/rjwalters/thrust/pull/271))
+**Hardware:** alcubierre cluster — 6 × 32-core Linux x86_64 nodes (alc-2/5/6/8/9/10), release build, scripted policies only (no NN, no Burn, no PPO)
+**Artifact:** [`data/2026-07-kstar-phase-diagram.json`](data/2026-07-kstar-phase-diagram.json) — 75 records keyed by `cell_tag`
+
+## TL;DR
+
+The coalition improvability gate (k\*: smallest coalition size `k ∈ 1..=4` whose
+episode-level bootstrap CI on the team-return gap clears zero) was measured on
+the **full 5 × 5 × 3 = 75-cell paper grid** (β ∈ {0.1, 0.3, 0.5, 0.7, 0.9},
+κ ∈ {0.1, 0.3, 0.5, 0.7, 0.9}, c ∈ {0.5, 1.0, 2.0}) from
+`compute_nash_phase_diagram.py`. Three headline findings:
+
+1. **Every cell has a finite k\* ≤ 4** — there is no flat/near-degenerate cell
+   anywhere on the grid. Distribution: **k\* = 1 on 15 cells, k\* = 2 on 45
+   cells, k\* = 4 on 15 cells** (no cell lands at k\* = 3).
+2. **k\* is a pure function of κ** (the solo-extinguish probability):
+   κ = 0.1 → k\* = 4, κ ∈ {0.3, 0.5, 0.7} → k\* = 2, κ = 0.9 → k\* = 1.
+   Work cost c shifts gap magnitudes slightly (monotonically up with c) but
+   never moves k\*.
+3. **The β axis is degenerate**: per-cell results are **bit-identical across
+   all five β values** at every (κ, c). This is not a measurement artifact —
+   `prob_fire_spreads_to_neighbor` is structurally dead in the engine's
+   Bernoulli extinguish mode (see "The β axis measures nothing" below), which
+   all cells here inherit via `minimal_specialization-v1`.
+
+The #268 gate verdict is reproduced exactly: the canonical no-convergence cells
+(κ = 0.1, c = 0.5) show k\* = 4 with gap **+33.24, 95% CI (+18.99, +50.14)** —
+byte-identical to PR #271's headline numbers, cross-checked macOS-arm64 vs
+Linux-x86_64.
+
+## Protocol
+
+Identical to the #268 gate, generalized to raw (β, κ, c) triples
+(`run_phase_cell` in `src/multi_agent/bucket_brigade_oracle.rs`):
+
+- 4 agents; `k` scripted coordinated deviators vs `N − k` frozen uniform
+  opponents; scripted coalition battery (always-rest / specialist /
+  owned- and any-house firefighters / randomized firefighter search with 64
+  samples × 40 episodes / hero+specialists / rest+specialists heterogeneous
+  mixes for k ≥ 2).
+- 400 eval episodes per (cell, k), shared per-episode seed stream between the
+  baseline and every candidate (paired comparison), seed 42, step cap 1000.
+- Gap statistic: episode-mean of the per-episode per-step team-return gap
+  (ceiling − all-uniform baseline); 1000-resample episode-level percentile
+  bootstrap, α = 0.05.
+- k\* rule: smallest `k` with CI lower bound strictly > 0.
+- Base scenario `minimal_specialization-v1` with the three swept fields
+  overridden — the same construction as the Python `_make_scenario`.
+
+## Results
+
+### k\* over the grid
+
+k\* by (β, κ) — the table below holds **for every c ∈ {0.5, 1.0, 2.0}** and is
+constant down each column (β-degeneracy):
+
+| β \ κ | 0.1 | 0.3 | 0.5 | 0.7 | 0.9 |
+|-------|-----|-----|-----|-----|-----|
+| 0.1   | 4   | 2   | 2   | 2   | 1   |
+| 0.3   | 4   | 2   | 2   | 2   | 1   |
+| 0.5   | 4   | 2   | 2   | 2   | 1   |
+| 0.7   | 4   | 2   | 2   | 2   | 1   |
+| 0.9   | 4   | 2   | 2   | 2   | 1   |
+
+### Per-k gap detail
+
+Because results are bit-identical across β, the 15 (κ, c) combinations carry
+the grid's full information (shown at β = 0.5; `gap_mean [CI_lo, CI_hi]`,
+episode-mean per-step team-return gap):
+
+| κ | c | k\* | k=1 | k=2 | k=3 | k=4 | ceiling @ k\* |
+|-----|-----|----|-----------------------|-----------------------|--------------------------|--------------------------|---------------|
+| 0.1 | 0.5 | 4 | −4.93 [−13.61, +1.97] | −4.76 [−13.22, +2.11] | +3.61 [−5.63, +13.75]    | +33.24 [+18.99, +50.14]  | search-best firefighter (any, work=0.485) |
+| 0.1 | 1.0 | 4 | −4.67 [−13.36, +2.23] | −4.26 [−12.72, +2.61] | +4.35 [−4.89, +14.48]    | +34.17 [+19.92, +51.07]  | search-best firefighter (any, work=0.485) |
+| 0.1 | 2.0 | 4 | −4.17 [−12.85, +2.74] | −3.26 [−11.72, +3.62] | +5.81 [−3.42, +15.93]    | +36.02 [+21.78, +52.92]  | search-best firefighter (any, work=0.485) |
+| 0.3 | 0.5 | 2 | +8.93 [−2.96, +20.32] | +42.18 [+22.42, +62.81] | +47.74 [+28.25, +65.89] | +74.56 [+51.76, +97.84]  | all firefighter (owned, work=1.0) |
+| 0.3 | 1.0 | 2 | +9.17 [−2.71, +20.57] | +42.65 [+22.89, +63.27] | +48.46 [+28.97, +66.60] | +75.50 [+52.71, +98.78]  | all firefighter (owned, work=1.0) |
+| 0.3 | 2.0 | 2 | +9.66 [−2.21, +21.07] | +43.59 [+23.84, +64.20] | +49.89 [+30.40, +68.04] | +77.39 [+54.60, +100.65] | all firefighter (owned, work=1.0) |
+| 0.5 | 0.5 | 2 | −4.37 [−16.82, +9.63] | +64.61 [+40.44, +87.88] | +349.12 [+312.71, +384.78] | +449.80 [+415.98, +482.15] | search-best firefighter (any, work=0.345) |
+| 0.5 | 1.0 | 2 | −4.12 [−16.57, +9.88] | +65.08 [+40.92, +88.36] | +349.69 [+313.29, +385.33] | +450.51 [+416.70, +482.86] | search-best firefighter (any, work=0.345) |
+| 0.5 | 2.0 | 2 | −3.61 [−16.06, +10.39] | +66.03 [+41.88, +89.30] | +350.81 [+314.45, +386.43] | +451.93 [+418.15, +484.28] | search-best firefighter (any, work=0.345) |
+| 0.7 | 0.5 | 2 | −6.26 [−21.86, +8.84] | +403.17 [+369.17, +436.93] | +506.91 [+477.31, +533.27] | +527.88 [+499.93, +552.08] | all firefighter (any, work=1.0) |
+| 0.7 | 1.0 | 2 | −6.01 [−21.61, +9.10] | +403.52 [+369.53, +437.26] | +507.42 [+477.83, +533.77] | +528.55 [+500.60, +552.75] | all firefighter (any, work=1.0) |
+| 0.7 | 2.0 | 2 | −5.50 [−21.11, +9.61] | +404.23 [+370.27, +437.92] | +508.43 [+478.87, +534.77] | +529.89 [+501.93, +554.09] | all firefighter (any, work=1.0) |
+| 0.9 | 0.5 | 1 | +400.53 [+366.35, +434.58] | +524.62 [+497.22, +551.36] | +541.72 [+514.62, +567.93] | +560.70 [+535.75, +587.87] | all firefighter (any, work=1.0) |
+| 0.9 | 1.0 | 1 | +400.70 [+366.54, +434.76] | +524.94 [+497.56, +551.69] | +542.20 [+515.12, +568.40] | +561.55 [+536.61, +588.71] | all firefighter (any, work=1.0) |
+| 0.9 | 2.0 | 1 | +401.05 [+366.91, +435.12] | +525.60 [+498.24, +552.35] | +543.18 [+516.12, +569.35] | +563.24 [+538.33, +590.39] | all firefighter (any, work=1.0) |
+
+### Interpretation
+
+- **κ is the coordination knob.** At κ = 0.9 a single deviating firefighter
+  already clears the gate by ~+400 per-step team return per episode-mean —
+  solo extinguishing works, so one competent agent lifts the whole team. At
+  κ = 0.1 no coalition smaller than the full team of 4 is statistically
+  distinguishable from uniform play, exactly the "trainability cliff" the
+  slepian-wolf-marl-2 k\* reframe predicted for the no-convergence band. The
+  intermediate κ band uniformly needs pairs.
+- **The ceiling policy family tracks κ.** In the hard band (κ = 0.1) the best
+  coalition is a *throttled* any-house firefighter (work ≈ 0.49 — working
+  every night is a net loss when extinguishing rarely succeeds); by κ ≥ 0.7 it
+  is the maximal any-house firefighter (work = 1.0).
+- **c is a second-order effect**: raising the work cost slightly *raises* the
+  measured gap at every (κ, k) (the all-uniform baseline pays the higher cost
+  on wasted work more often than the coalition does) but never moves k\*.
+- **For the downstream join** (`recalibrated_verdict.json` /
+  `conditional_entropy.json` in rjwalters/bucket-brigade): joining on
+  `cell_tag` is well-defined for all 75 records, but any β-structure found in
+  those artifacts cannot be explained by env dynamics — see below.
+
+## The β axis measures nothing (engine finding)
+
+Per-cell results are **bit-identical** across β at every (κ, c) — verified by
+hashing all 75 per-cell records with `cell_tag`/`beta` fields stripped (15
+groups of 5 identical hashes). Root cause, in
+`envs/bucket-brigade/bucket-brigade-core/src/engine/core.rs::step`:
+
+```text
+3. extinguish phase   — burning houses may become SAFE
+4. burn-out phase     — every still-BURNING house becomes RUINED  (bernoulli mode)
+5. spread phase       — fire spreads only from BURNING houses
+6. spontaneous ignition
+```
+
+In the default `"bernoulli"` extinguish mode (which `minimal_specialization`
+uses), the burn-out phase clears **all** BURNING houses before `spread_fires`
+runs, so the spread loop's `houses[house_idx] == 1` guard never passes:
+`prob_fire_spreads_to_neighbor` is dead code regardless of value. Only the
+`"continuous"` extinguish mode (issue #253), whose burn-out returns early,
+can ever exercise fire spread.
+
+Implications:
+
+- The "β = fire-spread rate" axis of the phase diagram does not vary the
+  dynamics for any Bernoulli-mode scenario; the historical `beta01` /
+  `beta05` / `beta09` no-convergence cells are one cell measured three times.
+  (Consistent with the #268 gate quoting a single headline number for all
+  three cells.)
+- Any cross-β differences in downstream Nash/entropy artifacts computed on
+  Bernoulli-mode scenarios are sampling noise, not β structure.
+
+This is a pre-existing engine property, not introduced or fixed by this
+sweep; it is tracked separately in
+[#289](https://github.com/rjwalters/thrust/issues/289).
+
+## Reproduction
+
+Per-cell records were produced by the `PHASE=1` grid mode added to the
+`br_oracle` example (this issue), distributed over 6 alcubierre nodes
+(12–13 cells per node, one tmux session each, ~5 s of compute per cell after
+the release build; zero node failures, zero re-runs):
+
+```bash
+# Full 75-cell grid on one host (writes one JSON per cell to phase_out/):
+PHASE=1 K=4 EVAL_EPISODES=400 OUT_DIR=phase_out \
+    cargo run --release --example br_oracle \
+        --features "training,env-bucket-brigade"
+
+# Arbitrary cell subset (the distribution knob used on the cluster):
+PHASE=1 K=4 EVAL_EPISODES=400 OUT_DIR=out \
+    CELLS="0.1,0.1,0.5;0.1,0.1,1.0" \
+    cargo run --release --example br_oracle \
+        --features "training,env-bucket-brigade"
+```
+
+Existing per-cell outputs are skipped on re-run, so partial failures lose one
+cell, not the run. The committed artifact is the concatenation of the 75
+per-cell records under a `protocol` / `grid` header (see
+`data/2026-07-kstar-phase-diagram.json`; determinism means byte-identical
+records regardless of which host produced them).
+
+## Caveats
+
+- The scripted-battery ceiling is a **lower bound** on improvability: a
+  richer policy class could clear zero at smaller k. k\* here is "smallest k
+  at which *this battery* provably beats uniform," the same operational
+  definition the #268 gate used.
+- The bootstrap CI is per-(cell, k); no multiple-comparison correction is
+  applied across the 300 (cell, k) tests. With the κ-banded structure being
+  15-fold replicated (β-degeneracy) and effect sizes far from the decision
+  boundary everywhere except κ = 0.1 k = 3 (CI [−5.63, +13.75], comfortably
+  spanning zero), correction would not change any k\*.

--- a/docs/research/data/2026-07-kstar-phase-diagram.json
+++ b/docs/research/data/2026-07-kstar-phase-diagram.json
@@ -1,0 +1,3420 @@
+{
+  "schema_version": 1,
+  "generated": "2026-07-04",
+  "issue": 269,
+  "gate_result": {
+    "issue": 268,
+    "k_star_no_convergence_cells": 4
+  },
+  "protocol": {
+    "num_agents": 4,
+    "k_max": 4,
+    "eval_episodes": 400,
+    "search_episodes": 40,
+    "num_search": 64,
+    "n_boot": 1000,
+    "alpha": 0.05,
+    "seed": 42,
+    "step_cap": 1000,
+    "base_scenario": "minimal_specialization-v1",
+    "k_star_rule": "smallest k in 1..=4 with episode-level bootstrap CI lower bound on the per-episode per-step team-return gap strictly > 0"
+  },
+  "grid": {
+    "beta_values": [
+      0.1,
+      0.3,
+      0.5,
+      0.7,
+      0.9
+    ],
+    "kappa_values": [
+      0.1,
+      0.3,
+      0.5,
+      0.7,
+      0.9
+    ],
+    "c_values": [
+      0.5,
+      1.0,
+      2.0
+    ]
+  },
+  "cells": [
+    {
+      "cell_tag": "b0.10_k0.10_c0.50",
+      "beta": 0.1,
+      "kappa": 0.1,
+      "c": 0.5,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.926900746881204,
+          "gap_ci_lo": -13.609809831333028,
+          "gap_ci_hi": 1.9748816893542358,
+          "team_gap_per_step": 0.06402474306594286,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -4.75921405767817,
+          "gap_ci_lo": -13.223859514057825,
+          "gap_ci_hi": 2.108850113689652,
+          "team_gap_per_step": -0.10756851233043108,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 3.6117363268320526,
+          "gap_ci_lo": -5.628063096906378,
+          "gap_ci_hi": 13.745607086414013,
+          "team_gap_per_step": 0.9105313134783728,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 33.242607973688365,
+          "gap_ci_lo": 18.9915648234312,
+          "gap_ci_hi": 50.14218831869374,
+          "team_gap_per_step": 2.0191512883726546,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.10_c1.00",
+      "beta": 0.1,
+      "kappa": 0.1,
+      "c": 1.0,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.674179140545203,
+          "gap_ci_lo": -13.355271872003275,
+          "gap_ci_hi": 2.2282874199457026,
+          "team_gap_per_step": 0.3149376841229241,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -4.259349238813645,
+          "gap_ci_lo": -12.721111693067966,
+          "gap_ci_hi": 2.612288072690621,
+          "team_gap_per_step": 0.39276481294018595,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 4.345193714110715,
+          "gap_ci_lo": -4.8917053772920385,
+          "gap_ci_hi": 14.475203249983183,
+          "team_gap_per_step": 1.6446543569412597,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 34.16809683382402,
+          "gap_ci_lo": 19.92126928362049,
+          "gap_ci_hi": 51.069545945972294,
+          "team_gap_per_step": 2.9531389872755653,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.10_c2.00",
+      "beta": 0.1,
+      "kappa": 0.1,
+      "c": 2.0,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.168735927873216,
+          "gap_ci_lo": -12.846195953343868,
+          "gap_ci_hi": 2.73509888112861,
+          "team_gap_per_step": 0.8167635662364319,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -3.2596196010845957,
+          "gap_ci_lo": -11.71561605108825,
+          "gap_ci_hi": 3.6191639906925763,
+          "team_gap_per_step": 1.393431463481079,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 5.812108488668018,
+          "gap_ci_lo": -3.4189899380633504,
+          "gap_ci_hi": 15.934395577121528,
+          "team_gap_per_step": 3.112900443866806,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 36.01907455409539,
+          "gap_ci_lo": 21.780678203999088,
+          "gap_ci_hi": 52.92426120052904,
+          "team_gap_per_step": 4.8211143850811595,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.30_c0.50",
+      "beta": 0.1,
+      "kappa": 0.3,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 8.930311202389518,
+          "gap_ci_lo": -2.956750505999738,
+          "gap_ci_hi": 20.31722180932864,
+          "team_gap_per_step": 1.250406177355444,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 42.176808558357344,
+          "gap_ci_lo": 22.416327609293557,
+          "gap_ci_hi": 62.80614807588434,
+          "team_gap_per_step": -3.710885426794107,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 47.744327943326354,
+          "gap_ci_lo": 28.252792811795203,
+          "gap_ci_hi": 65.88629105016271,
+          "team_gap_per_step": 3.2609341731510995,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 74.56050001372093,
+          "gap_ci_lo": 51.764646575982454,
+          "gap_ci_hi": 97.83813394883263,
+          "team_gap_per_step": 5.692194440408571,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.30_c1.00",
+      "beta": 0.1,
+      "kappa": 0.3,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 9.173165395698136,
+          "gap_ci_lo": -2.7070229288241068,
+          "gap_ci_hi": 20.56648726913318,
+          "team_gap_per_step": 1.496959342172886,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 42.64928861478872,
+          "gap_ci_lo": 22.889866834336566,
+          "gap_ci_hi": 63.27190828953146,
+          "team_gap_per_step": -3.233987056725141,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 48.46019662140842,
+          "gap_ci_lo": 28.96733411665072,
+          "gap_ci_hi": 66.60294074399798,
+          "team_gap_per_step": 3.981510692824372,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 75.50297586277678,
+          "gap_ci_lo": 52.708194145049866,
+          "gap_ci_hi": 98.77691991217873,
+          "team_gap_per_step": 6.645032856672174,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.30_c2.00",
+      "beta": 0.1,
+      "kappa": 0.3,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 9.658873782315375,
+          "gap_ci_lo": -2.207567774472826,
+          "gap_ci_hi": 21.065018188742226,
+          "team_gap_per_step": 1.9900656718078835,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 43.594248727651454,
+          "gap_ci_lo": 23.835796743580435,
+          "gap_ci_hi": 64.20345840354928,
+          "team_gap_per_step": -2.2801903165870954,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 49.89193397757248,
+          "gap_ci_lo": 30.396416726361796,
+          "gap_ci_hi": 68.0362401316685,
+          "team_gap_per_step": 5.422663732171031,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 77.38792756088837,
+          "gap_ci_lo": 54.59528928318465,
+          "gap_ci_hi": 100.65449183887068,
+          "team_gap_per_step": 8.55070968919938,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.50_c0.50",
+      "beta": 0.1,
+      "kappa": 0.5,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.373747558796274,
+          "gap_ci_lo": -16.817929070622192,
+          "gap_ci_hi": 9.632890849264033,
+          "team_gap_per_step": -7.455822064160543,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 64.60818513830246,
+          "gap_ci_lo": 40.44018199975822,
+          "gap_ci_hi": 87.88359067262792,
+          "team_gap_per_step": -7.69680960531025,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 349.1221434537493,
+          "gap_ci_lo": 312.70982587491943,
+          "gap_ci_hi": 384.7810276353792,
+          "team_gap_per_step": -2.713448046494591,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 449.79755340254366,
+          "gap_ci_lo": 415.9760966333622,
+          "gap_ci_hi": 482.1521855363267,
+          "team_gap_per_step": 65.42692117725551,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.50_c1.00",
+      "beta": 0.1,
+      "kappa": 0.5,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.120082410047584,
+          "gap_ci_lo": -16.566367839983997,
+          "gap_ci_hi": 9.884612693994939,
+          "team_gap_per_step": -7.205414049046567,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 65.08137751184049,
+          "gap_ci_lo": 40.92152438892408,
+          "gap_ci_hi": 88.35507811084567,
+          "team_gap_per_step": -7.2175517927896635,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 349.6853877284018,
+          "gap_ci_lo": 313.2889105098023,
+          "gap_ci_hi": 385.327998881803,
+          "team_gap_per_step": -2.0646368755041067,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 450.50761233299534,
+          "gap_ci_lo": 416.7022732744152,
+          "gap_ci_hi": 482.86284443554655,
+          "team_gap_per_step": 66.27110608155283,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.50_c2.00",
+      "beta": 0.1,
+      "kappa": 0.5,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -3.6127521125501976,
+          "gap_ci_lo": -16.0632453787076,
+          "gap_ci_hi": 10.388056383456824,
+          "team_gap_per_step": -6.704598018818615,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 66.02776225891665,
+          "gap_ci_lo": 41.884209167255925,
+          "gap_ci_hi": 89.29805298728134,
+          "team_gap_per_step": -6.259036167748263,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 350.8118762777072,
+          "gap_ci_lo": 314.447079779569,
+          "gap_ci_hi": 386.43178120836257,
+          "team_gap_per_step": -0.7670145335232519,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 451.9277301938991,
+          "gap_ci_lo": 418.1546265565193,
+          "gap_ci_hi": 484.2841622339854,
+          "team_gap_per_step": 67.95947589014759,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.70_c0.50",
+      "beta": 0.1,
+      "kappa": 0.7,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -6.262290947524271,
+          "gap_ci_lo": -21.863143442278535,
+          "gap_ci_hi": 8.838273109042042,
+          "team_gap_per_step": -3.345209476908394,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 403.16618523190334,
+          "gap_ci_lo": 369.1652382517277,
+          "gap_ci_hi": 436.92684591835564,
+          "team_gap_per_step": 30.90034006927067,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 506.91226197178383,
+          "gap_ci_lo": 477.3098201077114,
+          "gap_ci_hi": 533.2700755611029,
+          "team_gap_per_step": 167.00931015191344,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 527.8793559570356,
+          "gap_ci_lo": 499.9284327882379,
+          "gap_ci_hi": 552.0751588175517,
+          "team_gap_per_step": 222.2896316038706,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.70_c1.00",
+      "beta": 0.1,
+      "kappa": 0.7,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -6.009051659102197,
+          "gap_ci_lo": -21.611233604122116,
+          "gap_ci_hi": 9.096817960579815,
+          "team_gap_per_step": -3.095234395446596,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 403.52124514884946,
+          "gap_ci_lo": 369.5335018780555,
+          "gap_ci_hi": 437.25860952086487,
+          "team_gap_per_step": 31.325894636794033,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 507.4186463131216,
+          "gap_ci_lo": 477.83009621936543,
+          "gap_ci_hi": 533.7704163031531,
+          "team_gap_per_step": 167.6162184944676,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 528.5483285545484,
+          "gap_ci_lo": 500.5970828967731,
+          "gap_ci_hi": 552.7465169137994,
+          "team_gap_per_step": 223.08026053506774,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.70_c2.00",
+      "beta": 0.1,
+      "kappa": 0.7,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -5.502573082258098,
+          "gap_ci_lo": -21.107413927809315,
+          "gap_ci_hi": 9.613505967050674,
+          "team_gap_per_step": -2.5952842325228858,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 404.23136498274323,
+          "gap_ci_lo": 370.2700291307106,
+          "gap_ci_hi": 437.92213672588156,
+          "team_gap_per_step": 32.17700377184053,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 508.4314149957979,
+          "gap_ci_lo": 478.8706484426725,
+          "gap_ci_hi": 534.7710977872516,
+          "team_gap_per_step": 168.83003517957587,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 529.8862737495745,
+          "gap_ci_lo": 501.93438311384256,
+          "gap_ci_hi": 554.089233106295,
+          "team_gap_per_step": 224.66151839746198,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.90_c0.50",
+      "beta": 0.1,
+      "kappa": 0.9,
+      "c": 0.5,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 400.5289148556569,
+          "gap_ci_lo": 366.34991300537513,
+          "gap_ci_hi": 434.58097345396794,
+          "team_gap_per_step": 41.393049425692425,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 524.615775850144,
+          "gap_ci_lo": 497.21785742612235,
+          "gap_ci_hi": 551.3567860934489,
+          "team_gap_per_step": 234.05673548963415,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 541.7173561049896,
+          "gap_ci_lo": 514.6198092842353,
+          "gap_ci_hi": 567.9306868994943,
+          "team_gap_per_step": 264.23488507909605,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 560.7027521225501,
+          "gap_ci_lo": 535.7460390997604,
+          "gap_ci_hi": 587.8698965917529,
+          "team_gap_per_step": 333.00227813586474,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.90_c1.00",
+      "beta": 0.1,
+      "kappa": 0.9,
+      "c": 1.0,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 400.70372641050926,
+          "gap_ci_lo": 366.53745690680967,
+          "gap_ci_hi": 434.7619134265549,
+          "team_gap_per_step": 41.60523489546267,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 524.9423548902088,
+          "gap_ci_lo": 497.5579119025343,
+          "gap_ci_hi": 551.6877687501051,
+          "team_gap_per_step": 234.4522422505783,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 542.2046843030367,
+          "gap_ci_lo": 515.1213790947903,
+          "gap_ci_hi": 568.4037532008923,
+          "team_gap_per_step": 264.81803614284115,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 561.547470994213,
+          "gap_ci_lo": 536.6073686942501,
+          "gap_ci_hi": 588.7092558729904,
+          "team_gap_per_step": 333.8877285419247,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.10_k0.90_c2.00",
+      "beta": 0.1,
+      "kappa": 0.9,
+      "c": 2.0,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 401.05334952021354,
+          "gap_ci_lo": 366.91254470967755,
+          "gap_ci_hi": 435.1237933717285,
+          "team_gap_per_step": 42.029605835003395,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 525.5955129703411,
+          "gap_ci_lo": 498.2380208553591,
+          "gap_ci_hi": 552.3497340634194,
+          "team_gap_per_step": 235.2432557724668,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 543.1793406991312,
+          "gap_ci_lo": 516.1245187158979,
+          "gap_ci_hi": 569.3498858036872,
+          "team_gap_per_step": 265.98433827033153,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 563.2369087375383,
+          "gap_ci_lo": 538.3322379514465,
+          "gap_ci_hi": 590.3879744354626,
+          "team_gap_per_step": 335.65862935404476,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.10_c0.50",
+      "beta": 0.3,
+      "kappa": 0.1,
+      "c": 0.5,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.926900746881204,
+          "gap_ci_lo": -13.609809831333028,
+          "gap_ci_hi": 1.9748816893542358,
+          "team_gap_per_step": 0.06402474306594286,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -4.75921405767817,
+          "gap_ci_lo": -13.223859514057825,
+          "gap_ci_hi": 2.108850113689652,
+          "team_gap_per_step": -0.10756851233043108,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 3.6117363268320526,
+          "gap_ci_lo": -5.628063096906378,
+          "gap_ci_hi": 13.745607086414013,
+          "team_gap_per_step": 0.9105313134783728,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 33.242607973688365,
+          "gap_ci_lo": 18.9915648234312,
+          "gap_ci_hi": 50.14218831869374,
+          "team_gap_per_step": 2.0191512883726546,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.10_c1.00",
+      "beta": 0.3,
+      "kappa": 0.1,
+      "c": 1.0,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.674179140545203,
+          "gap_ci_lo": -13.355271872003275,
+          "gap_ci_hi": 2.2282874199457026,
+          "team_gap_per_step": 0.3149376841229241,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -4.259349238813645,
+          "gap_ci_lo": -12.721111693067966,
+          "gap_ci_hi": 2.612288072690621,
+          "team_gap_per_step": 0.39276481294018595,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 4.345193714110715,
+          "gap_ci_lo": -4.8917053772920385,
+          "gap_ci_hi": 14.475203249983183,
+          "team_gap_per_step": 1.6446543569412597,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 34.16809683382402,
+          "gap_ci_lo": 19.92126928362049,
+          "gap_ci_hi": 51.069545945972294,
+          "team_gap_per_step": 2.9531389872755653,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.10_c2.00",
+      "beta": 0.3,
+      "kappa": 0.1,
+      "c": 2.0,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.168735927873216,
+          "gap_ci_lo": -12.846195953343868,
+          "gap_ci_hi": 2.73509888112861,
+          "team_gap_per_step": 0.8167635662364319,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -3.2596196010845957,
+          "gap_ci_lo": -11.71561605108825,
+          "gap_ci_hi": 3.6191639906925763,
+          "team_gap_per_step": 1.393431463481079,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 5.812108488668018,
+          "gap_ci_lo": -3.4189899380633504,
+          "gap_ci_hi": 15.934395577121528,
+          "team_gap_per_step": 3.112900443866806,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 36.01907455409539,
+          "gap_ci_lo": 21.780678203999088,
+          "gap_ci_hi": 52.92426120052904,
+          "team_gap_per_step": 4.8211143850811595,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.30_c0.50",
+      "beta": 0.3,
+      "kappa": 0.3,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 8.930311202389518,
+          "gap_ci_lo": -2.956750505999738,
+          "gap_ci_hi": 20.31722180932864,
+          "team_gap_per_step": 1.250406177355444,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 42.176808558357344,
+          "gap_ci_lo": 22.416327609293557,
+          "gap_ci_hi": 62.80614807588434,
+          "team_gap_per_step": -3.710885426794107,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 47.744327943326354,
+          "gap_ci_lo": 28.252792811795203,
+          "gap_ci_hi": 65.88629105016271,
+          "team_gap_per_step": 3.2609341731510995,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 74.56050001372093,
+          "gap_ci_lo": 51.764646575982454,
+          "gap_ci_hi": 97.83813394883263,
+          "team_gap_per_step": 5.692194440408571,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.30_c1.00",
+      "beta": 0.3,
+      "kappa": 0.3,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 9.173165395698136,
+          "gap_ci_lo": -2.7070229288241068,
+          "gap_ci_hi": 20.56648726913318,
+          "team_gap_per_step": 1.496959342172886,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 42.64928861478872,
+          "gap_ci_lo": 22.889866834336566,
+          "gap_ci_hi": 63.27190828953146,
+          "team_gap_per_step": -3.233987056725141,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 48.46019662140842,
+          "gap_ci_lo": 28.96733411665072,
+          "gap_ci_hi": 66.60294074399798,
+          "team_gap_per_step": 3.981510692824372,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 75.50297586277678,
+          "gap_ci_lo": 52.708194145049866,
+          "gap_ci_hi": 98.77691991217873,
+          "team_gap_per_step": 6.645032856672174,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.30_c2.00",
+      "beta": 0.3,
+      "kappa": 0.3,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 9.658873782315375,
+          "gap_ci_lo": -2.207567774472826,
+          "gap_ci_hi": 21.065018188742226,
+          "team_gap_per_step": 1.9900656718078835,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 43.594248727651454,
+          "gap_ci_lo": 23.835796743580435,
+          "gap_ci_hi": 64.20345840354928,
+          "team_gap_per_step": -2.2801903165870954,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 49.89193397757248,
+          "gap_ci_lo": 30.396416726361796,
+          "gap_ci_hi": 68.0362401316685,
+          "team_gap_per_step": 5.422663732171031,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 77.38792756088837,
+          "gap_ci_lo": 54.59528928318465,
+          "gap_ci_hi": 100.65449183887068,
+          "team_gap_per_step": 8.55070968919938,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.50_c0.50",
+      "beta": 0.3,
+      "kappa": 0.5,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.373747558796274,
+          "gap_ci_lo": -16.817929070622192,
+          "gap_ci_hi": 9.632890849264033,
+          "team_gap_per_step": -7.455822064160543,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 64.60818513830246,
+          "gap_ci_lo": 40.44018199975822,
+          "gap_ci_hi": 87.88359067262792,
+          "team_gap_per_step": -7.69680960531025,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 349.1221434537493,
+          "gap_ci_lo": 312.70982587491943,
+          "gap_ci_hi": 384.7810276353792,
+          "team_gap_per_step": -2.713448046494591,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 449.79755340254366,
+          "gap_ci_lo": 415.9760966333622,
+          "gap_ci_hi": 482.1521855363267,
+          "team_gap_per_step": 65.42692117725551,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.50_c1.00",
+      "beta": 0.3,
+      "kappa": 0.5,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.120082410047584,
+          "gap_ci_lo": -16.566367839983997,
+          "gap_ci_hi": 9.884612693994939,
+          "team_gap_per_step": -7.205414049046567,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 65.08137751184049,
+          "gap_ci_lo": 40.92152438892408,
+          "gap_ci_hi": 88.35507811084567,
+          "team_gap_per_step": -7.2175517927896635,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 349.6853877284018,
+          "gap_ci_lo": 313.2889105098023,
+          "gap_ci_hi": 385.327998881803,
+          "team_gap_per_step": -2.0646368755041067,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 450.50761233299534,
+          "gap_ci_lo": 416.7022732744152,
+          "gap_ci_hi": 482.86284443554655,
+          "team_gap_per_step": 66.27110608155283,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.50_c2.00",
+      "beta": 0.3,
+      "kappa": 0.5,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -3.6127521125501976,
+          "gap_ci_lo": -16.0632453787076,
+          "gap_ci_hi": 10.388056383456824,
+          "team_gap_per_step": -6.704598018818615,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 66.02776225891665,
+          "gap_ci_lo": 41.884209167255925,
+          "gap_ci_hi": 89.29805298728134,
+          "team_gap_per_step": -6.259036167748263,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 350.8118762777072,
+          "gap_ci_lo": 314.447079779569,
+          "gap_ci_hi": 386.43178120836257,
+          "team_gap_per_step": -0.7670145335232519,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 451.9277301938991,
+          "gap_ci_lo": 418.1546265565193,
+          "gap_ci_hi": 484.2841622339854,
+          "team_gap_per_step": 67.95947589014759,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.70_c0.50",
+      "beta": 0.3,
+      "kappa": 0.7,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -6.262290947524271,
+          "gap_ci_lo": -21.863143442278535,
+          "gap_ci_hi": 8.838273109042042,
+          "team_gap_per_step": -3.345209476908394,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 403.16618523190334,
+          "gap_ci_lo": 369.1652382517277,
+          "gap_ci_hi": 436.92684591835564,
+          "team_gap_per_step": 30.90034006927067,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 506.91226197178383,
+          "gap_ci_lo": 477.3098201077114,
+          "gap_ci_hi": 533.2700755611029,
+          "team_gap_per_step": 167.00931015191344,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 527.8793559570356,
+          "gap_ci_lo": 499.9284327882379,
+          "gap_ci_hi": 552.0751588175517,
+          "team_gap_per_step": 222.2896316038706,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.70_c1.00",
+      "beta": 0.3,
+      "kappa": 0.7,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -6.009051659102197,
+          "gap_ci_lo": -21.611233604122116,
+          "gap_ci_hi": 9.096817960579815,
+          "team_gap_per_step": -3.095234395446596,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 403.52124514884946,
+          "gap_ci_lo": 369.5335018780555,
+          "gap_ci_hi": 437.25860952086487,
+          "team_gap_per_step": 31.325894636794033,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 507.4186463131216,
+          "gap_ci_lo": 477.83009621936543,
+          "gap_ci_hi": 533.7704163031531,
+          "team_gap_per_step": 167.6162184944676,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 528.5483285545484,
+          "gap_ci_lo": 500.5970828967731,
+          "gap_ci_hi": 552.7465169137994,
+          "team_gap_per_step": 223.08026053506774,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.70_c2.00",
+      "beta": 0.3,
+      "kappa": 0.7,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -5.502573082258098,
+          "gap_ci_lo": -21.107413927809315,
+          "gap_ci_hi": 9.613505967050674,
+          "team_gap_per_step": -2.5952842325228858,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 404.23136498274323,
+          "gap_ci_lo": 370.2700291307106,
+          "gap_ci_hi": 437.92213672588156,
+          "team_gap_per_step": 32.17700377184053,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 508.4314149957979,
+          "gap_ci_lo": 478.8706484426725,
+          "gap_ci_hi": 534.7710977872516,
+          "team_gap_per_step": 168.83003517957587,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 529.8862737495745,
+          "gap_ci_lo": 501.93438311384256,
+          "gap_ci_hi": 554.089233106295,
+          "team_gap_per_step": 224.66151839746198,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.90_c0.50",
+      "beta": 0.3,
+      "kappa": 0.9,
+      "c": 0.5,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 400.5289148556569,
+          "gap_ci_lo": 366.34991300537513,
+          "gap_ci_hi": 434.58097345396794,
+          "team_gap_per_step": 41.393049425692425,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 524.615775850144,
+          "gap_ci_lo": 497.21785742612235,
+          "gap_ci_hi": 551.3567860934489,
+          "team_gap_per_step": 234.05673548963415,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 541.7173561049896,
+          "gap_ci_lo": 514.6198092842353,
+          "gap_ci_hi": 567.9306868994943,
+          "team_gap_per_step": 264.23488507909605,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 560.7027521225501,
+          "gap_ci_lo": 535.7460390997604,
+          "gap_ci_hi": 587.8698965917529,
+          "team_gap_per_step": 333.00227813586474,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.90_c1.00",
+      "beta": 0.3,
+      "kappa": 0.9,
+      "c": 1.0,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 400.70372641050926,
+          "gap_ci_lo": 366.53745690680967,
+          "gap_ci_hi": 434.7619134265549,
+          "team_gap_per_step": 41.60523489546267,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 524.9423548902088,
+          "gap_ci_lo": 497.5579119025343,
+          "gap_ci_hi": 551.6877687501051,
+          "team_gap_per_step": 234.4522422505783,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 542.2046843030367,
+          "gap_ci_lo": 515.1213790947903,
+          "gap_ci_hi": 568.4037532008923,
+          "team_gap_per_step": 264.81803614284115,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 561.547470994213,
+          "gap_ci_lo": 536.6073686942501,
+          "gap_ci_hi": 588.7092558729904,
+          "team_gap_per_step": 333.8877285419247,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.30_k0.90_c2.00",
+      "beta": 0.3,
+      "kappa": 0.9,
+      "c": 2.0,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 401.05334952021354,
+          "gap_ci_lo": 366.91254470967755,
+          "gap_ci_hi": 435.1237933717285,
+          "team_gap_per_step": 42.029605835003395,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 525.5955129703411,
+          "gap_ci_lo": 498.2380208553591,
+          "gap_ci_hi": 552.3497340634194,
+          "team_gap_per_step": 235.2432557724668,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 543.1793406991312,
+          "gap_ci_lo": 516.1245187158979,
+          "gap_ci_hi": 569.3498858036872,
+          "team_gap_per_step": 265.98433827033153,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 563.2369087375383,
+          "gap_ci_lo": 538.3322379514465,
+          "gap_ci_hi": 590.3879744354626,
+          "team_gap_per_step": 335.65862935404476,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.10_c0.50",
+      "beta": 0.5,
+      "kappa": 0.1,
+      "c": 0.5,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.926900746881204,
+          "gap_ci_lo": -13.609809831333028,
+          "gap_ci_hi": 1.9748816893542358,
+          "team_gap_per_step": 0.06402474306594286,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -4.75921405767817,
+          "gap_ci_lo": -13.223859514057825,
+          "gap_ci_hi": 2.108850113689652,
+          "team_gap_per_step": -0.10756851233043108,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 3.6117363268320526,
+          "gap_ci_lo": -5.628063096906378,
+          "gap_ci_hi": 13.745607086414013,
+          "team_gap_per_step": 0.9105313134783728,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 33.242607973688365,
+          "gap_ci_lo": 18.9915648234312,
+          "gap_ci_hi": 50.14218831869374,
+          "team_gap_per_step": 2.0191512883726546,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.10_c1.00",
+      "beta": 0.5,
+      "kappa": 0.1,
+      "c": 1.0,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.674179140545203,
+          "gap_ci_lo": -13.355271872003275,
+          "gap_ci_hi": 2.2282874199457026,
+          "team_gap_per_step": 0.3149376841229241,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -4.259349238813645,
+          "gap_ci_lo": -12.721111693067966,
+          "gap_ci_hi": 2.612288072690621,
+          "team_gap_per_step": 0.39276481294018595,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 4.345193714110715,
+          "gap_ci_lo": -4.8917053772920385,
+          "gap_ci_hi": 14.475203249983183,
+          "team_gap_per_step": 1.6446543569412597,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 34.16809683382402,
+          "gap_ci_lo": 19.92126928362049,
+          "gap_ci_hi": 51.069545945972294,
+          "team_gap_per_step": 2.9531389872755653,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.10_c2.00",
+      "beta": 0.5,
+      "kappa": 0.1,
+      "c": 2.0,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.168735927873216,
+          "gap_ci_lo": -12.846195953343868,
+          "gap_ci_hi": 2.73509888112861,
+          "team_gap_per_step": 0.8167635662364319,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -3.2596196010845957,
+          "gap_ci_lo": -11.71561605108825,
+          "gap_ci_hi": 3.6191639906925763,
+          "team_gap_per_step": 1.393431463481079,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 5.812108488668018,
+          "gap_ci_lo": -3.4189899380633504,
+          "gap_ci_hi": 15.934395577121528,
+          "team_gap_per_step": 3.112900443866806,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 36.01907455409539,
+          "gap_ci_lo": 21.780678203999088,
+          "gap_ci_hi": 52.92426120052904,
+          "team_gap_per_step": 4.8211143850811595,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.30_c0.50",
+      "beta": 0.5,
+      "kappa": 0.3,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 8.930311202389518,
+          "gap_ci_lo": -2.956750505999738,
+          "gap_ci_hi": 20.31722180932864,
+          "team_gap_per_step": 1.250406177355444,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 42.176808558357344,
+          "gap_ci_lo": 22.416327609293557,
+          "gap_ci_hi": 62.80614807588434,
+          "team_gap_per_step": -3.710885426794107,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 47.744327943326354,
+          "gap_ci_lo": 28.252792811795203,
+          "gap_ci_hi": 65.88629105016271,
+          "team_gap_per_step": 3.2609341731510995,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 74.56050001372093,
+          "gap_ci_lo": 51.764646575982454,
+          "gap_ci_hi": 97.83813394883263,
+          "team_gap_per_step": 5.692194440408571,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.30_c1.00",
+      "beta": 0.5,
+      "kappa": 0.3,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 9.173165395698136,
+          "gap_ci_lo": -2.7070229288241068,
+          "gap_ci_hi": 20.56648726913318,
+          "team_gap_per_step": 1.496959342172886,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 42.64928861478872,
+          "gap_ci_lo": 22.889866834336566,
+          "gap_ci_hi": 63.27190828953146,
+          "team_gap_per_step": -3.233987056725141,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 48.46019662140842,
+          "gap_ci_lo": 28.96733411665072,
+          "gap_ci_hi": 66.60294074399798,
+          "team_gap_per_step": 3.981510692824372,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 75.50297586277678,
+          "gap_ci_lo": 52.708194145049866,
+          "gap_ci_hi": 98.77691991217873,
+          "team_gap_per_step": 6.645032856672174,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.30_c2.00",
+      "beta": 0.5,
+      "kappa": 0.3,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 9.658873782315375,
+          "gap_ci_lo": -2.207567774472826,
+          "gap_ci_hi": 21.065018188742226,
+          "team_gap_per_step": 1.9900656718078835,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 43.594248727651454,
+          "gap_ci_lo": 23.835796743580435,
+          "gap_ci_hi": 64.20345840354928,
+          "team_gap_per_step": -2.2801903165870954,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 49.89193397757248,
+          "gap_ci_lo": 30.396416726361796,
+          "gap_ci_hi": 68.0362401316685,
+          "team_gap_per_step": 5.422663732171031,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 77.38792756088837,
+          "gap_ci_lo": 54.59528928318465,
+          "gap_ci_hi": 100.65449183887068,
+          "team_gap_per_step": 8.55070968919938,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.50_c0.50",
+      "beta": 0.5,
+      "kappa": 0.5,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.373747558796274,
+          "gap_ci_lo": -16.817929070622192,
+          "gap_ci_hi": 9.632890849264033,
+          "team_gap_per_step": -7.455822064160543,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 64.60818513830246,
+          "gap_ci_lo": 40.44018199975822,
+          "gap_ci_hi": 87.88359067262792,
+          "team_gap_per_step": -7.69680960531025,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 349.1221434537493,
+          "gap_ci_lo": 312.70982587491943,
+          "gap_ci_hi": 384.7810276353792,
+          "team_gap_per_step": -2.713448046494591,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 449.79755340254366,
+          "gap_ci_lo": 415.9760966333622,
+          "gap_ci_hi": 482.1521855363267,
+          "team_gap_per_step": 65.42692117725551,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.50_c1.00",
+      "beta": 0.5,
+      "kappa": 0.5,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.120082410047584,
+          "gap_ci_lo": -16.566367839983997,
+          "gap_ci_hi": 9.884612693994939,
+          "team_gap_per_step": -7.205414049046567,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 65.08137751184049,
+          "gap_ci_lo": 40.92152438892408,
+          "gap_ci_hi": 88.35507811084567,
+          "team_gap_per_step": -7.2175517927896635,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 349.6853877284018,
+          "gap_ci_lo": 313.2889105098023,
+          "gap_ci_hi": 385.327998881803,
+          "team_gap_per_step": -2.0646368755041067,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 450.50761233299534,
+          "gap_ci_lo": 416.7022732744152,
+          "gap_ci_hi": 482.86284443554655,
+          "team_gap_per_step": 66.27110608155283,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.50_c2.00",
+      "beta": 0.5,
+      "kappa": 0.5,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -3.6127521125501976,
+          "gap_ci_lo": -16.0632453787076,
+          "gap_ci_hi": 10.388056383456824,
+          "team_gap_per_step": -6.704598018818615,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 66.02776225891665,
+          "gap_ci_lo": 41.884209167255925,
+          "gap_ci_hi": 89.29805298728134,
+          "team_gap_per_step": -6.259036167748263,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 350.8118762777072,
+          "gap_ci_lo": 314.447079779569,
+          "gap_ci_hi": 386.43178120836257,
+          "team_gap_per_step": -0.7670145335232519,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 451.9277301938991,
+          "gap_ci_lo": 418.1546265565193,
+          "gap_ci_hi": 484.2841622339854,
+          "team_gap_per_step": 67.95947589014759,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.70_c0.50",
+      "beta": 0.5,
+      "kappa": 0.7,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -6.262290947524271,
+          "gap_ci_lo": -21.863143442278535,
+          "gap_ci_hi": 8.838273109042042,
+          "team_gap_per_step": -3.345209476908394,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 403.16618523190334,
+          "gap_ci_lo": 369.1652382517277,
+          "gap_ci_hi": 436.92684591835564,
+          "team_gap_per_step": 30.90034006927067,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 506.91226197178383,
+          "gap_ci_lo": 477.3098201077114,
+          "gap_ci_hi": 533.2700755611029,
+          "team_gap_per_step": 167.00931015191344,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 527.8793559570356,
+          "gap_ci_lo": 499.9284327882379,
+          "gap_ci_hi": 552.0751588175517,
+          "team_gap_per_step": 222.2896316038706,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.70_c1.00",
+      "beta": 0.5,
+      "kappa": 0.7,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -6.009051659102197,
+          "gap_ci_lo": -21.611233604122116,
+          "gap_ci_hi": 9.096817960579815,
+          "team_gap_per_step": -3.095234395446596,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 403.52124514884946,
+          "gap_ci_lo": 369.5335018780555,
+          "gap_ci_hi": 437.25860952086487,
+          "team_gap_per_step": 31.325894636794033,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 507.4186463131216,
+          "gap_ci_lo": 477.83009621936543,
+          "gap_ci_hi": 533.7704163031531,
+          "team_gap_per_step": 167.6162184944676,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 528.5483285545484,
+          "gap_ci_lo": 500.5970828967731,
+          "gap_ci_hi": 552.7465169137994,
+          "team_gap_per_step": 223.08026053506774,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.70_c2.00",
+      "beta": 0.5,
+      "kappa": 0.7,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -5.502573082258098,
+          "gap_ci_lo": -21.107413927809315,
+          "gap_ci_hi": 9.613505967050674,
+          "team_gap_per_step": -2.5952842325228858,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 404.23136498274323,
+          "gap_ci_lo": 370.2700291307106,
+          "gap_ci_hi": 437.92213672588156,
+          "team_gap_per_step": 32.17700377184053,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 508.4314149957979,
+          "gap_ci_lo": 478.8706484426725,
+          "gap_ci_hi": 534.7710977872516,
+          "team_gap_per_step": 168.83003517957587,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 529.8862737495745,
+          "gap_ci_lo": 501.93438311384256,
+          "gap_ci_hi": 554.089233106295,
+          "team_gap_per_step": 224.66151839746198,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.90_c0.50",
+      "beta": 0.5,
+      "kappa": 0.9,
+      "c": 0.5,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 400.5289148556569,
+          "gap_ci_lo": 366.34991300537513,
+          "gap_ci_hi": 434.58097345396794,
+          "team_gap_per_step": 41.393049425692425,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 524.615775850144,
+          "gap_ci_lo": 497.21785742612235,
+          "gap_ci_hi": 551.3567860934489,
+          "team_gap_per_step": 234.05673548963415,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 541.7173561049896,
+          "gap_ci_lo": 514.6198092842353,
+          "gap_ci_hi": 567.9306868994943,
+          "team_gap_per_step": 264.23488507909605,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 560.7027521225501,
+          "gap_ci_lo": 535.7460390997604,
+          "gap_ci_hi": 587.8698965917529,
+          "team_gap_per_step": 333.00227813586474,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.90_c1.00",
+      "beta": 0.5,
+      "kappa": 0.9,
+      "c": 1.0,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 400.70372641050926,
+          "gap_ci_lo": 366.53745690680967,
+          "gap_ci_hi": 434.7619134265549,
+          "team_gap_per_step": 41.60523489546267,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 524.9423548902088,
+          "gap_ci_lo": 497.5579119025343,
+          "gap_ci_hi": 551.6877687501051,
+          "team_gap_per_step": 234.4522422505783,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 542.2046843030367,
+          "gap_ci_lo": 515.1213790947903,
+          "gap_ci_hi": 568.4037532008923,
+          "team_gap_per_step": 264.81803614284115,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 561.547470994213,
+          "gap_ci_lo": 536.6073686942501,
+          "gap_ci_hi": 588.7092558729904,
+          "team_gap_per_step": 333.8877285419247,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.50_k0.90_c2.00",
+      "beta": 0.5,
+      "kappa": 0.9,
+      "c": 2.0,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 401.05334952021354,
+          "gap_ci_lo": 366.91254470967755,
+          "gap_ci_hi": 435.1237933717285,
+          "team_gap_per_step": 42.029605835003395,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 525.5955129703411,
+          "gap_ci_lo": 498.2380208553591,
+          "gap_ci_hi": 552.3497340634194,
+          "team_gap_per_step": 235.2432557724668,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 543.1793406991312,
+          "gap_ci_lo": 516.1245187158979,
+          "gap_ci_hi": 569.3498858036872,
+          "team_gap_per_step": 265.98433827033153,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 563.2369087375383,
+          "gap_ci_lo": 538.3322379514465,
+          "gap_ci_hi": 590.3879744354626,
+          "team_gap_per_step": 335.65862935404476,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.10_c0.50",
+      "beta": 0.7,
+      "kappa": 0.1,
+      "c": 0.5,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.926900746881204,
+          "gap_ci_lo": -13.609809831333028,
+          "gap_ci_hi": 1.9748816893542358,
+          "team_gap_per_step": 0.06402474306594286,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -4.75921405767817,
+          "gap_ci_lo": -13.223859514057825,
+          "gap_ci_hi": 2.108850113689652,
+          "team_gap_per_step": -0.10756851233043108,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 3.6117363268320526,
+          "gap_ci_lo": -5.628063096906378,
+          "gap_ci_hi": 13.745607086414013,
+          "team_gap_per_step": 0.9105313134783728,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 33.242607973688365,
+          "gap_ci_lo": 18.9915648234312,
+          "gap_ci_hi": 50.14218831869374,
+          "team_gap_per_step": 2.0191512883726546,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.10_c1.00",
+      "beta": 0.7,
+      "kappa": 0.1,
+      "c": 1.0,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.674179140545203,
+          "gap_ci_lo": -13.355271872003275,
+          "gap_ci_hi": 2.2282874199457026,
+          "team_gap_per_step": 0.3149376841229241,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -4.259349238813645,
+          "gap_ci_lo": -12.721111693067966,
+          "gap_ci_hi": 2.612288072690621,
+          "team_gap_per_step": 0.39276481294018595,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 4.345193714110715,
+          "gap_ci_lo": -4.8917053772920385,
+          "gap_ci_hi": 14.475203249983183,
+          "team_gap_per_step": 1.6446543569412597,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 34.16809683382402,
+          "gap_ci_lo": 19.92126928362049,
+          "gap_ci_hi": 51.069545945972294,
+          "team_gap_per_step": 2.9531389872755653,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.10_c2.00",
+      "beta": 0.7,
+      "kappa": 0.1,
+      "c": 2.0,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.168735927873216,
+          "gap_ci_lo": -12.846195953343868,
+          "gap_ci_hi": 2.73509888112861,
+          "team_gap_per_step": 0.8167635662364319,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -3.2596196010845957,
+          "gap_ci_lo": -11.71561605108825,
+          "gap_ci_hi": 3.6191639906925763,
+          "team_gap_per_step": 1.393431463481079,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 5.812108488668018,
+          "gap_ci_lo": -3.4189899380633504,
+          "gap_ci_hi": 15.934395577121528,
+          "team_gap_per_step": 3.112900443866806,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 36.01907455409539,
+          "gap_ci_lo": 21.780678203999088,
+          "gap_ci_hi": 52.92426120052904,
+          "team_gap_per_step": 4.8211143850811595,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.30_c0.50",
+      "beta": 0.7,
+      "kappa": 0.3,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 8.930311202389518,
+          "gap_ci_lo": -2.956750505999738,
+          "gap_ci_hi": 20.31722180932864,
+          "team_gap_per_step": 1.250406177355444,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 42.176808558357344,
+          "gap_ci_lo": 22.416327609293557,
+          "gap_ci_hi": 62.80614807588434,
+          "team_gap_per_step": -3.710885426794107,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 47.744327943326354,
+          "gap_ci_lo": 28.252792811795203,
+          "gap_ci_hi": 65.88629105016271,
+          "team_gap_per_step": 3.2609341731510995,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 74.56050001372093,
+          "gap_ci_lo": 51.764646575982454,
+          "gap_ci_hi": 97.83813394883263,
+          "team_gap_per_step": 5.692194440408571,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.30_c1.00",
+      "beta": 0.7,
+      "kappa": 0.3,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 9.173165395698136,
+          "gap_ci_lo": -2.7070229288241068,
+          "gap_ci_hi": 20.56648726913318,
+          "team_gap_per_step": 1.496959342172886,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 42.64928861478872,
+          "gap_ci_lo": 22.889866834336566,
+          "gap_ci_hi": 63.27190828953146,
+          "team_gap_per_step": -3.233987056725141,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 48.46019662140842,
+          "gap_ci_lo": 28.96733411665072,
+          "gap_ci_hi": 66.60294074399798,
+          "team_gap_per_step": 3.981510692824372,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 75.50297586277678,
+          "gap_ci_lo": 52.708194145049866,
+          "gap_ci_hi": 98.77691991217873,
+          "team_gap_per_step": 6.645032856672174,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.30_c2.00",
+      "beta": 0.7,
+      "kappa": 0.3,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 9.658873782315375,
+          "gap_ci_lo": -2.207567774472826,
+          "gap_ci_hi": 21.065018188742226,
+          "team_gap_per_step": 1.9900656718078835,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 43.594248727651454,
+          "gap_ci_lo": 23.835796743580435,
+          "gap_ci_hi": 64.20345840354928,
+          "team_gap_per_step": -2.2801903165870954,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 49.89193397757248,
+          "gap_ci_lo": 30.396416726361796,
+          "gap_ci_hi": 68.0362401316685,
+          "team_gap_per_step": 5.422663732171031,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 77.38792756088837,
+          "gap_ci_lo": 54.59528928318465,
+          "gap_ci_hi": 100.65449183887068,
+          "team_gap_per_step": 8.55070968919938,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.50_c0.50",
+      "beta": 0.7,
+      "kappa": 0.5,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.373747558796274,
+          "gap_ci_lo": -16.817929070622192,
+          "gap_ci_hi": 9.632890849264033,
+          "team_gap_per_step": -7.455822064160543,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 64.60818513830246,
+          "gap_ci_lo": 40.44018199975822,
+          "gap_ci_hi": 87.88359067262792,
+          "team_gap_per_step": -7.69680960531025,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 349.1221434537493,
+          "gap_ci_lo": 312.70982587491943,
+          "gap_ci_hi": 384.7810276353792,
+          "team_gap_per_step": -2.713448046494591,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 449.79755340254366,
+          "gap_ci_lo": 415.9760966333622,
+          "gap_ci_hi": 482.1521855363267,
+          "team_gap_per_step": 65.42692117725551,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.50_c1.00",
+      "beta": 0.7,
+      "kappa": 0.5,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.120082410047584,
+          "gap_ci_lo": -16.566367839983997,
+          "gap_ci_hi": 9.884612693994939,
+          "team_gap_per_step": -7.205414049046567,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 65.08137751184049,
+          "gap_ci_lo": 40.92152438892408,
+          "gap_ci_hi": 88.35507811084567,
+          "team_gap_per_step": -7.2175517927896635,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 349.6853877284018,
+          "gap_ci_lo": 313.2889105098023,
+          "gap_ci_hi": 385.327998881803,
+          "team_gap_per_step": -2.0646368755041067,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 450.50761233299534,
+          "gap_ci_lo": 416.7022732744152,
+          "gap_ci_hi": 482.86284443554655,
+          "team_gap_per_step": 66.27110608155283,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.50_c2.00",
+      "beta": 0.7,
+      "kappa": 0.5,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -3.6127521125501976,
+          "gap_ci_lo": -16.0632453787076,
+          "gap_ci_hi": 10.388056383456824,
+          "team_gap_per_step": -6.704598018818615,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 66.02776225891665,
+          "gap_ci_lo": 41.884209167255925,
+          "gap_ci_hi": 89.29805298728134,
+          "team_gap_per_step": -6.259036167748263,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 350.8118762777072,
+          "gap_ci_lo": 314.447079779569,
+          "gap_ci_hi": 386.43178120836257,
+          "team_gap_per_step": -0.7670145335232519,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 451.9277301938991,
+          "gap_ci_lo": 418.1546265565193,
+          "gap_ci_hi": 484.2841622339854,
+          "team_gap_per_step": 67.95947589014759,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.70_c0.50",
+      "beta": 0.7,
+      "kappa": 0.7,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -6.262290947524271,
+          "gap_ci_lo": -21.863143442278535,
+          "gap_ci_hi": 8.838273109042042,
+          "team_gap_per_step": -3.345209476908394,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 403.16618523190334,
+          "gap_ci_lo": 369.1652382517277,
+          "gap_ci_hi": 436.92684591835564,
+          "team_gap_per_step": 30.90034006927067,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 506.91226197178383,
+          "gap_ci_lo": 477.3098201077114,
+          "gap_ci_hi": 533.2700755611029,
+          "team_gap_per_step": 167.00931015191344,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 527.8793559570356,
+          "gap_ci_lo": 499.9284327882379,
+          "gap_ci_hi": 552.0751588175517,
+          "team_gap_per_step": 222.2896316038706,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.70_c1.00",
+      "beta": 0.7,
+      "kappa": 0.7,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -6.009051659102197,
+          "gap_ci_lo": -21.611233604122116,
+          "gap_ci_hi": 9.096817960579815,
+          "team_gap_per_step": -3.095234395446596,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 403.52124514884946,
+          "gap_ci_lo": 369.5335018780555,
+          "gap_ci_hi": 437.25860952086487,
+          "team_gap_per_step": 31.325894636794033,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 507.4186463131216,
+          "gap_ci_lo": 477.83009621936543,
+          "gap_ci_hi": 533.7704163031531,
+          "team_gap_per_step": 167.6162184944676,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 528.5483285545484,
+          "gap_ci_lo": 500.5970828967731,
+          "gap_ci_hi": 552.7465169137994,
+          "team_gap_per_step": 223.08026053506774,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.70_c2.00",
+      "beta": 0.7,
+      "kappa": 0.7,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -5.502573082258098,
+          "gap_ci_lo": -21.107413927809315,
+          "gap_ci_hi": 9.613505967050674,
+          "team_gap_per_step": -2.5952842325228858,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 404.23136498274323,
+          "gap_ci_lo": 370.2700291307106,
+          "gap_ci_hi": 437.92213672588156,
+          "team_gap_per_step": 32.17700377184053,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 508.4314149957979,
+          "gap_ci_lo": 478.8706484426725,
+          "gap_ci_hi": 534.7710977872516,
+          "team_gap_per_step": 168.83003517957587,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 529.8862737495745,
+          "gap_ci_lo": 501.93438311384256,
+          "gap_ci_hi": 554.089233106295,
+          "team_gap_per_step": 224.66151839746198,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.90_c0.50",
+      "beta": 0.7,
+      "kappa": 0.9,
+      "c": 0.5,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 400.5289148556569,
+          "gap_ci_lo": 366.34991300537513,
+          "gap_ci_hi": 434.58097345396794,
+          "team_gap_per_step": 41.393049425692425,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 524.615775850144,
+          "gap_ci_lo": 497.21785742612235,
+          "gap_ci_hi": 551.3567860934489,
+          "team_gap_per_step": 234.05673548963415,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 541.7173561049896,
+          "gap_ci_lo": 514.6198092842353,
+          "gap_ci_hi": 567.9306868994943,
+          "team_gap_per_step": 264.23488507909605,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 560.7027521225501,
+          "gap_ci_lo": 535.7460390997604,
+          "gap_ci_hi": 587.8698965917529,
+          "team_gap_per_step": 333.00227813586474,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.90_c1.00",
+      "beta": 0.7,
+      "kappa": 0.9,
+      "c": 1.0,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 400.70372641050926,
+          "gap_ci_lo": 366.53745690680967,
+          "gap_ci_hi": 434.7619134265549,
+          "team_gap_per_step": 41.60523489546267,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 524.9423548902088,
+          "gap_ci_lo": 497.5579119025343,
+          "gap_ci_hi": 551.6877687501051,
+          "team_gap_per_step": 234.4522422505783,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 542.2046843030367,
+          "gap_ci_lo": 515.1213790947903,
+          "gap_ci_hi": 568.4037532008923,
+          "team_gap_per_step": 264.81803614284115,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 561.547470994213,
+          "gap_ci_lo": 536.6073686942501,
+          "gap_ci_hi": 588.7092558729904,
+          "team_gap_per_step": 333.8877285419247,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.70_k0.90_c2.00",
+      "beta": 0.7,
+      "kappa": 0.9,
+      "c": 2.0,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 401.05334952021354,
+          "gap_ci_lo": 366.91254470967755,
+          "gap_ci_hi": 435.1237933717285,
+          "team_gap_per_step": 42.029605835003395,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 525.5955129703411,
+          "gap_ci_lo": 498.2380208553591,
+          "gap_ci_hi": 552.3497340634194,
+          "team_gap_per_step": 235.2432557724668,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 543.1793406991312,
+          "gap_ci_lo": 516.1245187158979,
+          "gap_ci_hi": 569.3498858036872,
+          "team_gap_per_step": 265.98433827033153,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 563.2369087375383,
+          "gap_ci_lo": 538.3322379514465,
+          "gap_ci_hi": 590.3879744354626,
+          "team_gap_per_step": 335.65862935404476,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.10_c0.50",
+      "beta": 0.9,
+      "kappa": 0.1,
+      "c": 0.5,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.926900746881204,
+          "gap_ci_lo": -13.609809831333028,
+          "gap_ci_hi": 1.9748816893542358,
+          "team_gap_per_step": 0.06402474306594286,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -4.75921405767817,
+          "gap_ci_lo": -13.223859514057825,
+          "gap_ci_hi": 2.108850113689652,
+          "team_gap_per_step": -0.10756851233043108,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 3.6117363268320526,
+          "gap_ci_lo": -5.628063096906378,
+          "gap_ci_hi": 13.745607086414013,
+          "team_gap_per_step": 0.9105313134783728,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 33.242607973688365,
+          "gap_ci_lo": 18.9915648234312,
+          "gap_ci_hi": 50.14218831869374,
+          "team_gap_per_step": 2.0191512883726546,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.10_c1.00",
+      "beta": 0.9,
+      "kappa": 0.1,
+      "c": 1.0,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.674179140545203,
+          "gap_ci_lo": -13.355271872003275,
+          "gap_ci_hi": 2.2282874199457026,
+          "team_gap_per_step": 0.3149376841229241,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -4.259349238813645,
+          "gap_ci_lo": -12.721111693067966,
+          "gap_ci_hi": 2.612288072690621,
+          "team_gap_per_step": 0.39276481294018595,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 4.345193714110715,
+          "gap_ci_lo": -4.8917053772920385,
+          "gap_ci_hi": 14.475203249983183,
+          "team_gap_per_step": 1.6446543569412597,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 34.16809683382402,
+          "gap_ci_lo": 19.92126928362049,
+          "gap_ci_hi": 51.069545945972294,
+          "team_gap_per_step": 2.9531389872755653,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.10_c2.00",
+      "beta": 0.9,
+      "kappa": 0.1,
+      "c": 2.0,
+      "k_star": 4,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.168735927873216,
+          "gap_ci_lo": -12.846195953343868,
+          "gap_ci_hi": 2.73509888112861,
+          "team_gap_per_step": 0.8167635662364319,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": -3.2596196010845957,
+          "gap_ci_lo": -11.71561605108825,
+          "gap_ci_hi": 3.6191639906925763,
+          "team_gap_per_step": 1.393431463481079,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 3,
+          "gap_mean": 5.812108488668018,
+          "gap_ci_lo": -3.4189899380633504,
+          "gap_ci_hi": 15.934395577121528,
+          "team_gap_per_step": 3.112900443866806,
+          "best_coalition_policy": "all_search_best[owned,work=0.607]",
+          "is_k_star": false
+        },
+        {
+          "k": 4,
+          "gap_mean": 36.01907455409539,
+          "gap_ci_lo": 21.780678203999088,
+          "gap_ci_hi": 52.92426120052904,
+          "team_gap_per_step": 4.8211143850811595,
+          "best_coalition_policy": "all_search_best[any,work=0.485]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.30_c0.50",
+      "beta": 0.9,
+      "kappa": 0.3,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 8.930311202389518,
+          "gap_ci_lo": -2.956750505999738,
+          "gap_ci_hi": 20.31722180932864,
+          "team_gap_per_step": 1.250406177355444,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 42.176808558357344,
+          "gap_ci_lo": 22.416327609293557,
+          "gap_ci_hi": 62.80614807588434,
+          "team_gap_per_step": -3.710885426794107,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 47.744327943326354,
+          "gap_ci_lo": 28.252792811795203,
+          "gap_ci_hi": 65.88629105016271,
+          "team_gap_per_step": 3.2609341731510995,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 74.56050001372093,
+          "gap_ci_lo": 51.764646575982454,
+          "gap_ci_hi": 97.83813394883263,
+          "team_gap_per_step": 5.692194440408571,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.30_c1.00",
+      "beta": 0.9,
+      "kappa": 0.3,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 9.173165395698136,
+          "gap_ci_lo": -2.7070229288241068,
+          "gap_ci_hi": 20.56648726913318,
+          "team_gap_per_step": 1.496959342172886,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 42.64928861478872,
+          "gap_ci_lo": 22.889866834336566,
+          "gap_ci_hi": 63.27190828953146,
+          "team_gap_per_step": -3.233987056725141,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 48.46019662140842,
+          "gap_ci_lo": 28.96733411665072,
+          "gap_ci_hi": 66.60294074399798,
+          "team_gap_per_step": 3.981510692824372,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 75.50297586277678,
+          "gap_ci_lo": 52.708194145049866,
+          "gap_ci_hi": 98.77691991217873,
+          "team_gap_per_step": 6.645032856672174,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.30_c2.00",
+      "beta": 0.9,
+      "kappa": 0.3,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 9.658873782315375,
+          "gap_ci_lo": -2.207567774472826,
+          "gap_ci_hi": 21.065018188742226,
+          "team_gap_per_step": 1.9900656718078835,
+          "best_coalition_policy": "all_search_best[owned,work=0.340]",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 43.594248727651454,
+          "gap_ci_lo": 23.835796743580435,
+          "gap_ci_hi": 64.20345840354928,
+          "team_gap_per_step": -2.2801903165870954,
+          "best_coalition_policy": "all_firefighter[owned,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 49.89193397757248,
+          "gap_ci_lo": 30.396416726361796,
+          "gap_ci_hi": 68.0362401316685,
+          "team_gap_per_step": 5.422663732171031,
+          "best_coalition_policy": "all_specialist",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 77.38792756088837,
+          "gap_ci_lo": 54.59528928318465,
+          "gap_ci_hi": 100.65449183887068,
+          "team_gap_per_step": 8.55070968919938,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.50_c0.50",
+      "beta": 0.9,
+      "kappa": 0.5,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.373747558796274,
+          "gap_ci_lo": -16.817929070622192,
+          "gap_ci_hi": 9.632890849264033,
+          "team_gap_per_step": -7.455822064160543,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 64.60818513830246,
+          "gap_ci_lo": 40.44018199975822,
+          "gap_ci_hi": 87.88359067262792,
+          "team_gap_per_step": -7.69680960531025,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 349.1221434537493,
+          "gap_ci_lo": 312.70982587491943,
+          "gap_ci_hi": 384.7810276353792,
+          "team_gap_per_step": -2.713448046494591,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 449.79755340254366,
+          "gap_ci_lo": 415.9760966333622,
+          "gap_ci_hi": 482.1521855363267,
+          "team_gap_per_step": 65.42692117725551,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.50_c1.00",
+      "beta": 0.9,
+      "kappa": 0.5,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -4.120082410047584,
+          "gap_ci_lo": -16.566367839983997,
+          "gap_ci_hi": 9.884612693994939,
+          "team_gap_per_step": -7.205414049046567,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 65.08137751184049,
+          "gap_ci_lo": 40.92152438892408,
+          "gap_ci_hi": 88.35507811084567,
+          "team_gap_per_step": -7.2175517927896635,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 349.6853877284018,
+          "gap_ci_lo": 313.2889105098023,
+          "gap_ci_hi": 385.327998881803,
+          "team_gap_per_step": -2.0646368755041067,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 450.50761233299534,
+          "gap_ci_lo": 416.7022732744152,
+          "gap_ci_hi": 482.86284443554655,
+          "team_gap_per_step": 66.27110608155283,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.50_c2.00",
+      "beta": 0.9,
+      "kappa": 0.5,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -3.6127521125501976,
+          "gap_ci_lo": -16.0632453787076,
+          "gap_ci_hi": 10.388056383456824,
+          "team_gap_per_step": -6.704598018818615,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 66.02776225891665,
+          "gap_ci_lo": 41.884209167255925,
+          "gap_ci_hi": 89.29805298728134,
+          "team_gap_per_step": -6.259036167748263,
+          "best_coalition_policy": "all_search_best[any,work=0.345]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 350.8118762777072,
+          "gap_ci_lo": 314.447079779569,
+          "gap_ci_hi": 386.43178120836257,
+          "team_gap_per_step": -0.7670145335232519,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 451.9277301938991,
+          "gap_ci_lo": 418.1546265565193,
+          "gap_ci_hi": 484.2841622339854,
+          "team_gap_per_step": 67.95947589014759,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.70_c0.50",
+      "beta": 0.9,
+      "kappa": 0.7,
+      "c": 0.5,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -6.262290947524271,
+          "gap_ci_lo": -21.863143442278535,
+          "gap_ci_hi": 8.838273109042042,
+          "team_gap_per_step": -3.345209476908394,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 403.16618523190334,
+          "gap_ci_lo": 369.1652382517277,
+          "gap_ci_hi": 436.92684591835564,
+          "team_gap_per_step": 30.90034006927067,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 506.91226197178383,
+          "gap_ci_lo": 477.3098201077114,
+          "gap_ci_hi": 533.2700755611029,
+          "team_gap_per_step": 167.00931015191344,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 527.8793559570356,
+          "gap_ci_lo": 499.9284327882379,
+          "gap_ci_hi": 552.0751588175517,
+          "team_gap_per_step": 222.2896316038706,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.70_c1.00",
+      "beta": 0.9,
+      "kappa": 0.7,
+      "c": 1.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -6.009051659102197,
+          "gap_ci_lo": -21.611233604122116,
+          "gap_ci_hi": 9.096817960579815,
+          "team_gap_per_step": -3.095234395446596,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 403.52124514884946,
+          "gap_ci_lo": 369.5335018780555,
+          "gap_ci_hi": 437.25860952086487,
+          "team_gap_per_step": 31.325894636794033,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 507.4186463131216,
+          "gap_ci_lo": 477.83009621936543,
+          "gap_ci_hi": 533.7704163031531,
+          "team_gap_per_step": 167.6162184944676,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 528.5483285545484,
+          "gap_ci_lo": 500.5970828967731,
+          "gap_ci_hi": 552.7465169137994,
+          "team_gap_per_step": 223.08026053506774,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.70_c2.00",
+      "beta": 0.9,
+      "kappa": 0.7,
+      "c": 2.0,
+      "k_star": 2,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": -5.502573082258098,
+          "gap_ci_lo": -21.107413927809315,
+          "gap_ci_hi": 9.613505967050674,
+          "team_gap_per_step": -2.5952842325228858,
+          "best_coalition_policy": "all_always_rest",
+          "is_k_star": false
+        },
+        {
+          "k": 2,
+          "gap_mean": 404.23136498274323,
+          "gap_ci_lo": 370.2700291307106,
+          "gap_ci_hi": 437.92213672588156,
+          "team_gap_per_step": 32.17700377184053,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 508.4314149957979,
+          "gap_ci_lo": 478.8706484426725,
+          "gap_ci_hi": 534.7710977872516,
+          "team_gap_per_step": 168.83003517957587,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 529.8862737495745,
+          "gap_ci_lo": 501.93438311384256,
+          "gap_ci_hi": 554.089233106295,
+          "team_gap_per_step": 224.66151839746198,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.90_c0.50",
+      "beta": 0.9,
+      "kappa": 0.9,
+      "c": 0.5,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 400.5289148556569,
+          "gap_ci_lo": 366.34991300537513,
+          "gap_ci_hi": 434.58097345396794,
+          "team_gap_per_step": 41.393049425692425,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 524.615775850144,
+          "gap_ci_lo": 497.21785742612235,
+          "gap_ci_hi": 551.3567860934489,
+          "team_gap_per_step": 234.05673548963415,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 541.7173561049896,
+          "gap_ci_lo": 514.6198092842353,
+          "gap_ci_hi": 567.9306868994943,
+          "team_gap_per_step": 264.23488507909605,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 560.7027521225501,
+          "gap_ci_lo": 535.7460390997604,
+          "gap_ci_hi": 587.8698965917529,
+          "team_gap_per_step": 333.00227813586474,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.90_c1.00",
+      "beta": 0.9,
+      "kappa": 0.9,
+      "c": 1.0,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 400.70372641050926,
+          "gap_ci_lo": 366.53745690680967,
+          "gap_ci_hi": 434.7619134265549,
+          "team_gap_per_step": 41.60523489546267,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 524.9423548902088,
+          "gap_ci_lo": 497.5579119025343,
+          "gap_ci_hi": 551.6877687501051,
+          "team_gap_per_step": 234.4522422505783,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 542.2046843030367,
+          "gap_ci_lo": 515.1213790947903,
+          "gap_ci_hi": 568.4037532008923,
+          "team_gap_per_step": 264.81803614284115,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 561.547470994213,
+          "gap_ci_lo": 536.6073686942501,
+          "gap_ci_hi": 588.7092558729904,
+          "team_gap_per_step": 333.8877285419247,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    },
+    {
+      "cell_tag": "b0.90_k0.90_c2.00",
+      "beta": 0.9,
+      "kappa": 0.9,
+      "c": 2.0,
+      "k_star": 1,
+      "per_k": [
+        {
+          "k": 1,
+          "gap_mean": 401.05334952021354,
+          "gap_ci_lo": 366.91254470967755,
+          "gap_ci_hi": 435.1237933717285,
+          "team_gap_per_step": 42.029605835003395,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 2,
+          "gap_mean": 525.5955129703411,
+          "gap_ci_lo": 498.2380208553591,
+          "gap_ci_hi": 552.3497340634194,
+          "team_gap_per_step": 235.2432557724668,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 3,
+          "gap_mean": 543.1793406991312,
+          "gap_ci_lo": 516.1245187158979,
+          "gap_ci_hi": 569.3498858036872,
+          "team_gap_per_step": 265.98433827033153,
+          "best_coalition_policy": "all_firefighter[any,work=1.0]",
+          "is_k_star": true
+        },
+        {
+          "k": 4,
+          "gap_mean": 563.2369087375383,
+          "gap_ci_lo": 538.3322379514465,
+          "gap_ci_hi": 590.3879744354626,
+          "team_gap_per_step": 335.65862935404476,
+          "best_coalition_policy": "hero[any]+specialists",
+          "is_k_star": true
+        }
+      ]
+    }
+  ]
+}

--- a/examples/games/bucket_brigade/br_oracle.rs
+++ b/examples/games/bucket_brigade/br_oracle.rs
@@ -46,11 +46,38 @@
 //!         --features "training,env-bucket-brigade"
 //! ```
 //!
+//! # Phase-diagram grid mode (issue #269)
+//!
+//! Setting `PHASE=1` sweeps the coalition oracle (k = 1..=`K`, default 4)
+//! across an arbitrary (β, κ, c) grid — by default the FULL 5×5×3 = 75-cell
+//! paper grid from `compute_nash_phase_diagram.py` — writing one JSON record
+//! per cell to `OUT_DIR/<cell_tag>.json` (tag format `b{β:.2}_k{κ:.2}_c{c:.2}`,
+//! joinable with the Nash phase-diagram artifacts). Cells parallelize via
+//! rayon; existing per-cell outputs are skipped, so re-runs resume.
+//!
+//! ```bash
+//! # Full 75-cell grid, k = 1..4, per-cell JSONs under phase_out/:
+//! PHASE=1 K=4 EVAL_EPISODES=400 OUT_DIR=phase_out \
+//!     cargo run --release --example br_oracle \
+//!         --features "training,env-bucket-brigade"
+//!
+//! # Explicit cell subset (distributed-launch knob):
+//! PHASE=1 CELLS="0.1,0.1,0.5;0.3,0.5,2.0" ...
+//! ```
+//!
 //! # Env-var knobs
 //!
 //! - `CELL` — one of `beta01|beta05|beta09` (default `beta05`). Ignored in
 //!   coalition mode (all three cells are swept).
-//! - `K` — if set, run the coalition sweep for `k = 1..=K` (issue #268).
+//! - `K` — if set, run the coalition sweep for `k = 1..=K` (issue #268). In
+//!   `PHASE=1` mode `K` is the per-cell k_max (default 4).
+//! - `PHASE` — set to `1` for the phase-diagram grid mode (issue #269).
+//! - `BETA_VALUES` / `KAPPA_VALUES` / `C_VALUES` — comma-separated floats
+//!   overriding the FULL grid axes in `PHASE=1` mode.
+//! - `CELLS` — semicolon-separated explicit `beta,kappa,c` triples; overrides
+//!   the cartesian product in `PHASE=1` mode.
+//! - `OUT_DIR` — per-cell JSON output directory in `PHASE=1` mode (default
+//!   `phase_out`).
 //! - `EVAL_EPISODES` — episodes for the final reported numbers (default 400).
 //! - `SEARCH_EPISODES` — episodes used to score each searched firefighter
 //!   (default 40).
@@ -63,11 +90,15 @@
 //!   its own once all houses are safe or ruined after `min_nights`).
 
 use anyhow::Result;
+use rayon::prelude::*;
 use thrust_rl::{
     env::games::bucket_brigade::{BucketBrigadeMaEnv, NUM_HOUSES, registry},
     multi_agent::{
         bucket_brigade_baselines::BucketBrigadeCell,
-        bucket_brigade_oracle::{OracleReport, run_coalition_oracle, run_oracle},
+        bucket_brigade_oracle::{
+            OracleReport, PhaseCellRecord, phase_cell_tag, run_coalition_oracle, run_oracle,
+            run_phase_cell,
+        },
     },
 };
 
@@ -247,8 +278,197 @@ fn run_coalition_sweep(
     }
 }
 
+/// Parse a comma-separated float list from an env var, with a default.
+fn env_f32_list(key: &str, default: &[f32]) -> Vec<f32> {
+    match std::env::var(key) {
+        Ok(s) => s
+            .split(',')
+            .map(|t| {
+                t.trim()
+                    .parse::<f32>()
+                    .unwrap_or_else(|_| panic!("{key} entry '{t}' is not a float"))
+            })
+            .collect(),
+        Err(_) => default.to_vec(),
+    }
+}
+
+/// Full paper grid (5 × 5 × 3 = 75 cells) from
+/// `envs/bucket-brigade/experiments/scripts/compute_nash_phase_diagram.py`
+/// (`FULL_BETA_VALUES` / `FULL_KAPPA_VALUES` / `FULL_C_VALUES`).
+const FULL_BETA_VALUES: [f32; 5] = [0.1, 0.3, 0.5, 0.7, 0.9];
+const FULL_KAPPA_VALUES: [f32; 5] = [0.1, 0.3, 0.5, 0.7, 0.9];
+const FULL_C_VALUES: [f32; 3] = [0.5, 1.0, 2.0];
+
+/// Phase-diagram k* sweep (issue #269): run the `k = 1..=k_max` coalition
+/// oracle on every requested `(β, κ, c)` cell in parallel (rayon over cells)
+/// and write one JSON record per cell to `out_dir/<cell_tag>.json` so partial
+/// failures lose one cell, not the run. Cells whose output file already exists
+/// are skipped (resume support for distributed / re-run workflows).
+#[allow(clippy::too_many_arguments)]
+fn run_phase_sweep(
+    cells: &[(f32, f32, f32)],
+    out_dir: &str,
+    k_max: usize,
+    eval_episodes: usize,
+    search_episodes: usize,
+    num_search: usize,
+    seed: u64,
+    step_cap: usize,
+    n_boot: usize,
+    alpha: f64,
+) -> Result<()> {
+    std::fs::create_dir_all(out_dir)?;
+    tracing::info!("Phase-diagram k* sweep (issue #269)");
+    tracing::info!("  cells           = {}", cells.len());
+    tracing::info!("  k sweep         = 1..={k_max}");
+    tracing::info!("  num_agents      = {NUM_AGENTS}");
+    tracing::info!("  eval_episodes   = {eval_episodes}");
+    tracing::info!("  search_episodes = {search_episodes}");
+    tracing::info!("  num_search      = {num_search}");
+    tracing::info!("  n_boot          = {n_boot}  alpha = {alpha}");
+    tracing::info!("  seed            = {seed}  step_cap = {step_cap}");
+    tracing::info!("  out_dir         = {out_dir}");
+
+    let pending: Vec<(f32, f32, f32)> = cells
+        .iter()
+        .copied()
+        .filter(|&(beta, kappa, c)| {
+            let tag = phase_cell_tag(beta, kappa, c);
+            let path = format!("{out_dir}/{tag}.json");
+            if std::path::Path::new(&path).exists() {
+                tracing::info!("  skip {tag} (output exists)");
+                false
+            } else {
+                true
+            }
+        })
+        .collect();
+    tracing::info!("  pending cells   = {}", pending.len());
+
+    let results: Vec<Result<PhaseCellRecord>> = pending
+        .par_iter()
+        .map(|&(beta, kappa, c)| {
+            let record = run_phase_cell(
+                beta,
+                kappa,
+                c,
+                NUM_AGENTS,
+                NUM_HOUSES,
+                k_max,
+                eval_episodes,
+                search_episodes,
+                num_search,
+                seed,
+                step_cap,
+                n_boot,
+                alpha,
+            );
+            let path = format!("{out_dir}/{}.json", record.cell_tag);
+            std::fs::write(&path, serde_json::to_string_pretty(&record)?)?;
+            tracing::info!(
+                "  done {}: k* = {}",
+                record.cell_tag,
+                record.k_star.map_or("none".to_string(), |k| k.to_string()),
+            );
+            Ok(record)
+        })
+        .collect();
+
+    // Summary table.
+    tracing::info!("============================================================");
+    tracing::info!("{:<22} {:>6}  per-k gap_mean [CI]", "cell_tag", "k*");
+    let mut ok = 0usize;
+    for r in &results {
+        match r {
+            Ok(rec) => {
+                ok += 1;
+                let per_k: Vec<String> = rec
+                    .per_k
+                    .iter()
+                    .map(|p| {
+                        format!(
+                            "k{}={:+.2}[{:+.2},{:+.2}]",
+                            p.k, p.gap_mean, p.gap_ci_lo, p.gap_ci_hi
+                        )
+                    })
+                    .collect();
+                tracing::info!(
+                    "{:<22} {:>6}  {}",
+                    rec.cell_tag,
+                    rec.k_star.map_or("none".to_string(), |k| k.to_string()),
+                    per_k.join("  "),
+                );
+            }
+            Err(e) => tracing::warn!("cell failed: {e}"),
+        }
+    }
+    tracing::info!("phase sweep complete: {ok}/{} pending cells written", pending.len());
+    Ok(())
+}
+
+/// Resolve the phase-sweep cell list from env vars: an explicit `CELLS` list
+/// (semicolon-separated `beta,kappa,c` triples — the knob a distributed
+/// launcher uses to assign arbitrary cell subsets to nodes) or the cartesian
+/// product of `BETA_VALUES` × `KAPPA_VALUES` × `C_VALUES` (defaulting to the
+/// FULL 75-cell paper grid).
+fn phase_cells_from_env() -> Vec<(f32, f32, f32)> {
+    if let Ok(s) = std::env::var("CELLS") {
+        return s
+            .split(';')
+            .filter(|t| !t.trim().is_empty())
+            .map(|t| {
+                let v: Vec<f32> = t
+                    .split(',')
+                    .map(|x| {
+                        x.trim()
+                            .parse()
+                            .unwrap_or_else(|_| panic!("CELLS entry '{t}' is not b,k,c floats"))
+                    })
+                    .collect();
+                assert!(v.len() == 3, "CELLS entry '{t}' must have exactly 3 floats");
+                (v[0], v[1], v[2])
+            })
+            .collect();
+    }
+    let betas = env_f32_list("BETA_VALUES", &FULL_BETA_VALUES);
+    let kappas = env_f32_list("KAPPA_VALUES", &FULL_KAPPA_VALUES);
+    let cs = env_f32_list("C_VALUES", &FULL_C_VALUES);
+    let mut out = Vec::with_capacity(betas.len() * kappas.len() * cs.len());
+    for &b in &betas {
+        for &k in &kappas {
+            for &c in &cs {
+                out.push((b, k, c));
+            }
+        }
+    }
+    out
+}
+
 fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter("info").init();
+
+    // Phase-diagram grid mode (issue #269): triggered by `PHASE=1`. Takes
+    // precedence over the single-grid coalition mode below (`K` is reused as
+    // the k_max knob in both modes).
+    if std::env::var("PHASE").map(|v| v == "1").unwrap_or(false) {
+        let cells = phase_cells_from_env();
+        let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| "phase_out".to_string());
+        let k_max = env_usize("K", 4);
+        assert!((1..=NUM_AGENTS).contains(&k_max), "K={k_max} out of range 1..={NUM_AGENTS}");
+        return run_phase_sweep(
+            &cells,
+            &out_dir,
+            k_max,
+            env_usize("EVAL_EPISODES", 400),
+            env_usize("SEARCH_EPISODES", 40),
+            env_usize("NUM_SEARCH", 64),
+            env_usize("SEED", 42) as u64,
+            env_usize("STEP_CAP", 1000),
+            env_usize("N_BOOT", 1000),
+            std::env::var("ALPHA").ok().and_then(|s| s.parse().ok()).unwrap_or(0.05),
+        );
+    }
 
     // Coalition mode (issue #268): triggered by the `K` env var.
     if let Ok(k_str) = std::env::var("K") {

--- a/src/multi_agent/bucket_brigade_oracle.rs
+++ b/src/multi_agent/bucket_brigade_oracle.rs
@@ -58,9 +58,10 @@
 //!   the target.
 
 use rand::{Rng, SeedableRng, rngs::StdRng};
+use serde::Serialize;
 
 use crate::{
-    env::games::bucket_brigade::BucketBrigadeMaEnv,
+    env::games::bucket_brigade::{BucketBrigadeMaEnv, registry},
     multi_agent::bucket_brigade_baselines::specialist_action,
 };
 
@@ -850,6 +851,155 @@ pub fn run_coalition_oracle(
     let (gap_ci_lo, gap_ci_hi) = bootstrap_mean_ci(&gap_series, n_boot, alpha, &mut boot_rng);
 
     CoalitionOracleReport { k, baseline, candidates, best_idx, gap_mean, gap_ci_lo, gap_ci_hi }
+}
+
+// ===========================================================================
+// Phase-diagram sweep (issue #269)
+// ===========================================================================
+//
+// The coalition oracle above measures k* on a *single* (β, κ, c) cell. Issue
+// #269 sweeps k* across the full (β, κ, c) phase-diagram grid (the same grid
+// `envs/bucket-brigade/experiments/scripts/compute_nash_phase_diagram.py`
+// defines). The types and `run_phase_cell` helper below are the per-cell unit
+// of that sweep: they own env construction from raw floats (the raw-float
+// generalization of the `BucketBrigadeCell`-keyed constructor) and emit a
+// serializable per-cell record so a driver can parallelize over cells (rayon)
+// and write one JSON file per cell.
+
+/// One `k`-slice of a phase-diagram cell sweep: the coalition-oracle summary
+/// for a fixed coalition size `k` on one cell.
+#[derive(Debug, Clone, Serialize)]
+pub struct PhaseKRecord {
+    /// Coalition size (number of scripted deviators).
+    pub k: usize,
+    /// Episode-mean per-step team-return gap (ceiling − baseline). The point
+    /// estimate the bootstrap CI brackets.
+    pub gap_mean: f64,
+    /// Bootstrap CI lower bound on `gap_mean`.
+    pub gap_ci_lo: f64,
+    /// Bootstrap CI upper bound on `gap_mean`.
+    pub gap_ci_hi: f64,
+    /// Step-weighted per-step team-return gap of the ceiling over the
+    /// all-uniform baseline (the aggregate companion to `gap_mean`).
+    pub team_gap_per_step: f64,
+    /// Label of the ceiling coalition assignment at this `k`.
+    pub best_coalition_policy: String,
+    /// Whether this `k` clears the coordination threshold (CI lower bound
+    /// strictly above zero).
+    pub is_k_star: bool,
+}
+
+/// One phase-diagram cell record: the `k = 1..=k_max` coalition sweep for a
+/// fixed `(β, κ, c)` triple plus the derived per-cell `k*`.
+///
+/// `cell_tag` uses the canonical `b{β:.2}_k{κ:.2}_c{c:.2}` format shared with
+/// `compute_nash_phase_diagram.py::_cell_tag` and `BucketBrigadeCell::tag`, so
+/// records join against the downstream verdict / entropy artifacts by tag.
+#[derive(Debug, Clone, Serialize)]
+pub struct PhaseCellRecord {
+    /// Canonical `b{β:.2}_k{κ:.2}_c{c:.2}` join key.
+    pub cell_tag: String,
+    /// Fire-spread probability β (`prob_fire_spreads_to_neighbor`).
+    pub beta: f32,
+    /// Single-agent extinguish probability κ
+    /// (`prob_solo_agent_extinguishes_fire`).
+    pub kappa: f32,
+    /// Work cost c (`cost_to_work_one_night`).
+    pub c: f32,
+    /// Smallest `k` whose gap CI lower bound is strictly positive, or `None`
+    /// if no `k <= k_max` clears zero (flat / near-degenerate cell).
+    pub k_star: Option<usize>,
+    /// Per-`k` coalition-oracle summaries, `k = 1..=k_max` in order.
+    pub per_k: Vec<PhaseKRecord>,
+}
+
+/// Filesystem-safe cell tag: `b{β:.2}_k{κ:.2}_c{c:.2}`.
+///
+/// Byte-for-byte identical to `compute_nash_phase_diagram.py::_cell_tag` so the
+/// Rust k* records and the Python Nash verdicts key against the same string.
+pub fn phase_cell_tag(beta: f32, kappa: f32, c: f32) -> String {
+    format!("b{beta:.2}_k{kappa:.2}_c{c:.2}")
+}
+
+/// Construct the bucket-brigade multi-agent env for a raw `(β, κ, c)` cell.
+///
+/// The raw-float generalization of the `BucketBrigadeCell`-keyed constructors
+/// in `br_oracle.rs` / `train_br_probe.rs`: starts from the
+/// `minimal_specialization-v1` base scenario (the family the asymmetric-NE
+/// search was calibrated on) and overrides only the three swept fields, exactly
+/// as the Python `_make_scenario` does.
+pub fn make_phase_cell_env(
+    beta: f32,
+    kappa: f32,
+    c: f32,
+    num_agents: usize,
+    seed: u64,
+) -> BucketBrigadeMaEnv {
+    let mut scenario = registry::get_scenario_by_id("minimal_specialization-v1")
+        .expect("minimal_specialization-v1 must resolve in the registry");
+    scenario.prob_fire_spreads_to_neighbor = beta;
+    scenario.prob_solo_agent_extinguishes_fire = kappa;
+    scenario.cost_to_work_one_night = c;
+    BucketBrigadeMaEnv::new(scenario, num_agents, Some(seed))
+}
+
+/// Run the full `k = 1..=k_max` coalition sweep for one `(β, κ, c)` cell and
+/// return its serializable [`PhaseCellRecord`] (issue #269).
+///
+/// Rebuilds a fresh env per `k` (identical to the single-cell sweep in
+/// `br_oracle.rs`) so every `k` sees the same env-construction seed, and reuses
+/// the shared per-episode seed stream inside [`run_coalition_oracle`] — the
+/// same measurement protocol the #268 gate used. Self-contained (owns env
+/// construction) so a driver can call it under `rayon::par_iter` with one cell
+/// per task.
+#[allow(clippy::too_many_arguments)]
+pub fn run_phase_cell(
+    beta: f32,
+    kappa: f32,
+    c: f32,
+    num_agents: usize,
+    num_houses: usize,
+    k_max: usize,
+    eval_episodes: usize,
+    search_episodes: usize,
+    num_search: usize,
+    seed: u64,
+    step_cap: usize,
+    n_boot: usize,
+    alpha: f64,
+) -> PhaseCellRecord {
+    let mut per_k = Vec::with_capacity(k_max);
+    let mut k_star: Option<usize> = None;
+    for k in 1..=k_max {
+        let mut env = make_phase_cell_env(beta, kappa, c, num_agents, seed);
+        let report = run_coalition_oracle(
+            &mut env,
+            num_agents,
+            num_houses,
+            k,
+            eval_episodes,
+            search_episodes,
+            num_search,
+            seed,
+            step_cap,
+            n_boot,
+            alpha,
+        );
+        let is_star = report.is_k_star();
+        if is_star && k_star.is_none() {
+            k_star = Some(k);
+        }
+        per_k.push(PhaseKRecord {
+            k,
+            gap_mean: report.gap_mean,
+            gap_ci_lo: report.gap_ci_lo,
+            gap_ci_hi: report.gap_ci_hi,
+            team_gap_per_step: report.team_gap_per_step(),
+            best_coalition_policy: report.best().label.clone(),
+            is_k_star: is_star,
+        });
+    }
+    PhaseCellRecord { cell_tag: phase_cell_tag(beta, kappa, c), beta, kappa, c, k_star, per_k }
 }
 
 #[cfg(test)]

--- a/tests/test_bucket_brigade_oracle_coalition.rs
+++ b/tests/test_bucket_brigade_oracle_coalition.rs
@@ -16,7 +16,9 @@ use thrust_rl::{
     env::games::bucket_brigade::{BucketBrigadeMaEnv, NUM_HOUSES, registry},
     multi_agent::{
         bucket_brigade_baselines::BucketBrigadeCell,
-        bucket_brigade_oracle::{bootstrap_mean_ci, run_coalition_oracle},
+        bucket_brigade_oracle::{
+            bootstrap_mean_ci, phase_cell_tag, run_coalition_oracle, run_phase_cell,
+        },
     },
 };
 
@@ -119,4 +121,44 @@ fn bootstrap_ci_is_well_ordered() {
     // Empty input degrades gracefully to NaN bounds.
     let (elo, ehi) = bootstrap_mean_ci(&[], 1000, 0.05, &mut rng);
     assert!(elo.is_nan() && ehi.is_nan());
+}
+
+/// Phase-diagram sweep smoke test (issue #269): `run_phase_cell` on the
+/// canonical no-convergence cell (β=0.5, κ=0.1, c=0.5) at a trivially small
+/// budget produces a well-formed serializable record — canonical
+/// `b{β:.2}_k{κ:.2}_c{c:.2}` cell tag, one `PhaseKRecord` per k in order,
+/// finite well-ordered CIs, and a `k_star` consistent with the per-k
+/// `is_k_star` flags. Also pins the tag format itself so it stays joinable
+/// with `compute_nash_phase_diagram.py::_cell_tag` output.
+#[test]
+fn phase_cell_record_smoke() {
+    assert_eq!(phase_cell_tag(0.5, 0.1, 0.5), "b0.50_k0.10_c0.50");
+    assert_eq!(phase_cell_tag(0.1, 0.3, 1.0), "b0.10_k0.30_c1.00");
+    assert_eq!(phase_cell_tag(0.9, 0.7, 2.0), "b0.90_k0.70_c2.00");
+
+    let record =
+        run_phase_cell(0.5, 0.1, 0.5, NUM_AGENTS, NUM_HOUSES, 2, 50, 10, 4, 42, 500, 200, 0.05);
+    assert_eq!(record.cell_tag, "b0.50_k0.10_c0.50");
+    assert_eq!(record.beta, 0.5);
+    assert_eq!(record.kappa, 0.1);
+    assert_eq!(record.c, 0.5);
+    assert_eq!(record.per_k.len(), 2);
+    for (i, pk) in record.per_k.iter().enumerate() {
+        assert_eq!(pk.k, i + 1, "per_k must be ordered k=1..=k_max");
+        assert!(pk.gap_mean.is_finite());
+        assert!(pk.gap_ci_lo.is_finite() && pk.gap_ci_hi.is_finite());
+        assert!(pk.gap_ci_lo <= pk.gap_ci_hi, "k={} CI lo <= hi", pk.k);
+        assert_eq!(pk.is_k_star, pk.gap_ci_lo > 0.0);
+        assert!(!pk.best_coalition_policy.is_empty());
+    }
+    // k_star is the smallest k with is_k_star, or None if no k clears zero.
+    let expected_k_star = record.per_k.iter().find(|p| p.is_k_star).map(|p| p.k);
+    assert_eq!(record.k_star, expected_k_star);
+
+    // The record serializes to JSON with the schema fields downstream joins
+    // rely on.
+    let json = serde_json::to_value(&record).expect("record must serialize");
+    assert_eq!(json["cell_tag"], "b0.50_k0.10_c0.50");
+    assert!(json["per_k"].as_array().is_some_and(|a| a.len() == 2));
+    assert!(json["per_k"][0]["best_coalition_policy"].is_string());
 }


### PR DESCRIPTION
## Summary

Measures the coalition coordination threshold k* across the **full 5x5x3 = 75-cell** (beta, kappa, c) phase-diagram grid (the FULL grid from `compute_nash_phase_diagram.py`), per the operator-decided scope on #269. Adds a raw-float phase-sweep mode to the `br_oracle` example, runs it distributed over 6 alcubierre cluster nodes, and commits the merged JSON artifact plus a research writeup.

**Headline results:**
- Every cell has finite k* <= 4. Distribution: **k*=1 on 15 cells, k*=2 on 45 cells, k*=4 on 15 cells** (none at k*=3, none unresolved).
- **k* is a pure function of kappa**: kappa=0.1 -> k*=4, kappa in {0.3,0.5,0.7} -> k*=2, kappa=0.9 -> k*=1. c never moves k*.
- **The beta axis is degenerate**: results are bit-identical across all five beta values at every (kappa, c) — `prob_fire_spreads_to_neighbor` is structurally dead in bernoulli extinguish mode (burn-out clears all BURNING houses before the spread phase runs). Pre-existing engine property, documented in the writeup and tracked separately in #289.
- Correctness anchor: the canonical beta05 cell reproduces PR #271's gate numbers **exactly** (k*=4, gap +33.24, CI (+18.99, +50.14)), byte-identical macOS-arm64 vs Linux-x86_64.

## Changes

- `src/multi_agent/bucket_brigade_oracle.rs`: `run_phase_cell` / `make_phase_cell_env` / `phase_cell_tag` / serializable `PhaseCellRecord` + `PhaseKRecord` — per-cell k=1..k_max coalition sweep from raw (beta, kappa, c) floats, keyed by the canonical `b{beta:.2f}_k{kappa:.2f}_c{c:.2f}` tag (byte-compatible with `compute_nash_phase_diagram.py::_cell_tag`).
- `examples/games/bucket_brigade/br_oracle.rs`: `PHASE=1` grid mode — rayon over cells, one JSON per cell (resume-safe: existing outputs skipped), `CELLS` / `BETA_VALUES` / `KAPPA_VALUES` / `C_VALUES` / `OUT_DIR` knobs, FULL 75-cell grid default. Existing `CELL` and `K` modes unchanged.
- `tests/test_bucket_brigade_oracle_coalition.rs`: `phase_cell_record_smoke` pinning tag format, record schema/serialization, per-k ordering, and k_star consistency.
- `docs/research/data/2026-07-kstar-phase-diagram.json`: merged artifact — 75 records keyed by `cell_tag`, per-k `gap_mean`/`gap_ci_lo`/`gap_ci_hi`/`best_coalition_policy`, per-cell `k_star`, protocol + grid header.
- `docs/research/2026-07-kstar-phase-diagram.md`: k* tables, per-k gap detail, interpretation, the beta-degeneracy engine finding, reproduction commands, caveats.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| JSON artifact under docs/research/data/, one record per grid cell keyed by `b{beta:.2f}_k{kappa:.2f}_c{c:.2f}`, joinable downstream | ✅ | 75 records; tag format pinned by test against `_cell_tag` examples (`b0.10_k0.30_c1.00` etc.) |
| JSON includes per-cell `k_star` (null if none <= 4) + per-k `gap_mean`, `gap_ci_lo`, `gap_ci_hi`, `best_coalition_policy` | ✅ | Schema asserted in `phase_cell_record_smoke`; all 75 records carry all fields (k_star is nullable `Option<usize>`; all cells resolved) |
| Human-readable table + writeup in docs/research/2026-07-kstar-phase-diagram.md | ✅ | Committed; k* grid table + 15-row per-k detail table + interpretation |
| Grid scope confirmed before running | ✅ | Operator explicitly decided the FULL 75-cell grid, distributed on the alcubierre cluster |
| `cargo test --test test_bucket_brigade_oracle_coalition` passes | ✅ | 4/4 pass (release), including the new smoke test |
| Scripted policies only — no NN training, no Burn dep added | ✅ | Reuses the #271 coalition oracle; no new dependencies |

## Test Plan

- `cargo test --release --test test_bucket_brigade_oracle_coalition --features "training,env-bucket-brigade"` — 4 passed.
- `cargo test --lib --features "training,env-bucket-brigade"` — 431 passed, 3 ignored.
- `cargo clippy --lib --examples --tests --features "training,env-bucket-brigade" -- -D warnings` — clean; `cargo fmt --check` — clean.
- Anchor run: `PHASE=1 K=4 EVAL_EPISODES=400 CELLS="0.5,0.1,0.5"` reproduces the #268/#271 gate verdict byte-for-byte.
- Cluster run: 6 nodes (alc-2/5/6/8/9/10), 12-13 cells each in tmux, all exited 0, 75/75 per-cell JSONs harvested, zero re-runs needed.

Closes #269