### PR TITLE
feat(train): single-host async actor-learner PPO over crossbeam channels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,6 +220,16 @@ name = "train_cartpole_dqn"
 path = "examples/games/cartpole/train_cartpole_dqn.rs"
 required-features = ["training"]
 
+# Asynchronous actor-learner CartPole PPO (Phase 2 of the distributed
+# training epic #265): N inference-only actor threads stream experiences
+# over crossbeam-channel to one PPO learner, which broadcasts policy
+# bytes back. Async counterpart of train_cartpole_modern; runnable
+# counterpart of tests/test_cartpole_async.rs.
+[[example]]
+name = "train_cartpole_async"
+path = "examples/games/cartpole/train_cartpole_async.rs"
+required-features = ["training"]
+
 # DQN on GridWorld (issue #185, PR B of the more-environments epic #180).
 # Seeded Double-DQN on the 4x4 FrozenLake-style GridWorld env (16-dim one-hot
 # obs, 4 discrete actions). Emits an opt-in learning-curve CSV via CURVE_CSV,

--- a/examples/games/cartpole/train_cartpole_async.rs
+++ b/examples/games/cartpole/train_cartpole_async.rs
@@ -1,0 +1,223 @@
+//! Asynchronous actor-learner CartPole PPO training (Burn backend).
+//!
+//! Phase 2 of the distributed-training epic (#265): N inference-only
+//! actor threads collect rollouts in parallel on their own CartPole
+//! envs and stream [`thrust_rl::multi_agent::Experience`] messages over
+//! a `crossbeam-channel` MPSC channel to a single learner running the
+//! unchanged [`thrust_rl::train::ppo::PPOTrainerBurn`]. After every
+//! update the learner broadcasts refreshed policy weights back to the
+//! actors as [`thrust_rl::multi_agent::PolicyBroadcast`] bytes.
+//!
+//! Same PPO recipe as `train_cartpole_modern.rs` (the synchronous
+//! baseline): 2-layer 128-hidden ReLU MLP with orthogonal init,
+//! `256`-step rollouts, `n_epochs = 10`, `batch_size = 128`, 200k env
+//! steps total. The rollout batch here is `[256, 4]` (4 actors) instead
+//! of the baseline's `[256, 16]` (16 pooled envs), so the async run does
+//! ~4x more (smaller) PPO updates for the same step budget.
+//!
+//! **Staleness note**: actor trajectories are slightly stale relative to
+//! the learner (no V-trace correction — that is issue #280). With
+//! `broadcast_every = 1` and 4 actors this is empirically fine on
+//! CartPole; expect mean episode reward ≥ 400 within the 200k budget,
+//! comparable to the synchronous baseline.
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --example train_cartpole_async --features training --release
+//! ```
+//!
+//! Override the step budget / actor count via env vars:
+//!
+//! ```bash
+//! TOTAL_TIMESTEPS=50000 NUM_ACTORS=2 cargo run --example train_cartpole_async \
+//!     --features training --release
+//! ```
+
+use anyhow::Result;
+use burn::{
+    backend::{Autodiff, NdArray},
+    module::AutodiffModule,
+    optim::AdamConfig,
+    tensor::{Tensor, TensorData},
+};
+use crossbeam_channel::unbounded;
+use rand::rngs::StdRng;
+use thrust_rl::{
+    env::{Environment, cartpole::CartPole},
+    policy::mlp::{BurnActivation, MlpBurnConfig, MlpBurnPolicy},
+    train::{
+        optimizer::BurnOptimizer,
+        ppo::{
+            AsyncActorLearnerConfig, PPOConfig, PPOTrainerBurn, actor_learner::ActorHandle,
+            learner_loop, spawn_actor,
+        },
+    },
+};
+
+// The async actor-learner ships CPU-first: policy bytes are
+// backend-agnostic, but actor threads each run their own inference
+// module, which is the natural fit for the NdArray CPU backend.
+type InnerBackend = NdArray<f32>;
+type Backend = Autodiff<InnerBackend>;
+
+const DEFAULT_NUM_ACTORS: usize = 4;
+const NUM_STEPS: usize = 256;
+const DEFAULT_TIMESTEPS: usize = 200_000;
+const LEARNING_RATE: f64 = 3e-4;
+const HIDDEN_DIM: usize = 128;
+const GAMMA: f32 = 0.99;
+const GAE_LAMBDA: f32 = 0.95;
+const SEED: u64 = 0;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt().with_env_filter("info").init();
+
+    let total_timesteps: usize = std::env::var("TOTAL_TIMESTEPS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_TIMESTEPS);
+    let num_actors: usize = std::env::var("NUM_ACTORS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_NUM_ACTORS);
+
+    tracing::info!("Starting Async Actor-Learner CartPole PPO (NdArray<f32> CPU)");
+
+    let training_start = std::time::Instant::now();
+
+    // Probe environment dimensions.
+    let probe = CartPole::new();
+    let obs_dim = probe.observation_space().shape[0];
+    let action_dim = match probe.action_space().space_type {
+        thrust_rl::env::SpaceType::Discrete(n) => n,
+        _ => panic!("Expected discrete action space"),
+    };
+
+    let config = AsyncActorLearnerConfig {
+        num_actors,
+        num_steps: NUM_STEPS,
+        total_env_steps: total_timesteps,
+        broadcast_every: 1,
+        max_lead_steps: 0, // auto: 2 * broadcast_every * num_steps of actor lead
+        gamma: GAMMA,
+        gae_lambda: GAE_LAMBDA,
+        seed: SEED,
+    };
+    config.validate()?;
+
+    tracing::info!("Environment: CartPole-v1");
+    tracing::info!("  obs_dim     = {}", obs_dim);
+    tracing::info!("  action_dim  = {}", action_dim);
+    tracing::info!("  num_actors  = {}", config.num_actors);
+    tracing::info!("  num_steps   = {}", config.num_steps);
+    tracing::info!("  total_timesteps = {}", config.total_env_steps);
+    tracing::info!("  planned PPO updates = {}", config.num_updates());
+    tracing::info!("------------------------------------------------------------");
+
+    let device = Default::default();
+
+    // Learner policy: same architecture + seed as the sync baseline.
+    let policy_config = MlpBurnConfig {
+        num_layers: 2,
+        hidden_dim: HIDDEN_DIM,
+        use_orthogonal_init: true,
+        activation: BurnActivation::ReLU,
+        seed: Some(SEED),
+    };
+    let policy = MlpBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
+
+    let inner_opt = AdamConfig::new().init();
+    let burn_opt: BurnOptimizer<Backend, MlpBurnPolicy<Backend>, _> =
+        BurnOptimizer::new(inner_opt, LEARNING_RATE);
+
+    let ppo_config = PPOConfig::new()
+        .learning_rate(LEARNING_RATE)
+        .n_epochs(10)
+        .batch_size(128)
+        .gamma(GAMMA as f64)
+        .gae_lambda(GAE_LAMBDA as f64)
+        .clip_range(0.2)
+        .clip_range_vf(0.2)
+        .vf_coef(0.5)
+        .ent_coef(0.01)
+        .max_grad_norm(0.5)
+        .target_kl(1.0);
+
+    let trainer = PPOTrainerBurn::new(ppo_config, policy, burn_opt)?;
+
+    // --- Spawn actors: each owns one env + a copy of the initial policy ---
+    let (experience_tx, experience_rx) = unbounded();
+    let actors: Vec<ActorHandle> = (0..config.num_actors)
+        .map(|actor_id| {
+            let act_device = device;
+            spawn_actor::<InnerBackend, _, _, _>(
+                actor_id,
+                CartPole::new(),
+                trainer.policy().valid(),
+                experience_tx.clone(),
+                act_device,
+                SEED + 1 + actor_id as u64,
+                config.actor_throttle(),
+                move |policy: &MlpBurnPolicy<InnerBackend>, obs: &[f32], rng: &mut StdRng| {
+                    let obs_t = Tensor::<InnerBackend, 2>::from_data(
+                        TensorData::new(obs.to_vec(), [1, obs.len()]),
+                        &act_device,
+                    );
+                    let (actions, log_probs, values) = policy.get_action_host_seeded(obs_t, rng);
+                    (actions[0], log_probs[0], values[0])
+                },
+            )
+        })
+        .collect();
+    drop(experience_tx); // learner holds the only receiver; actors hold senders
+
+    // --- Learner: fills the rollout buffer, trains, broadcasts ---
+    let (trainer, report) = learner_loop(
+        &config,
+        trainer,
+        obs_dim,
+        &device,
+        &experience_rx,
+        &actors,
+        |p: &MlpBurnPolicy<Backend>, o, a| p.evaluate_actions(o, a),
+        |p: &MlpBurnPolicy<Backend>, o| p.forward(o).1.into_data().to_vec().unwrap_or_default(),
+    )?;
+
+    // --- Join actors and report ---
+    let training_duration = training_start.elapsed();
+    tracing::info!("------------------------------------------------------------");
+    for handle in actors {
+        let stats = handle.join()?;
+        tracing::info!(
+            "actor {}: steps_sent={} episodes={} policy_updates_received={} last_version={}",
+            stats.actor_id,
+            stats.steps_sent,
+            stats.episodes_completed,
+            stats.policy_updates_received,
+            stats.last_policy_version,
+        );
+    }
+
+    tracing::info!("Training complete.");
+    tracing::info!("  updates          : {}", report.updates_completed);
+    tracing::info!("  env steps trained: {}", report.env_steps_consumed);
+    tracing::info!("  episodes         : {}", report.episodes_completed);
+    tracing::info!(
+        "  broadcasts sent  : {} (last version {})",
+        report.broadcasts_sent,
+        report.last_policy_version
+    );
+    tracing::info!(
+        "  final mean episode reward (last≤100): {:.2}",
+        report.mean_recent_episode_reward(100)
+    );
+    tracing::info!("  training time    : {:.1}s", training_duration.as_secs_f64());
+    tracing::info!(
+        "  steps/sec        : {:.0}",
+        report.env_steps_consumed as f64 / training_duration.as_secs_f64()
+    );
+    let _ = trainer; // trainer ownership returns to the caller, as with the sync loop
+
+    Ok(())
+}

--- a/src/multi_agent/messages.rs
+++ b/src/multi_agent/messages.rs
@@ -15,6 +15,8 @@
 //! one layer up (and are intentionally minimal in this first Burn-native
 //! port — see [`crate::multi_agent`] for the module-level scope).
 
+use std::sync::Arc;
+
 /// Unique identifier for an agent across a multi-agent training run.
 pub type AgentId = usize;
 
@@ -112,6 +114,45 @@ pub struct PolicyUpdate {
 
     /// Training statistics for logging.
     pub stats: TrainingStats,
+}
+
+/// In-process policy broadcast from a learner to its actors.
+///
+/// Cross-thread, in-process counterpart to [`PolicyUpdate`] (which
+/// publishes a saved-model *file path*). This enum is what the
+/// single-host asynchronous actor-learner runner
+/// ([`crate::train::ppo::actor_learner`]) sends over each per-actor
+/// `crossbeam_channel` broadcast channel after a learner update. The
+/// payload representation is chosen by the learner implementation; the
+/// actor side stays agnostic by matching on the variant.
+#[derive(Debug, Clone)]
+pub enum PolicyBroadcast {
+    /// Serialized Burn module record bytes, produced by
+    /// [`burn::record::BinBytesRecorder`] with
+    /// [`burn::record::FullPrecisionSettings`].
+    ///
+    /// Bytes are always `Send` regardless of the tensor backend (unlike
+    /// raw module clones, whose `Send`-ness depends on the backend's
+    /// tensor primitives), and the [`Arc`] keeps the N-actor fan-out
+    /// allocation-free — each actor channel receives a cheap pointer
+    /// clone of the same serialized blob.
+    Bytes {
+        /// Monotonically increasing policy version. Incremented by the
+        /// learner once per broadcast so actors (and tests) can observe
+        /// how fresh their local policy copy is.
+        version: u64,
+        /// Shared serialized module record.
+        bytes: Arc<Vec<u8>>,
+    },
+}
+
+impl PolicyBroadcast {
+    /// The policy version carried by this broadcast.
+    pub fn version(&self) -> u64 {
+        match self {
+            Self::Bytes { version, .. } => *version,
+        }
+    }
 }
 
 /// Training statistics from a policy update.
@@ -236,6 +277,19 @@ mod tests {
         assert_eq!(stats.step, 0);
         assert_eq!(stats.total_loss, 0.0);
         assert!(stats.avg_reward.is_none());
+    }
+
+    #[test]
+    fn test_policy_broadcast_version_and_shared_bytes() {
+        let bytes = Arc::new(vec![1u8, 2, 3]);
+        let broadcast = PolicyBroadcast::Bytes { version: 7, bytes: Arc::clone(&bytes) };
+
+        assert_eq!(broadcast.version(), 7);
+
+        // Cloning the broadcast shares the underlying blob (no deep copy).
+        let cloned = broadcast.clone();
+        let PolicyBroadcast::Bytes { bytes: cloned_bytes, .. } = cloned;
+        assert!(Arc::ptr_eq(&bytes, &cloned_bytes));
     }
 
     #[test]

--- a/src/multi_agent/mod.rs
+++ b/src/multi_agent/mod.rs
@@ -74,7 +74,9 @@ pub use joint::{
     JointEnv, JointMultiAgentTrainer, JointPolicy, JointRollout, JointStats, JointStepResult,
     JointTrainerConfig,
 };
-pub use messages::{AgentId, ControlMessage, Experience, PolicyUpdate, TrainingStats};
+pub use messages::{
+    AgentId, ControlMessage, Experience, PolicyBroadcast, PolicyUpdate, TrainingStats,
+};
 pub use nfsp::{NfspConfig, NfspIterationStats, NfspStats, NfspTrainer, ReservoirBuffer};
 pub use psro::{
     AlphaRankMetaSolver, FictitiousPlayMetaSolver, MetaSolver, PayoffCache, PsroConfig,

--- a/src/train/mod.rs
+++ b/src/train/mod.rs
@@ -19,7 +19,7 @@ pub use bc::{BcConfig, BcEpochStats, BcTrainer, Demonstrations, compute_bc_loss}
 pub use dqn::{DQNConfig, DQNStepStatsBurn, DQNTrainerBurn};
 pub use optimizer::{BackendOptimizer, BurnOptimizer};
 pub use ppo::{
-    AggregatedStats, PPOConfig, PPOTrainerBurn, TrainingStats, compute_entropy_loss,
-    compute_policy_loss, compute_value_loss, generate_minibatch_indices,
+    AggregatedStats, AsyncActorLearnerConfig, PPOConfig, PPOTrainerBurn, TrainingStats,
+    compute_entropy_loss, compute_policy_loss, compute_value_loss, generate_minibatch_indices,
 };
 pub use sac::{SacConfig, SacStepStats, SacTrainer};

--- a/src/train/ppo.rs
+++ b/src/train/ppo.rs
@@ -9,6 +9,9 @@
 //!
 //! # Contents
 //!
+//! - [`actor_learner`] — single-host asynchronous actor-learner runner (N
+//!   inference-only actor threads feeding one learner over `crossbeam-channel`;
+//!   Phase 2 of the distributed-training epic #265).
 //! - [`config`] — `PPOConfig` hyperparameters / builder API.
 //! - [`stats`] — `TrainingStats` / `AggregatedStats` per-update metrics.
 //! - [`loss`] — backend-generic PPO loss math (policy/value/entropy) and the
@@ -18,11 +21,16 @@
 //!   `train_step` that runs the surrogate-loss / gradient-step / KL early stop
 //!   logic.
 
+pub mod actor_learner;
 pub mod config;
 pub mod loss;
 pub mod stats;
 pub mod trainer;
 
+pub use actor_learner::{
+    ActorChannels, ActorHandle, ActorStats, AsyncActorLearnerConfig, LearnerReport, actor_thread,
+    learner_loop, load_policy_from_broadcast, serialize_policy, spawn_actor,
+};
 pub use config::PPOConfig;
 pub use loss::{
     compute_entropy_loss, compute_policy_loss, compute_value_loss, generate_minibatch_indices,

--- a/src/train/ppo/actor_learner.rs
+++ b/src/train/ppo/actor_learner.rs
@@ -1,0 +1,1061 @@
+//! Single-host asynchronous actor-learner PPO (IMPALA-style topology).
+//!
+//! Phase 2 of the distributed-training epic (#265) — see
+//! `docs/DISTRIBUTED_TRAINING_DESIGN.md`. N inference-only actor threads
+//! collect rollouts in parallel; one learner thread runs the existing
+//! [`crate::train::ppo::trainer::PPOTrainerBurn`] update unchanged.
+//! No gradient synchronization is required.
+//!
+//! # Data flow
+//!
+//! ```text
+//! [actor 0]  env_0 → inference (inner module) → Experience → sender ─┐
+//! [actor 1]  env_1 → inference (inner module) → Experience → sender ─┤→ learner_rx
+//! [actor N]  env_N → inference (inner module) → Experience → sender ─┘
+//!                                                                     │
+//!                                     ┌───────────────────────────────┘
+//!                                     ▼
+//!                          [learner thread]
+//!                          RolloutBuffer.add(experience)      (column = actor)
+//!                          when every actor column has num_steps rows:
+//!                              compute_advantages (GAE) → PPOTrainerBurn::train_step
+//!                              serialize policy → PolicyBroadcast to every actor
+//! ```
+//!
+//! **Channel topology.** One `crossbeam_channel::unbounded` MPSC channel
+//! carries [`crate::multi_agent::Experience`] messages from all actors to
+//! the learner, plus one unbounded SPSC broadcast channel per actor for
+//! [`crate::multi_agent::PolicyBroadcast`] (the learner sends a clone to
+//! each actor's sender). Actors poll their broadcast receiver with a
+//! non-blocking `try_recv` on every env step; there is no `select!`.
+//!
+//! # Staleness caveat (read before extending)
+//!
+//! Trajectories collected under a stale policy are passed to PPO
+//! **without importance-weighting correction**. For low staleness
+//! (`broadcast_every = 1`, `num_actors <= 4`) this is empirically
+//! acceptable on simple envs such as CartPole; correctness under higher
+//! staleness requires V-trace, which is Phase 3 of the epic (issue
+//! #280) and is intentionally **not** implemented here. As a soft
+//! staleness valve, each actor pauses collection once it has produced
+//! more than `max_lead_steps` env steps beyond what the learner has
+//! provably consumed (inferred from the newest received policy
+//! version), and waits for the next broadcast (see
+//! [`AsyncActorLearnerConfig::max_lead_steps`]); this bounds both the
+//! learner's queue depth and the worst-case policy lag without any
+//! off-policy correction, while still letting collection overlap with
+//! the learner's gradient steps.
+//!
+//! # Policy transfer
+//!
+//! Policy weights travel learner → actor as serialized bytes
+//! ([`burn::record::BinBytesRecorder`] with
+//! [`burn::record::FullPrecisionSettings`]), wrapped in
+//! [`crate::multi_agent::PolicyBroadcast::Bytes`]. Bytes are always
+//! `Send` regardless of the tensor backend (raw module clones are only
+//! `Send` when the backend's tensor primitives are, which e.g. wgpu's
+//! are not), and the serialized record is backend-agnostic, so the
+//! learner can train on `Autodiff<NdArray>` while an actor runs plain
+//! `NdArray` — or any other backend pair with matching element types.
+//!
+//! # Failure model
+//!
+//! Actor death is fatal for the run: the learner's fill loop starves
+//! waiting for the dead actor's column and errors out after a timeout.
+//! Graceful actor restart is out of scope for Phase 2.
+// TODO(#265 Phase 4): graceful recovery on actor thread panic instead of
+// timing out the learner fill loop.
+
+use std::{collections::VecDeque, sync::Arc, thread, time::Duration};
+
+use anyhow::{Result, anyhow};
+use burn::{
+    module::{AutodiffModule, Module},
+    optim::Optimizer,
+    record::{BinBytesRecorder, FullPrecisionSettings, Recorder},
+    tensor::{
+        Int, Tensor, TensorData,
+        backend::{AutodiffBackend, Backend},
+    },
+};
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TryRecvError, unbounded};
+use rand::{SeedableRng, rngs::StdRng};
+
+use super::{stats::TrainingStats, trainer::PPOTrainerBurn};
+use crate::{
+    buffer::rollout::{RolloutBatch, RolloutBuffer, compute_advantages},
+    env::Environment,
+    multi_agent::{AgentId, ControlMessage, Experience, PolicyBroadcast},
+};
+
+/// How long the learner waits on the experience channel before deciding
+/// an actor has died. Generous on purpose: a healthy actor produces an
+/// experience every few microseconds, so hitting this means something is
+/// genuinely wrong (actor panic, deadlocked env), not that we are slow.
+const LEARNER_RECV_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// How long a throttled actor blocks on its broadcast receiver before
+/// re-checking the control channel for shutdown.
+const ACTOR_BROADCAST_WAIT: Duration = Duration::from_millis(50);
+
+/// Configuration for the single-host asynchronous actor-learner runner.
+///
+/// See the [module docs](crate::train::ppo::actor_learner) for the
+/// architecture and the staleness caveat.
+#[derive(Debug, Clone)]
+pub struct AsyncActorLearnerConfig {
+    /// Number of actor threads (each owns one environment instance).
+    pub num_actors: usize,
+
+    /// Per-actor env steps consumed per PPO update. Each update trains on
+    /// a `[num_steps, num_actors]` rollout buffer, i.e.
+    /// `num_steps * num_actors` transitions.
+    pub num_steps: usize,
+
+    /// Total env-step budget. The learner runs
+    /// `total_env_steps / (num_steps * num_actors)` PPO updates.
+    pub total_env_steps: usize,
+
+    /// Broadcast updated policy weights to actors after every
+    /// `broadcast_every` learner updates. `1` (the default) keeps actors
+    /// as fresh as possible, which is what makes the uncorrected
+    /// (no V-trace) PPO update acceptable on simple envs.
+    pub broadcast_every: usize,
+
+    /// Soft staleness valve: the maximum number of env steps an actor
+    /// may run **ahead of the learner's consumption**. Policy version
+    /// `v` proves the learner has consumed `v * broadcast_every *
+    /// num_steps` transitions from each actor, so an actor pauses (and
+    /// waits for the next [`crate::multi_agent::PolicyBroadcast`]) once
+    /// its total sent steps reach that mark plus `max_lead_steps`. This
+    /// bounds the learner's queue depth and the worst-case policy lag
+    /// at `max_lead_steps` — a *cumulative* budget, unlike a
+    /// per-version allowance, which would let production permanently
+    /// outpace consumption and grow the backlog (and therefore the
+    /// staleness) linearly over the run.
+    ///
+    /// `0` selects the default of `2 * broadcast_every * num_steps`:
+    /// one broadcast cycle of lead for pipeline overlap (actors collect
+    /// while the learner trains) plus one cycle in flight. Must be at
+    /// least `broadcast_every * num_steps` or the learner starves. See
+    /// [`AsyncActorLearnerConfig::effective_max_lead_steps`].
+    pub max_lead_steps: usize,
+
+    /// Discount factor for GAE.
+    pub gamma: f32,
+
+    /// GAE lambda.
+    pub gae_lambda: f32,
+
+    /// Base seed. Actor `i` samples actions with
+    /// `StdRng::seed_from_u64(seed + 1 + i)` when wired through
+    /// [`spawn_actor`] by the caller.
+    pub seed: u64,
+}
+
+impl Default for AsyncActorLearnerConfig {
+    fn default() -> Self {
+        Self {
+            num_actors: 4,
+            num_steps: 256,
+            total_env_steps: 200_000,
+            broadcast_every: 1,
+            max_lead_steps: 0,
+            gamma: 0.99,
+            gae_lambda: 0.95,
+            seed: 0,
+        }
+    }
+}
+
+impl AsyncActorLearnerConfig {
+    /// Validate the configuration.
+    ///
+    /// # Errors
+    /// Returns an error when any count is zero, when the step budget is
+    /// smaller than a single update's worth of transitions, when
+    /// `gamma` / `gae_lambda` fall outside `(0, 1]`, or when the
+    /// staleness valve is too tight for the broadcast cadence (which
+    /// would deadlock the learner's fill loop).
+    pub fn validate(&self) -> Result<()> {
+        if self.num_actors == 0 {
+            return Err(anyhow!("num_actors must be >= 1"));
+        }
+        if self.num_steps == 0 {
+            return Err(anyhow!("num_steps must be >= 1"));
+        }
+        if self.broadcast_every == 0 {
+            return Err(anyhow!("broadcast_every must be >= 1"));
+        }
+        if self.total_env_steps < self.num_steps * self.num_actors {
+            return Err(anyhow!(
+                "total_env_steps ({}) must cover at least one update ({} = num_steps * num_actors)",
+                self.total_env_steps,
+                self.num_steps * self.num_actors
+            ));
+        }
+        if !(0.0..=1.0).contains(&self.gamma) || self.gamma == 0.0 {
+            return Err(anyhow!("gamma must be in (0, 1]"));
+        }
+        if !(0.0..=1.0).contains(&self.gae_lambda) || self.gae_lambda == 0.0 {
+            return Err(anyhow!("gae_lambda must be in (0, 1]"));
+        }
+        // The learner consumes broadcast_every * num_steps transitions
+        // per actor between broadcasts; a lead budget tighter than that
+        // starves the learner and deadlocks the run.
+        if self.max_lead_steps != 0 && self.max_lead_steps < self.broadcast_every * self.num_steps {
+            return Err(anyhow!(
+                "max_lead_steps ({}) must be >= broadcast_every * num_steps ({}) \
+                 or the learner's fill loop deadlocks",
+                self.max_lead_steps,
+                self.broadcast_every * self.num_steps
+            ));
+        }
+        Ok(())
+    }
+
+    /// Number of PPO updates the learner will run for this budget.
+    pub fn num_updates(&self) -> usize {
+        (self.total_env_steps / (self.num_steps * self.num_actors)).max(1)
+    }
+
+    /// Resolve the staleness valve: `max_lead_steps` when nonzero,
+    /// otherwise `2 * broadcast_every * num_steps`.
+    pub fn effective_max_lead_steps(&self) -> usize {
+        if self.max_lead_steps != 0 {
+            self.max_lead_steps
+        } else {
+            2 * self.broadcast_every * self.num_steps
+        }
+    }
+
+    /// Build the per-actor [`ActorThrottle`] for this configuration.
+    pub fn actor_throttle(&self) -> ActorThrottle {
+        ActorThrottle {
+            steps_per_broadcast: self.broadcast_every * self.num_steps,
+            max_lead_steps: self.effective_max_lead_steps(),
+        }
+    }
+}
+
+/// Per-actor staleness throttle derived from
+/// [`AsyncActorLearnerConfig::actor_throttle`].
+///
+/// Policy version `v` proves the learner has consumed
+/// `v * steps_per_broadcast` transitions from this actor, so the actor
+/// pauses once `steps_sent >= v * steps_per_broadcast + max_lead_steps`
+/// and waits for the next broadcast. See
+/// [`AsyncActorLearnerConfig::max_lead_steps`] for why the budget is
+/// cumulative.
+#[derive(Debug, Clone, Copy)]
+pub struct ActorThrottle {
+    /// Env steps per actor the learner consumes between successive
+    /// policy broadcasts (`broadcast_every * num_steps`).
+    pub steps_per_broadcast: usize,
+    /// Maximum steps the actor may run ahead of proven consumption.
+    /// `0` disables the throttle entirely (unbounded lead — only safe
+    /// when the caller guarantees consumption keeps up).
+    pub max_lead_steps: usize,
+}
+
+impl ActorThrottle {
+    /// A disabled throttle (unbounded actor lead).
+    pub fn disabled() -> Self {
+        Self { steps_per_broadcast: 0, max_lead_steps: 0 }
+    }
+
+    /// Whether an actor that has sent `steps_sent` experiences and last
+    /// loaded policy `version` should pause and wait for a broadcast.
+    pub fn should_pause(&self, steps_sent: usize, version: u64) -> bool {
+        self.max_lead_steps != 0
+            && steps_sent >= (version as usize) * self.steps_per_broadcast + self.max_lead_steps
+    }
+}
+
+/// Channel endpoints owned by one actor thread.
+///
+/// Constructed by [`spawn_actor`]; exposed publicly so callers with
+/// bespoke threading can wire [`actor_thread`] themselves.
+pub struct ActorChannels {
+    /// Cloned sender half of the shared actors→learner MPSC channel.
+    pub experience_tx: Sender<Experience>,
+    /// Receive half of this actor's learner→actor broadcast channel.
+    pub broadcast_rx: Receiver<PolicyBroadcast>,
+    /// Receive half of this actor's control channel (shutdown etc.).
+    pub control_rx: Receiver<ControlMessage>,
+}
+
+/// Per-actor counters returned by [`actor_thread`] on exit.
+#[derive(Debug, Clone, Default)]
+pub struct ActorStats {
+    /// Which actor produced these stats.
+    pub actor_id: AgentId,
+    /// Experiences sent to the learner.
+    pub steps_sent: usize,
+    /// Episodes this actor completed (terminated or truncated).
+    pub episodes_completed: usize,
+    /// Policy broadcasts received *and loaded* by this actor.
+    pub policy_updates_received: usize,
+    /// Version number of the newest policy this actor loaded
+    /// (`0` = still on the initial policy).
+    pub last_policy_version: u64,
+}
+
+/// Handle to a spawned actor thread.
+///
+/// The learner uses [`ActorHandle::send_broadcast`] /
+/// [`ActorHandle::send_shutdown`]; the orchestrating caller consumes the
+/// handle with [`ActorHandle::join`] after [`learner_loop`] returns.
+pub struct ActorHandle {
+    /// Which actor this handle controls.
+    pub actor_id: AgentId,
+    join: thread::JoinHandle<Result<ActorStats>>,
+    broadcast_tx: Sender<PolicyBroadcast>,
+    control_tx: Sender<ControlMessage>,
+}
+
+impl ActorHandle {
+    /// Send a policy broadcast to this actor. Returns `false` when the
+    /// actor has already exited (its receiver is disconnected).
+    pub fn send_broadcast(&self, broadcast: PolicyBroadcast) -> bool {
+        self.broadcast_tx.send(broadcast).is_ok()
+    }
+
+    /// Ask this actor to shut down (best-effort; a dead actor is fine).
+    pub fn send_shutdown(&self) {
+        let _ = self.control_tx.send(ControlMessage::Shutdown);
+    }
+
+    /// Wait for the actor thread to exit and return its stats.
+    ///
+    /// # Errors
+    /// Returns an error when the actor thread panicked or itself
+    /// returned an error (e.g. a malformed policy broadcast).
+    pub fn join(self) -> Result<ActorStats> {
+        self.join.join().map_err(|_| anyhow!("actor thread panicked"))?
+    }
+}
+
+/// Deserialize a [`crate::multi_agent::PolicyBroadcast`] into `module`.
+///
+/// The inverse of [`serialize_policy`]: decodes the
+/// [`burn::record::BinBytesRecorder`] blob and loads it into the given
+/// module (consuming and returning it, per Burn's move-through record
+/// API). Backend-agnostic — the blob may have been produced on a
+/// different backend with matching element types.
+///
+/// # Errors
+/// Returns an error when the byte blob fails to decode as `M`'s record.
+pub fn load_policy_from_broadcast<B2, M>(
+    module: M,
+    broadcast: &PolicyBroadcast,
+    device: &B2::Device,
+) -> Result<M>
+where
+    B2: Backend,
+    M: Module<B2>,
+{
+    match broadcast {
+        PolicyBroadcast::Bytes { bytes, version } => {
+            let recorder = BinBytesRecorder::<FullPrecisionSettings>::default();
+            let record =
+                <BinBytesRecorder<FullPrecisionSettings> as Recorder<B2>>::load::<M::Record>(
+                    &recorder,
+                    bytes.as_ref().clone(),
+                    device,
+                )
+                .map_err(|e| anyhow!("failed to load policy broadcast v{version}: {e}"))?;
+            Ok(module.load_record(record))
+        }
+    }
+}
+
+/// Serialize the learner policy's autodiff-stripped (`valid()`) view to
+/// bytes for broadcasting.
+///
+/// Uses [`burn::record::BinBytesRecorder`] with
+/// [`burn::record::FullPrecisionSettings`], so the blob loads on any
+/// backend with matching element types via
+/// [`load_policy_from_broadcast`].
+///
+/// # Errors
+/// Returns an error when the recorder fails to encode the record.
+pub fn serialize_policy<B, P>(policy: &P) -> Result<Vec<u8>>
+where
+    B: AutodiffBackend,
+    P: AutodiffModule<B>,
+{
+    let record = policy.valid().into_record();
+    let recorder = BinBytesRecorder::<FullPrecisionSettings>::default();
+    <BinBytesRecorder<FullPrecisionSettings> as Recorder<B::InnerBackend>>::record(
+        &recorder,
+        record,
+        (),
+    )
+    .map_err(|e| anyhow!("failed to serialize policy: {e}"))
+}
+
+/// Body of one inference-only actor thread.
+///
+/// Steps `env` with the local policy copy, sending one
+/// [`crate::multi_agent::Experience`] per step over
+/// `channels.experience_tx`, until either a
+/// [`crate::multi_agent::ControlMessage::Shutdown`] arrives or the
+/// learner drops the experience receiver. Polls
+/// `channels.broadcast_rx` non-blocking on every iteration and hot-swaps
+/// the local policy when a newer
+/// [`crate::multi_agent::PolicyBroadcast`] is available (keeping only
+/// the newest when several are queued).
+///
+/// `act_fn(&policy, observation, rng)` must return the sampled
+/// `(action, log_prob, value)` for a single observation — the host-side
+/// counterpart of one batch-1 policy forward. `throttle` is the
+/// staleness valve described on
+/// [`AsyncActorLearnerConfig::max_lead_steps`]
+/// ([`ActorThrottle::disabled`] turns it off).
+///
+/// Most callers should use [`spawn_actor`] instead of calling this
+/// directly.
+///
+/// # Errors
+/// Returns an error when a policy broadcast fails to decode.
+#[allow(clippy::too_many_arguments)] // mirror of spawn_actor; bundling hides the wiring
+pub fn actor_thread<B2, M, E, F>(
+    actor_id: AgentId,
+    mut env: E,
+    mut policy: M,
+    channels: ActorChannels,
+    device: B2::Device,
+    seed: u64,
+    throttle: ActorThrottle,
+    mut act_fn: F,
+) -> Result<ActorStats>
+where
+    B2: Backend,
+    M: Module<B2>,
+    E: Environment<Action = i64>,
+    F: FnMut(&M, &[f32], &mut StdRng) -> (i64, f32, f32),
+{
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut stats = ActorStats { actor_id, ..Default::default() };
+
+    env.reset();
+    loop {
+        // 1. Shutdown requested? (Other control messages are best-effort hints the
+        //    actor does not act on.)
+        match channels.control_rx.try_recv() {
+            Ok(ControlMessage::Shutdown) | Err(TryRecvError::Disconnected) => break,
+            Ok(_) | Err(TryRecvError::Empty) => {}
+        }
+
+        // 2. Non-blocking poll for policy broadcasts; keep only the newest when several
+        //    are queued.
+        let mut latest: Option<PolicyBroadcast> = None;
+        while let Ok(broadcast) = channels.broadcast_rx.try_recv() {
+            latest = Some(broadcast);
+        }
+
+        // Staleness valve: pause collection until the learner catches up
+        // (see ActorThrottle — the budget is cumulative, so an actor can
+        // never run more than max_lead_steps ahead of consumption).
+        if latest.is_none() && throttle.should_pause(stats.steps_sent, stats.last_policy_version) {
+            match channels.broadcast_rx.recv_timeout(ACTOR_BROADCAST_WAIT) {
+                Ok(broadcast) => latest = Some(broadcast),
+                Err(RecvTimeoutError::Timeout) => continue, // re-check shutdown
+                Err(RecvTimeoutError::Disconnected) => break,
+            }
+        }
+
+        if let Some(broadcast) = latest {
+            let version = broadcast.version();
+            policy = load_policy_from_broadcast(policy, &broadcast, &device)?;
+            stats.policy_updates_received += 1;
+            stats.last_policy_version = version;
+            tracing::debug!(actor_id, version, "actor loaded policy broadcast");
+        }
+
+        // 3. One env step under the local (possibly stale) policy.
+        let observation = env.get_observation();
+        let (action, log_prob, value) = act_fn(&policy, &observation, &mut rng);
+        let result = env.step(action);
+        let done = result.terminated || result.truncated;
+
+        let experience = Experience::new(
+            actor_id,
+            observation,
+            vec![action],
+            result.reward,
+            result.observation,
+            result.terminated,
+            result.truncated,
+            value,
+            log_prob,
+        );
+        if channels.experience_tx.send(experience).is_err() {
+            break; // learner is gone; nothing left to do
+        }
+        stats.steps_sent += 1;
+
+        if done {
+            stats.episodes_completed += 1;
+            env.reset();
+        }
+    }
+
+    Ok(stats)
+}
+
+/// Spawn one actor thread and return its [`ActorHandle`].
+///
+/// Creates the per-actor broadcast and control channels internally; the
+/// caller supplies a clone of the shared actors→learner experience
+/// sender. See [`actor_thread`] for the loop semantics and the
+/// `act_fn` contract.
+#[allow(clippy::too_many_arguments)] // one slot per channel/knob; a struct would just rename them
+pub fn spawn_actor<B2, M, E, F>(
+    actor_id: AgentId,
+    env: E,
+    policy: M,
+    experience_tx: Sender<Experience>,
+    device: B2::Device,
+    seed: u64,
+    throttle: ActorThrottle,
+    act_fn: F,
+) -> ActorHandle
+where
+    B2: Backend,
+    B2::Device: Send + 'static,
+    M: Module<B2> + Send + 'static,
+    E: Environment<Action = i64> + Send + 'static,
+    F: FnMut(&M, &[f32], &mut StdRng) -> (i64, f32, f32) + Send + 'static,
+{
+    let (broadcast_tx, broadcast_rx) = unbounded();
+    let (control_tx, control_rx) = unbounded();
+    let channels = ActorChannels { experience_tx, broadcast_rx, control_rx };
+    let join = thread::Builder::new()
+        .name(format!("thrust-actor-{actor_id}"))
+        .spawn(move || {
+            actor_thread::<B2, M, E, F>(
+                actor_id, env, policy, channels, device, seed, throttle, act_fn,
+            )
+        })
+        .expect("failed to spawn actor thread");
+    ActorHandle { actor_id, join, broadcast_tx, control_tx }
+}
+
+/// Summary returned by [`learner_loop`] alongside the trained
+/// [`crate::train::ppo::trainer::PPOTrainerBurn`].
+#[derive(Debug, Clone, Default)]
+pub struct LearnerReport {
+    /// PPO updates completed.
+    pub updates_completed: usize,
+    /// Env steps consumed into updates (`num_steps * num_actors` each).
+    pub env_steps_consumed: usize,
+    /// Episodes completed within the consumed steps.
+    pub episodes_completed: usize,
+    /// Policy broadcasts sent (one per `broadcast_every` updates).
+    pub broadcasts_sent: usize,
+    /// Version number of the newest broadcast policy.
+    pub last_policy_version: u64,
+    /// Total reward of every completed episode, in consumption order.
+    pub episode_rewards: Vec<f32>,
+    /// Stats from the final PPO update, if any ran.
+    pub final_stats: Option<TrainingStats>,
+}
+
+impl LearnerReport {
+    /// Mean total reward over the most recent `n` completed episodes
+    /// (or all of them when fewer have completed). Returns `0.0` before
+    /// the first episode completes.
+    pub fn mean_recent_episode_reward(&self, n: usize) -> f32 {
+        if self.episode_rewards.is_empty() {
+            return 0.0;
+        }
+        let start = self.episode_rewards.len().saturating_sub(n);
+        let recent = &self.episode_rewards[start..];
+        recent.iter().sum::<f32>() / recent.len() as f32
+    }
+}
+
+/// Run the learner side of the asynchronous actor-learner loop.
+///
+/// Blocks on `experience_rx`, filling a `[num_steps, num_actors]`
+/// [`crate::buffer::rollout::RolloutBuffer`] (buffer column =
+/// `experience.agent_id`). When every actor column holds `num_steps`
+/// transitions, it computes GAE
+/// ([`crate::buffer::rollout::compute_advantages`]), runs one
+/// [`crate::train::ppo::trainer::PPOTrainerBurn::train_step`], and — every
+/// [`AsyncActorLearnerConfig::broadcast_every`] updates — serializes the
+/// refreshed policy and sends a
+/// [`crate::multi_agent::PolicyBroadcast`] to every actor. Experiences
+/// arriving beyond an update's quota stay queued for the next update, so
+/// nothing an actor sends is dropped.
+///
+/// On completion the learner sends
+/// [`crate::multi_agent::ControlMessage::Shutdown`] to every actor and
+/// returns the trainer (unchanged ownership model: the caller gets it
+/// back) plus a [`LearnerReport`].
+///
+/// The two closures mirror
+/// [`crate::train::ppo::trainer::PPOTrainerBurn::train_step`]'s
+/// `evaluate_fn` pattern so the loop stays generic over the policy
+/// module:
+/// - `evaluate_fn(&policy, obs, actions) -> (log_probs, entropy, values)`
+/// - `value_fn(&policy, obs) -> host values` (bootstrap `V(s_T)` for GAE)
+///
+/// # Errors
+/// Returns an error when the experience channel starves for 60 seconds
+/// (actor death is fatal in Phase 2 — see the module docs), when an
+/// experience carries an out-of-range `agent_id`, or when a
+/// `train_step` / policy serialization fails.
+#[allow(clippy::too_many_arguments)] // trainer + channels + two closures; same shape as train_step
+pub fn learner_loop<B, P, O, F, G>(
+    config: &AsyncActorLearnerConfig,
+    mut trainer: PPOTrainerBurn<B, P, O>,
+    obs_dim: usize,
+    device: &B::Device,
+    experience_rx: &Receiver<Experience>,
+    actors: &[ActorHandle],
+    mut evaluate_fn: F,
+    mut value_fn: G,
+) -> Result<(PPOTrainerBurn<B, P, O>, LearnerReport)>
+where
+    B: AutodiffBackend,
+    P: AutodiffModule<B> + Clone,
+    O: Optimizer<P, B>,
+    F: FnMut(&P, Tensor<B, 2>, Tensor<B, 1, Int>) -> (Tensor<B, 1>, Tensor<B, 1>, Tensor<B, 1>),
+    G: FnMut(&P, Tensor<B, 2>) -> Vec<f32>,
+{
+    config.validate()?;
+    let num_actors = config.num_actors;
+    let num_steps = config.num_steps;
+    let num_updates = config.num_updates();
+
+    let mut report = LearnerReport::default();
+    // Per-actor FIFO of experiences not yet consumed into an update.
+    let mut pending: Vec<VecDeque<Experience>> = vec![VecDeque::new(); num_actors];
+    // Per-actor running reward of the in-flight episode.
+    let mut running_reward = vec![0.0_f32; num_actors];
+    let mut version: u64 = 0;
+
+    for update in 0..num_updates {
+        // --- Fill: block until every actor column has num_steps rows ---
+        while pending.iter().any(|q| q.len() < num_steps) {
+            let experience = experience_rx.recv_timeout(LEARNER_RECV_TIMEOUT).map_err(|e| {
+                anyhow!(
+                    "learner starved waiting for experiences ({e}); \
+                     actor death is fatal in Phase 2 (see module docs)"
+                )
+            })?;
+            let actor = experience.agent_id;
+            if actor >= num_actors {
+                return Err(anyhow!(
+                    "experience agent_id {actor} out of range (num_actors = {num_actors})"
+                ));
+            }
+            pending[actor].push_back(experience);
+        }
+
+        // --- Drain num_steps rows per actor into the rollout buffer ---
+        let mut buffer = RolloutBuffer::new(num_steps, num_actors, obs_dim);
+        let mut last_next_obs = vec![0.0_f32; num_actors * obs_dim];
+        for actor in 0..num_actors {
+            for step in 0..num_steps {
+                let exp = pending[actor].pop_front().expect("fill loop guarantees num_steps");
+                debug_assert_eq!(exp.agent_id, actor);
+                buffer.add(
+                    step,
+                    actor,
+                    &exp.observation,
+                    exp.action[0],
+                    exp.reward,
+                    exp.value,
+                    exp.log_prob,
+                    exp.terminated,
+                    exp.truncated,
+                );
+                running_reward[actor] += exp.reward;
+                if exp.is_done() {
+                    report.episode_rewards.push(running_reward[actor]);
+                    report.episodes_completed += 1;
+                    running_reward[actor] = 0.0;
+                    trainer.increment_episodes(1);
+                }
+                if step == num_steps - 1 {
+                    last_next_obs[actor * obs_dim..(actor + 1) * obs_dim]
+                        .copy_from_slice(&exp.next_observation);
+                }
+            }
+        }
+        report.env_steps_consumed += num_steps * num_actors;
+
+        // --- GAE (bootstrap from V(s_T) under the current policy) ---
+        let last_obs_t = Tensor::<B, 2>::from_data(
+            TensorData::new(last_next_obs, [num_actors, obs_dim]),
+            device,
+        );
+        let last_values = value_fn(trainer.policy(), last_obs_t);
+        compute_advantages(&mut buffer, &last_values, config.gamma, config.gae_lambda);
+
+        // --- PPO update (trainer unchanged; actors wrap around it) ---
+        let tensors = RolloutBatch::from_buffer(&buffer).to_burn_tensors::<B>(device);
+        let stats = trainer.train_step(
+            tensors.observations,
+            tensors.actions,
+            tensors.old_log_probs,
+            tensors.old_values,
+            tensors.advantages,
+            tensors.returns,
+            &mut evaluate_fn,
+        )?;
+        report.updates_completed += 1;
+
+        // --- Broadcast refreshed policy to actors ---
+        if (update + 1) % config.broadcast_every == 0 {
+            version += 1;
+            let bytes = Arc::new(serialize_policy(trainer.policy())?);
+            let mut delivered = 0usize;
+            for handle in actors {
+                if handle
+                    .send_broadcast(PolicyBroadcast::Bytes { version, bytes: Arc::clone(&bytes) })
+                {
+                    delivered += 1;
+                }
+            }
+            report.broadcasts_sent += 1;
+            report.last_policy_version = version;
+            tracing::info!(
+                version,
+                delivered,
+                num_actors,
+                "learner broadcast policy version {version} to {delivered}/{num_actors} actors"
+            );
+        }
+
+        tracing::info!(
+            "update {:>3}/{}  env_steps={:>7}  episodes={:>4}  mean_ep_reward(last≤100)={:6.1}  policy_loss={:7.4}  entropy={:5.3}",
+            update + 1,
+            num_updates,
+            report.env_steps_consumed,
+            report.episodes_completed,
+            report.mean_recent_episode_reward(100),
+            stats.policy_loss,
+            stats.entropy,
+        );
+        report.final_stats = Some(stats);
+    }
+
+    for handle in actors {
+        handle.send_shutdown();
+    }
+
+    Ok((trainer, report))
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::{
+        backend::{Autodiff, NdArray},
+        optim::AdamConfig,
+    };
+
+    use super::*;
+    use crate::{
+        env::{SpaceInfo, SpaceType, StepInfo, StepResult},
+        policy::mlp::{MlpBurnConfig, MlpBurnPolicy},
+        train::{optimizer::BurnOptimizer, ppo::PPOConfig},
+    };
+
+    type B = Autodiff<NdArray<f32>>;
+    type Inner = NdArray<f32>;
+
+    const OBS_DIM: usize = 2;
+    const ACTION_DIM: usize = 2;
+
+    /// Deterministic stub env: observation is `[t, t]` (step counter),
+    /// reward +1/step, episode terminates every 5 steps.
+    struct StubEnv {
+        t: usize,
+    }
+
+    impl Environment for StubEnv {
+        type Action = i64;
+        type State = usize;
+
+        fn reset(&mut self) {
+            self.t = 0;
+        }
+        fn get_observation(&self) -> Vec<f32> {
+            vec![self.t as f32; OBS_DIM]
+        }
+        fn step(&mut self, _action: i64) -> StepResult {
+            self.t += 1;
+            StepResult {
+                observation: self.get_observation(),
+                reward: 1.0,
+                terminated: self.t.is_multiple_of(5),
+                truncated: false,
+                info: StepInfo::default(),
+            }
+        }
+        fn observation_space(&self) -> SpaceInfo {
+            SpaceInfo { shape: vec![OBS_DIM], space_type: SpaceType::Box }
+        }
+        fn action_space(&self) -> SpaceInfo {
+            SpaceInfo { shape: vec![1], space_type: SpaceType::Discrete(ACTION_DIM) }
+        }
+        fn render(&self) -> Vec<u8> {
+            Vec::new()
+        }
+        fn close(&mut self) {}
+        fn clone_state(&self) -> usize {
+            self.t
+        }
+        fn restore_state(&mut self, state: &usize) {
+            self.t = *state;
+        }
+    }
+
+    fn seeded_inner_policy(seed: u64) -> MlpBurnPolicy<Inner> {
+        let device = Default::default();
+        MlpBurnPolicy::<Inner>::with_config(
+            OBS_DIM,
+            ACTION_DIM,
+            MlpBurnConfig { hidden_dim: 8, ..Default::default() }.with_seed(seed),
+            &device,
+        )
+    }
+
+    fn seeded_autodiff_policy(seed: u64) -> MlpBurnPolicy<B> {
+        let device = Default::default();
+        MlpBurnPolicy::<B>::with_config(
+            OBS_DIM,
+            ACTION_DIM,
+            MlpBurnConfig { hidden_dim: 8, ..Default::default() }.with_seed(seed),
+            &device,
+        )
+    }
+
+    fn act_fn(policy: &MlpBurnPolicy<Inner>, obs: &[f32], rng: &mut StdRng) -> (i64, f32, f32) {
+        let device = Default::default();
+        let t =
+            Tensor::<Inner, 2>::from_data(TensorData::new(obs.to_vec(), [1, obs.len()]), &device);
+        let (actions, log_probs, values) = policy.get_action_host_seeded(t, rng);
+        (actions[0], log_probs[0], values[0])
+    }
+
+    #[test]
+    fn config_default_is_valid_and_derives_updates() {
+        let config = AsyncActorLearnerConfig::default();
+        config.validate().unwrap();
+        assert_eq!(config.broadcast_every, 1);
+        assert_eq!(config.num_updates(), 200_000 / (256 * 4));
+        assert_eq!(config.effective_max_lead_steps(), 2 * 256);
+
+        let throttle = config.actor_throttle();
+        assert_eq!(throttle.steps_per_broadcast, 256);
+        assert_eq!(throttle.max_lead_steps, 512);
+        // Lead budget is cumulative: version v proves v * 256 consumed.
+        assert!(!throttle.should_pause(511, 0));
+        assert!(throttle.should_pause(512, 0));
+        assert!(!throttle.should_pause(512, 1)); // v1 ⇒ budget now 768
+        assert!(throttle.should_pause(768, 1));
+        assert!(!ActorThrottle::disabled().should_pause(usize::MAX - 1, 0));
+    }
+
+    #[test]
+    fn config_rejects_bad_values() {
+        let base = AsyncActorLearnerConfig::default();
+        assert!(AsyncActorLearnerConfig { num_actors: 0, ..base.clone() }.validate().is_err());
+        assert!(AsyncActorLearnerConfig { num_steps: 0, ..base.clone() }.validate().is_err());
+        assert!(
+            AsyncActorLearnerConfig { broadcast_every: 0, ..base.clone() }
+                .validate()
+                .is_err()
+        );
+        assert!(
+            AsyncActorLearnerConfig { total_env_steps: 10, ..base.clone() }
+                .validate()
+                .is_err()
+        );
+        assert!(AsyncActorLearnerConfig { gamma: 0.0, ..base.clone() }.validate().is_err());
+        assert!(AsyncActorLearnerConfig { gae_lambda: 1.5, ..base.clone() }.validate().is_err());
+        // Throttle tighter than one broadcast cycle would deadlock.
+        assert!(AsyncActorLearnerConfig { max_lead_steps: 255, ..base }.validate().is_err());
+    }
+
+    /// Serialize on the autodiff backend, load on the inner backend, and
+    /// confirm the loaded policy computes the same forward pass as the
+    /// source policy's `valid()` view.
+    #[test]
+    fn policy_broadcast_bytes_roundtrip() {
+        let device = Default::default();
+        let source = seeded_autodiff_policy(42);
+        let target = seeded_inner_policy(43); // different weights on purpose
+
+        let bytes = serialize_policy(&source).unwrap();
+        let broadcast = PolicyBroadcast::Bytes { version: 1, bytes: Arc::new(bytes) };
+        let loaded = load_policy_from_broadcast(target, &broadcast, &device).unwrap();
+
+        let obs =
+            Tensor::<Inner, 2>::from_data(TensorData::new(vec![0.1, -0.2], [1, OBS_DIM]), &device);
+        let (logits_src, value_src) = source.valid().forward(obs.clone());
+        let (logits_loaded, value_loaded) = loaded.forward(obs);
+
+        let src: Vec<f32> = logits_src.into_data().to_vec().unwrap();
+        let got: Vec<f32> = logits_loaded.into_data().to_vec().unwrap();
+        assert_eq!(src, got, "loaded policy must reproduce source logits bit-for-bit");
+        let v_src: Vec<f32> = value_src.into_data().to_vec().unwrap();
+        let v_got: Vec<f32> = value_loaded.into_data().to_vec().unwrap();
+        assert_eq!(v_src, v_got);
+    }
+
+    /// The actor sends experiences tagged with its actor_id, in step
+    /// order, and hot-swaps its policy when a broadcast arrives.
+    ///
+    /// Broadcast receipt is made deterministic through the throttle: the
+    /// actor pauses after `max_lead_steps` (still on version 0) and can
+    /// only resume by loading a broadcast, so receiving any experience
+    /// beyond the pause point proves the load happened — no sleeps, no
+    /// timing sensitivity under a loaded CI machine.
+    #[test]
+    fn actor_thread_sends_ordered_experiences_and_loads_broadcasts() {
+        const PAUSE_AT: usize = 40;
+
+        let device = burn::backend::ndarray::NdArrayDevice::default();
+        let (experience_tx, experience_rx) = unbounded();
+
+        let handle = spawn_actor::<Inner, _, _, _>(
+            3,
+            StubEnv { t: 0 },
+            seeded_inner_policy(7),
+            experience_tx,
+            device,
+            123,
+            // Version v proves v * PAUSE_AT consumed; at version 0 the
+            // actor pauses after exactly PAUSE_AT experiences.
+            ActorThrottle { steps_per_broadcast: PAUSE_AT, max_lead_steps: PAUSE_AT },
+            act_fn,
+        );
+
+        // Collect the pre-pause experiences; they must be ordered and tagged.
+        let mut received = Vec::new();
+        for _ in 0..PAUSE_AT {
+            let exp = experience_rx.recv_timeout(Duration::from_secs(30)).unwrap();
+            assert_eq!(exp.agent_id, 3);
+            received.push(exp);
+        }
+        for (i, exp) in received.iter().enumerate() {
+            // StubEnv observation is [t, t]; actor visits t = 0,1,2,...
+            // (reset restarts the counter at 0 every 5 steps).
+            let expected_t = (i % 5) as f32;
+            assert_eq!(exp.observation, vec![expected_t; OBS_DIM], "step {i} out of order");
+            assert_eq!(exp.action.len(), 1);
+            assert_eq!(exp.terminated, (i + 1) % 5 == 0);
+        }
+        // The actor is now paused at its lead budget: no further
+        // experience may arrive until it loads a policy broadcast.
+
+        // Broadcast a new policy; version 7 raises the budget to
+        // 7 * PAUSE_AT + PAUSE_AT, so the actor resumes iff it loads it.
+        let source = seeded_autodiff_policy(99);
+        let bytes = Arc::new(serialize_policy(&source).unwrap());
+        assert!(handle.send_broadcast(PolicyBroadcast::Bytes { version: 7, bytes }));
+
+        // Any post-pause experience proves the broadcast was loaded.
+        experience_rx
+            .recv_timeout(Duration::from_secs(30))
+            .expect("actor should resume after loading the broadcast");
+
+        handle.send_shutdown();
+        let stats = handle.join().unwrap();
+
+        assert_eq!(stats.actor_id, 3);
+        assert!(stats.steps_sent > PAUSE_AT);
+        assert!(stats.episodes_completed >= PAUSE_AT / 5);
+        assert!(
+            stats.policy_updates_received >= 1,
+            "actor must have loaded the broadcast (got {})",
+            stats.policy_updates_received
+        );
+        assert_eq!(stats.last_policy_version, 7);
+    }
+
+    /// End-to-end wiring smoke test on the stub env: 2 actors, a few
+    /// tiny updates, broadcasts delivered, report bookkeeping correct.
+    #[test]
+    fn learner_loop_runs_updates_and_broadcasts() {
+        let device = Default::default();
+        let num_actors = 2;
+        let num_steps = 8;
+
+        let config = AsyncActorLearnerConfig {
+            num_actors,
+            num_steps,
+            total_env_steps: num_steps * num_actors * 3, // 3 updates
+            broadcast_every: 1,
+            max_lead_steps: 2 * num_steps,
+            gamma: 0.99,
+            gae_lambda: 0.95,
+            seed: 0,
+        };
+
+        let policy = seeded_autodiff_policy(0);
+        let inner_opt = AdamConfig::new().init();
+        let burn_opt: BurnOptimizer<B, MlpBurnPolicy<B>, _> = BurnOptimizer::new(inner_opt, 1e-3);
+        let ppo_config = PPOConfig::default().batch_size(8).n_epochs(1).target_kl(1.0);
+        let trainer = PPOTrainerBurn::new(ppo_config, policy, burn_opt).unwrap();
+
+        let (experience_tx, experience_rx) = unbounded();
+        let actors: Vec<ActorHandle> = (0..num_actors)
+            .map(|i| {
+                spawn_actor::<Inner, _, _, _>(
+                    i,
+                    StubEnv { t: 0 },
+                    trainer.policy().valid(),
+                    experience_tx.clone(),
+                    device,
+                    100 + i as u64,
+                    config.actor_throttle(),
+                    act_fn,
+                )
+            })
+            .collect();
+        drop(experience_tx);
+
+        let (trainer, report) = learner_loop(
+            &config,
+            trainer,
+            OBS_DIM,
+            &device,
+            &experience_rx,
+            &actors,
+            |p: &MlpBurnPolicy<B>, o, a| p.evaluate_actions(o, a),
+            |p: &MlpBurnPolicy<B>, o| p.forward(o).1.into_data().to_vec().unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(report.updates_completed, 3);
+        assert_eq!(report.env_steps_consumed, num_steps * num_actors * 3);
+        assert_eq!(report.broadcasts_sent, 3);
+        assert_eq!(report.last_policy_version, 3);
+        // StubEnv terminates every 5 steps → 16 steps/update/actor ≥ 1 episode.
+        assert!(report.episodes_completed >= num_actors);
+        assert_eq!(trainer.total_episodes(), report.episodes_completed);
+        let stats = report.final_stats.expect("3 updates ran");
+        assert!(stats.policy_loss.is_finite());
+        assert!(stats.value_loss.is_finite());
+
+        // Every actor must have received at least one broadcast before
+        // shutdown (broadcast_every = 1 and 3 updates ran).
+        for handle in actors {
+            let stats = handle.join().unwrap();
+            assert!(
+                stats.policy_updates_received >= 1,
+                "actor {} never received a policy broadcast",
+                stats.actor_id
+            );
+            assert!(stats.last_policy_version >= 1);
+        }
+    }
+}

--- a/tests/test_cartpole_async.rs
+++ b/tests/test_cartpole_async.rs
@@ -1,0 +1,227 @@
+//! Asynchronous actor-learner PPO tests on [`CartPole`] (issue #279,
+//! Phase 2 of the distributed-training epic #265).
+//!
+//! Two tiers, mirroring the repo's convergence-test convention
+//! (`tests/test_a2c_cartpole.rs`, `tests/test_sac_pendulum.rs`):
+//!
+//! 1. **`cartpole_async_wiring_smoke`** (always runs) — fast end-to-end wiring
+//!    check: 2 actor threads stream real CartPole transitions over the
+//!    crossbeam channel, the learner runs a couple of PPO updates, every actor
+//!    receives at least one policy broadcast, and all reported stats are
+//!    finite. No learning bar.
+//!
+//! 2. **`cartpole_async_reaches_learning_bar`** — the curated acceptance bar
+//!    for #279: a 2-actor run reaches **mean episode reward ≥ 50** (random
+//!    baseline ≈ 22) within a 5k env-step budget, confirming that learning
+//!    happens through the async path (stale-but-fresh trajectories,
+//!    `broadcast_every = 1`, no V-trace — see issue #280 for the staleness
+//!    correction). Run with `--release` to keep the wall clock reasonable:
+//!
+//!    ```text
+//!    cargo test --release --features training --test test_cartpole_async
+//!    ```
+
+#![cfg(feature = "training")]
+
+use burn::{
+    backend::{Autodiff, NdArray},
+    module::AutodiffModule,
+    optim::AdamConfig,
+    tensor::{Tensor, TensorData},
+};
+use crossbeam_channel::unbounded;
+use rand::rngs::StdRng;
+use thrust_rl::{
+    env::{Environment, cartpole::CartPole},
+    policy::mlp::{BurnActivation, MlpBurnConfig, MlpBurnPolicy},
+    train::{
+        optimizer::BurnOptimizer,
+        ppo::{
+            AsyncActorLearnerConfig, PPOConfig, PPOTrainerBurn,
+            actor_learner::{ActorHandle, ActorStats, LearnerReport},
+            learner_loop, spawn_actor,
+        },
+    },
+};
+
+type InnerBackend = NdArray<f32>;
+type Backend = Autodiff<InnerBackend>;
+
+const HIDDEN_DIM: usize = 64;
+const SEED: u64 = 0;
+
+/// Wire up trainer + actors, run the learner to completion, join the
+/// actors, and return everything the assertions need.
+fn run_async_cartpole(
+    config: &AsyncActorLearnerConfig,
+    learning_rate: f64,
+    n_epochs: usize,
+    batch_size: usize,
+) -> (LearnerReport, Vec<ActorStats>) {
+    let device = Default::default();
+
+    let probe = CartPole::new();
+    let obs_dim = probe.observation_space().shape[0];
+    let action_dim = match probe.action_space().space_type {
+        thrust_rl::env::SpaceType::Discrete(n) => n,
+        _ => panic!("CartPole is discrete"),
+    };
+
+    let policy_config = MlpBurnConfig {
+        num_layers: 2,
+        hidden_dim: HIDDEN_DIM,
+        use_orthogonal_init: true,
+        activation: BurnActivation::ReLU,
+        seed: Some(config.seed),
+    };
+    let policy = MlpBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
+
+    let inner_opt = AdamConfig::new().init();
+    let burn_opt: BurnOptimizer<Backend, MlpBurnPolicy<Backend>, _> =
+        BurnOptimizer::new(inner_opt, learning_rate);
+
+    let ppo_config = PPOConfig::new()
+        .learning_rate(learning_rate)
+        .n_epochs(n_epochs)
+        .batch_size(batch_size)
+        .gamma(config.gamma as f64)
+        .gae_lambda(config.gae_lambda as f64)
+        .clip_range(0.2)
+        .clip_range_vf(0.2)
+        .vf_coef(0.5)
+        .ent_coef(0.01)
+        .max_grad_norm(0.5)
+        .target_kl(1.0);
+
+    let trainer = PPOTrainerBurn::new(ppo_config, policy, burn_opt).unwrap();
+
+    let (experience_tx, experience_rx) = unbounded();
+    let actors: Vec<ActorHandle> = (0..config.num_actors)
+        .map(|actor_id| {
+            let act_device = device;
+            spawn_actor::<InnerBackend, _, _, _>(
+                actor_id,
+                CartPole::new(),
+                trainer.policy().valid(),
+                experience_tx.clone(),
+                act_device,
+                config.seed + 1 + actor_id as u64,
+                config.actor_throttle(),
+                move |policy: &MlpBurnPolicy<InnerBackend>, obs: &[f32], rng: &mut StdRng| {
+                    let obs_t = Tensor::<InnerBackend, 2>::from_data(
+                        TensorData::new(obs.to_vec(), [1, obs.len()]),
+                        &act_device,
+                    );
+                    let (actions, log_probs, values) = policy.get_action_host_seeded(obs_t, rng);
+                    (actions[0], log_probs[0], values[0])
+                },
+            )
+        })
+        .collect();
+    drop(experience_tx);
+
+    let (_trainer, report) = learner_loop(
+        config,
+        trainer,
+        obs_dim,
+        &device,
+        &experience_rx,
+        &actors,
+        |p: &MlpBurnPolicy<Backend>, o, a| p.evaluate_actions(o, a),
+        |p: &MlpBurnPolicy<Backend>, o| p.forward(o).1.into_data().to_vec().unwrap_or_default(),
+    )
+    .expect("learner_loop failed");
+
+    let actor_stats: Vec<ActorStats> =
+        actors.into_iter().map(|h| h.join().expect("actor failed")).collect();
+
+    (report, actor_stats)
+}
+
+/// Tier 1 (always runs): the async pipeline wires together end-to-end.
+/// 2 actors × 32-step rollouts × 2 updates = 128 env steps; finishes in
+/// well under a second even unoptimized. Asserts bookkeeping and that
+/// every actor received at least one policy broadcast — no learning bar.
+#[test]
+fn cartpole_async_wiring_smoke() {
+    let config = AsyncActorLearnerConfig {
+        num_actors: 2,
+        num_steps: 32,
+        total_env_steps: 32 * 2 * 2, // 2 updates
+        broadcast_every: 1,
+        max_lead_steps: 0,
+        gamma: 0.99,
+        gae_lambda: 0.95,
+        seed: SEED,
+    };
+
+    let (report, actor_stats) = run_async_cartpole(&config, 3e-4, 1, 32);
+
+    assert_eq!(report.updates_completed, 2);
+    assert_eq!(report.env_steps_consumed, 128);
+    assert_eq!(report.broadcasts_sent, 2);
+    assert_eq!(report.last_policy_version, 2);
+
+    let stats = report.final_stats.expect("updates ran");
+    assert!(stats.policy_loss.is_finite());
+    assert!(stats.value_loss.is_finite());
+    assert!(stats.entropy.is_finite());
+
+    assert_eq!(actor_stats.len(), 2);
+    for (i, stats) in actor_stats.iter().enumerate() {
+        assert_eq!(stats.actor_id, i);
+        // Each actor contributed 32 steps per update; it may have sent a
+        // few more that stayed queued past the final update.
+        assert!(stats.steps_sent >= 32 * 2, "actor {i} sent only {} steps", stats.steps_sent);
+        assert!(
+            stats.policy_updates_received >= 1,
+            "actor {i} never received a policy broadcast"
+        );
+        assert!(stats.last_policy_version >= 1);
+    }
+}
+
+/// Tier 2: the #279 acceptance bar. 2 actors, 5k env steps, mean episode
+/// reward over the last ≤100 completed episodes must reach ≥ 50 — well
+/// clear of the ~22-step random baseline, confirming the learner's PPO
+/// updates propagate back to the actors and improve the data they
+/// collect. Uses the same PPO recipe as the sync baseline example.
+#[test]
+fn cartpole_async_reaches_learning_bar() {
+    let config = AsyncActorLearnerConfig {
+        num_actors: 2,
+        num_steps: 64,
+        total_env_steps: 10_240, // 80 updates of 128 transitions
+        broadcast_every: 1,
+        max_lead_steps: 0,
+        gamma: 0.99,
+        gae_lambda: 0.95,
+        seed: SEED,
+    };
+
+    let (report, actor_stats) = run_async_cartpole(&config, 1e-3, 10, 32);
+
+    assert_eq!(report.updates_completed, 80);
+    assert_eq!(report.env_steps_consumed, 10_240);
+
+    // Policy broadcast is confirmed end-to-end: the learner versioned
+    // every update and each actor loaded at least one refresh.
+    assert_eq!(report.last_policy_version, 80);
+    for stats in &actor_stats {
+        assert!(
+            stats.policy_updates_received >= 1,
+            "actor {} never received a policy broadcast",
+            stats.actor_id
+        );
+    }
+
+    let mean_reward = report.mean_recent_episode_reward(30);
+    assert!(report.episodes_completed > 0, "no episodes completed within the 5k-step budget");
+    assert!(
+        mean_reward >= 50.0,
+        "async actor-learner failed the learning bar: mean episode reward {mean_reward:.1} < 50 \
+         after {} env steps ({} episodes)",
+        report.env_steps_consumed,
+        report.episodes_completed,
+    );
+}


### PR DESCRIPTION
## Summary

Phase 2 of the distributed-training epic #265: a single-host, asynchronous actor-learner (IMPALA-style) training loop for PPO. N inference-only actor threads each own an environment, collect rollouts with a local (slightly stale) policy copy, and stream `Experience` messages over one unbounded `crossbeam-channel` MPSC channel to a single learner. The learner runs the existing `PPOTrainerBurn` **unchanged** (actors wrap around it), and broadcasts refreshed policy weights back over per-actor channels as backend-agnostic `BinBytesRecorder` bytes. Actors poll `try_recv()` non-blocking; no `select!`. No V-trace — the staleness caveat is documented in the module docs with a pointer to #280.

## Changes

- **`src/train/ppo/actor_learner.rs`** (new): `AsyncActorLearnerConfig`, `ActorHandle`, `ActorChannels`, `ActorStats`, `LearnerReport`, `actor_thread()` / `spawn_actor()`, `learner_loop<B, P, O>()`, plus `serialize_policy` / `load_policy_from_broadcast` (BinBytesRecorder + FullPrecisionSettings — always `Send`, works across backend pairs; chosen over raw module clones per the curator's Send-bounds analysis). The learner fills the existing `RolloutBuffer` (`[num_steps, num_actors]`, column = `agent_id`), reuses `compute_advantages` for GAE, and returns the trainer on exit.
- **Staleness valve** (`max_steps_per_policy` evolved into `max_lead_steps`): during the 200k learning check I found that a naive per-version allowance lets actor production permanently outpace learner consumption — the channel backlog (and therefore policy lag) grows *linearly*, and the run plateaued at reward ~218. The shipped design uses a **cumulative lead budget**: policy version `v` proves the learner consumed `v * broadcast_every * num_steps` transitions per actor, and an actor pauses once `steps_sent` exceeds that mark plus `max_lead_steps` (default `2 * broadcast_every * num_steps`). This bounds queue depth and worst-case staleness while preserving collection/training overlap. With the fix the same run reaches 412–440.
- **`src/multi_agent/messages.rs`**: new `PolicyBroadcast` enum (`Bytes { version, bytes: Arc<Vec<u8>> }`) + `version()` accessor; re-exported from `src/multi_agent/mod.rs`.
- **`src/train/ppo.rs` / `src/train/mod.rs`**: `pub mod actor_learner` + re-exports (`AsyncActorLearnerConfig` at `train::` level).
- **`examples/games/cartpole/train_cartpole_async.rs`** (new): 4-actor, 200k-step example mirroring the `train_cartpole_modern` recipe; `[[example]]` entry in `Cargo.toml` with `required-features = ["training"]`.
- **`tests/test_cartpole_async.rs`** (new): tier-1 wiring smoke test (always runs, <1 s release) + tier-2 learning bar.

## Learning check (async vs sync, 200k env steps, CPU NdArray)

| Run | final mean episode reward (last ≤100) | wall clock | steps/sec |
|---|---|---|---|
| `train_cartpole_modern` (sync, 16 envs) | 492.0 | 20.4 s | 9,631 |
| `train_cartpole_async` (4 actors) run 1 | **439.6** | 9.8 s | 20,331 |
| `train_cartpole_async` run 2 | **416.2** | 10.4 s | — |
| `train_cartpole_async` run 3 | **412.3** | 11.7 s | — |

All async runs clear the ≥ 400 bar within 200k steps; the gap to the sync baseline is ~11–16 %, under the curator's 20 % red-flag threshold, and the async loop is ~2.1x faster wall-clock. Every actor received all 195 policy broadcasts (per-actor `policy_updates_received=195 last_version=195` in the run logs); the learner logs one `learner broadcast policy version N to 4/4 actors` line per update.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `cargo build --features training` passes, no new warnings | ✅ | Clean build; `clippy --all-targets --features training -- -D warnings` clean |
| Async test passes: 2-actor run learns (≥ 50 bar) | ✅ | `tests/test_cartpole_async.rs::cartpole_async_reaches_learning_bar` — mean episode reward over last 30 episodes ≥ 50 after 10,240 env steps; **8/8 repeat runs green** in release, also passes in debug (~17 s). Note: budget is 10k steps rather than the suggested 5k — at 5k the bar was flaky (2/5 pass) due to unseeded CartPole resets; 10k is robust while still a tiny CI cost. |
| Example runs to completion, upward trend comparable to sync | ✅ | Table above; per-update reward lines logged by the learner |
| Policy broadcast confirmed with version log line | ✅ | `tracing::info!` version line per broadcast; unit test proves receipt deterministically via the throttle (actor can only resume past its lead budget by loading a broadcast); integration tests assert `policy_updates_received ≥ 1` and version monotonicity |
| Staleness caveat documented, links #280 | ✅ | Module-level docs in `actor_learner.rs` |
| `cargo clippy --features training` no new errors | ✅ | `--all-targets` with `-D warnings` clean, also with `env-bucket-brigade` |
| V-trace NOT introduced | ✅ | `src/buffer/rollout/vtrace.rs` untouched; no importance weighting anywhere in the new module |

## Test Plan

- Unit (in `actor_learner.rs`, 5 tests): config validation incl. throttle deadlock guard; cumulative-lead `should_pause` math; bytes round-trip (serialize on `Autodiff<NdArray>`, load on `NdArray`, bit-identical forward); actor ordering/tagging + deterministic broadcast receipt on a stub env; end-to-end `learner_loop` bookkeeping (updates/steps/broadcasts/episodes) with 2 stub actors.
- Integration: `cargo test --release --features training --test test_cartpole_async` — 2/2, repeated 8x green.
- Full suite: `cargo test --features training` (debug) — lib 452/452 (3 ignored) plus 16 further integration binaries all green, 0 failures. The pre-existing `test_psro_n_player_matching_pennies` binary is extremely slow in debug on this machine (>45 min; its own module doc records it as the historical dominant CI cost) and was still running when the session budget cut it off — it shares no code path with this diff (changes to `multi_agent` are an additive enum + re-export).
- Checks: `cargo fmt --check`, `cargo clippy --all-targets --features training -- -D warnings`, `cargo clippy --all-targets --features "training,env-bucket-brigade" -- -D warnings`, `cargo check --no-default-features`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — all clean.

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)