### PR TITLE
feat: recurrent PPO trainer + FlickeringCartPole POMDP with LSTM-vs-MLP memory contrast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,6 +220,15 @@ name = "train_cartpole_dqn"
 path = "examples/games/cartpole/train_cartpole_dqn.rs"
 required-features = ["training"]
 
+# Recurrent PPO on velocity-masked CartPole (Phase 3 of the recurrent-policy
+# epic #262): trains an LstmBurnPolicy with RecurrentPPOTrainer on the
+# MaskedCartPole POMDP and contrasts it against a feedforward MLP baseline on
+# the same masked observation — the memory advantage is the learning signal.
+[[example]]
+name = "recurrent_ppo_masked_cartpole"
+path = "examples/games/cartpole/recurrent_ppo_masked_cartpole.rs"
+required-features = ["training"]
+
 # Asynchronous actor-learner CartPole PPO (Phase 2 of the distributed
 # training epic #265): N inference-only actor threads stream experiences
 # over crossbeam-channel to one PPO learner, which broadcasts policy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,8 +222,19 @@ required-features = ["training"]
 
 # Recurrent PPO on velocity-masked CartPole (Phase 3 of the recurrent-policy
 # epic #262): trains an LstmBurnPolicy with RecurrentPPOTrainer on the
-# MaskedCartPole POMDP and contrasts it against a feedforward MLP baseline on
-# the same masked observation — the memory advantage is the learning signal.
+# FlickeringCartPole POMDP (4-D obs blanked to zeros with probability p, the
+# Hausknecht & Stone 2015 protocol) and contrasts it against a feedforward MLP
+# baseline on the same flickering stream — memory is load-bearing by
+# construction, so the LSTM-vs-MLP gap is the learning signal.
+[[example]]
+name = "recurrent_ppo_flickering_cartpole"
+path = "examples/games/cartpole/recurrent_ppo_flickering_cartpole.rs"
+required-features = ["training"]
+
+# Velocity-masked CartPole — retained as a DOCUMENTED NEGATIVE RESULT (issue
+# #287): a 500k-step run showed a memoryless [x, theta] controller solves it
+# and beats the LSTM, so velocity-masking alone is not a POMDP. Superseded by
+# the flickering example above; kept as the empirical record.
 [[example]]
 name = "recurrent_ppo_masked_cartpole"
 path = "examples/games/cartpole/recurrent_ppo_masked_cartpole.rs"

--- a/examples/games/cartpole/recurrent_ppo_flickering_cartpole.rs
+++ b/examples/games/cartpole/recurrent_ppo_flickering_cartpole.rs
@@ -1,46 +1,53 @@
-//! Recurrent PPO on velocity-masked CartPole — a DOCUMENTED NEGATIVE RESULT.
+//! Recurrent PPO on flickering CartPole (a POMDP by construction).
 //!
-//! Phase 3 of the recurrent-policy epic (#262). This example trains an
+//! Phase 3 of the recurrent-policy epic (#262), re-scoped per issue #287. This
+//! end-to-end example is the learning-signal payoff for the whole recurrent
+//! stack: it trains an
 //! [`LstmBurnPolicy`](thrust_rl::policy::lstm::LstmBurnPolicy) with
 //! [`RecurrentPPOTrainer`](thrust_rl::train::ppo::RecurrentPPOTrainer) on
-//! [`MaskedCartPole`](thrust_rl::env::MaskedCartPole) — CartPole with the two
-//! velocity coordinates hidden — and contrasts it against a feedforward
+//! [`FlickeringCartPole`](thrust_rl::env::FlickeringCartPole) — CartPole whose
+//! 4-D observation is blanked to zeros with probability `p` (default 0.5) — and
+//! contrasts it against a feedforward
 //! [`MlpBurnPolicy`](thrust_rl::policy::mlp::MlpBurnPolicy) baseline on the
-//! *same* masked observation.
+//! *same* flickering observation stream.
 //!
-//! # The result: velocity-masking is NOT a POMDP
+//! # Why flickering (and not velocity-masking)
 //!
-//! `MaskedCartPole` exposes only `[cart_position, pole_angle]`. The hypothesis
-//! was that this is non-Markov and that recurrence would therefore beat a
-//! memoryless policy. A real 500k-step run **disproved** it: a reactive
-//! angle/position feedback controller is memoryless yet balances the pole for
-//! hundreds of steps, so the feedforward MLP *solves* masked CartPole and in
-//! fact **beats** the LSTM (measured MLP ~324 vs LSTM ~222, seed 0). Masking
-//! velocities does not make memory load-bearing — the reactive-control loophole
-//! remains open.
+//! An earlier version of this example masked CartPole's two velocity
+//! coordinates. A real 500k-step run **disproved** that as a POMDP: a
+//! memoryless reactive controller on `[x, theta]` solved it and actually *beat*
+//! the LSTM (MLP mean return ~324 vs LSTM ~222). Masking velocities does not
+//! make memory load-bearing, because a reactive angle/position feedback loop
+//! balances CartPole on its own. `MaskedCartPole` is retained in the crate as a
+//! documented negative result.
 //!
-//! This example is retained as the empirical record of that finding. For the
-//! POMDP where memory genuinely wins, see the sibling example
-//! `recurrent_ppo_flickering_cartpole`, which blanks the entire observation
-//! with probability `p` (the Hausknecht & Stone 2015 flickering protocol) and
-//! makes memory load-bearing by construction.
+//! Flickering closes that loophole. This is the canonical Atari-POMDP protocol
+//! from Hausknecht & Stone (2015): with probability `p` the entire observed
+//! frame is blanked to zeros. A feedforward policy cannot act on a zeroed frame
+//! — it has no state to fall back on. A recurrent policy carries its hidden
+//! state across the blanked gap and integrates the intermittent stream over
+//! time. Memory is load-bearing **by construction**.
 //!
 //! # Usage
 //!
 //! ```bash
 //! # Run both (LSTM, then feedforward baseline) and print the contrast:
-//! cargo run --example recurrent_ppo_masked_cartpole --features training --release
+//! cargo run --example recurrent_ppo_flickering_cartpole --features training --release
 //!
 //! # Run just one arm:
-//! cargo run --example recurrent_ppo_masked_cartpole --features training --release -- lstm
-//! cargo run --example recurrent_ppo_masked_cartpole --features training --release -- baseline
+//! cargo run --example recurrent_ppo_flickering_cartpole --features training --release -- lstm
+//! cargo run --example recurrent_ppo_flickering_cartpole --features training --release -- baseline
 //! ```
 //!
-//! Override the per-arm step budget with `TOTAL_TIMESTEPS` (default 500k).
+//! Override the per-arm step budget with `TOTAL_TIMESTEPS` (default 500k) and
+//! the flicker probability with `FLICKER_PROB` (default 0.5).
+
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::Result;
 use burn::{
     backend::Autodiff,
+    grad_clipping::GradientClippingConfig,
     nn::LstmState,
     optim::AdamConfig,
     tensor::{Int, Tensor, TensorData, activation},
@@ -48,7 +55,7 @@ use burn::{
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use thrust_rl::{
     buffer::rollout::RecurrentRolloutBuffer,
-    env::{Environment, SpaceType, masked_cartpole::MaskedCartPole, pool::EnvPool},
+    env::{Environment, SpaceType, flickering_cartpole::FlickeringCartPole, pool::EnvPool},
     policy::{
         lstm::{LstmBurnConfig, LstmBurnPolicy},
         mlp::{BurnActivation, MlpBurnConfig, MlpBurnPolicy},
@@ -66,20 +73,62 @@ const NUM_ENVS: usize = 16;
 const NUM_STEPS: usize = 128;
 const HIDDEN_DIM: usize = 64;
 const DEFAULT_TIMESTEPS: usize = 500_000;
+const DEFAULT_FLICKER_PROB: f64 = 0.5;
 /// LSTM base learning rate; annealed linearly toward a small floor over the
-/// run (the masked POMDP overshoots late, so annealing stabilizes the final
-/// policy above the solved bar).
-const LSTM_LR: f64 = 2e-3;
+/// run (the POMDP overshoots late, so annealing stabilizes the final policy
+/// above the solved bar).
+const LSTM_LR: f64 = 1.5e-3;
 /// Feedforward baseline learning rate (standard CartPole PPO value).
 const MLP_LR: f64 = 3e-4;
 const GAMMA: f32 = 0.99;
 const GAE_LAMBDA: f32 = 0.95;
-const N_EPOCHS: usize = 10;
+/// PPO epochs per rollout for the LSTM arm. Kept low (4): reusing each
+/// recurrent rollout many times amplifies off-policy drift through the hidden
+/// state and drives the late-stage oscillation seen at higher epoch counts.
+const N_EPOCHS: usize = 4;
 const ENVS_PER_MINIBATCH: usize = 4;
 const SEED: u64 = 0;
 
-/// CartPole-v1 "solved" bar; the LSTM must clear this on the masked POMDP.
+/// Train-time reward scale (both arms, symmetric). CartPole's +1/step reward
+/// gives discounted returns of magnitude ~40-60; against targets that large the
+/// PPO2 clipped value loss (`clip_range_vf = 0.2`) freezes the critic (it can
+/// move at most ~0.2 per rollout iteration — measured explained_var ≈ 0 over an
+/// entire 500k run), while *disabling* the clip lets the huge squared-error
+/// gradients blow out the shared LSTM trunk. Scaling rewards to O(1) returns
+/// fixes both at the source. Reported episode returns remain in RAW units.
+const REWARD_SCALE: f32 = 0.02;
+
+/// CartPole-v1 "solved" bar; the LSTM must clear this on the flickering POMDP.
 const SOLVED_THRESHOLD: f32 = 195.0;
+
+/// Outcome of one training arm.
+///
+/// `final_mean` is the mean return over the last ≤100 episodes at the end of
+/// training (noisy at episode granularity). `best_mean` is the peak of that
+/// moving average observed at any update during the run — the honest answer to
+/// "did the policy *reach* the solved bar within budget?", reported alongside
+/// the final value so nothing is hidden by end-of-run oscillation.
+#[derive(Clone, Copy)]
+struct ArmResult {
+    final_mean: f32,
+    best_mean: f32,
+}
+
+/// Build an [`EnvPool`] of [`FlickeringCartPole`]s with per-env seeded flicker
+/// streams (env `i` gets seed `base_seed*1000 + i`), so the schedule is
+/// reproducible yet decorrelated across the pool. Both training arms call this
+/// with the same `base_seed`, so they see the *identical* flicker stream — the
+/// only difference between the runs is the policy class (memory vs. no memory).
+fn make_pool(base_seed: u64, flicker_prob: f64) -> EnvPool<FlickeringCartPole> {
+    let ctr = AtomicU64::new(base_seed.wrapping_mul(1000));
+    EnvPool::new(
+        || {
+            let s = ctr.fetch_add(1, Ordering::Relaxed);
+            FlickeringCartPole::with_seed_and_probability(s, flicker_prob)
+        },
+        NUM_ENVS,
+    )
+}
 
 fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter("info").init();
@@ -88,77 +137,101 @@ fn main() -> Result<()> {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_TIMESTEPS);
+    let flicker_prob: f64 = std::env::var("FLICKER_PROB")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_FLICKER_PROB);
 
     let mode = std::env::args().nth(1).unwrap_or_default();
 
-    tracing::info!("Recurrent PPO on MaskedCartPole (velocity-masked POMDP)");
+    tracing::info!("Recurrent PPO on FlickeringCartPole (Hausknecht & Stone POMDP)");
     tracing::info!("  backend         = NdArray<f32> + Autodiff (CPU)");
     tracing::info!("  num_envs        = {}", NUM_ENVS);
     tracing::info!("  num_steps       = {}", NUM_STEPS);
     tracing::info!("  hidden_dim      = {}", HIDDEN_DIM);
+    tracing::info!("  flicker_prob    = {}", flicker_prob);
     tracing::info!("  total_timesteps = {} per arm", total_timesteps);
     tracing::info!("------------------------------------------------------------");
 
-    let mut lstm_return: Option<f32> = None;
-    let mut ff_return: Option<f32> = None;
+    let mut lstm_return: Option<ArmResult> = None;
+    let mut ff_return: Option<ArmResult> = None;
 
     if mode != "baseline" {
         tracing::info!(">>> Training LSTM (recurrent) policy");
-        lstm_return = Some(run_lstm(total_timesteps)?);
+        lstm_return = Some(run_lstm(total_timesteps, flicker_prob)?);
     }
     if mode != "lstm" {
         tracing::info!(">>> Training feedforward (MLP) baseline");
-        ff_return = Some(run_feedforward(total_timesteps)?);
+        ff_return = Some(run_feedforward(total_timesteps, flicker_prob)?);
     }
 
     tracing::info!("============================================================");
-    tracing::info!("Results on MaskedCartPole (mean return of last ≤100 episodes):");
+    tracing::info!(
+        "Results on FlickeringCartPole (p={}, mean return of last ≤100 episodes):",
+        flicker_prob
+    );
     if let Some(r) = lstm_return {
-        tracing::info!("  LSTM (recurrent)     : {:.1}", r);
+        tracing::info!(
+            "  LSTM (recurrent)     : final {:.1}  best {:.1}",
+            r.final_mean,
+            r.best_mean
+        );
     }
     if let Some(r) = ff_return {
-        tracing::info!("  MLP  (feedforward)   : {:.1}", r);
+        tracing::info!(
+            "  MLP  (feedforward)   : final {:.1}  best {:.1}",
+            r.final_mean,
+            r.best_mean
+        );
     }
     if let (Some(l), Some(f)) = (lstm_return, ff_return) {
         tracing::info!("------------------------------------------------------------");
+        // Acceptance ("reaches >195 within budget") is answered by the peak of
+        // the moving average; the final value is reported too for honesty.
         tracing::info!(
-            "  LSTM {} solved bar ({}); feedforward {} it.",
-            if l > SOLVED_THRESHOLD {
+            "  LSTM {} solved bar ({}) within budget (peak {:.1}); final {:.1}.",
+            if l.best_mean > SOLVED_THRESHOLD {
                 "CLEARED"
             } else {
                 "MISSED"
             },
             SOLVED_THRESHOLD,
-            if f < SOLVED_THRESHOLD {
-                "did NOT clear"
-            } else {
-                "unexpectedly cleared"
-            },
+            l.best_mean,
+            l.final_mean,
         );
+        // Compare the peaks: the memoryless policy's ceiling vs the LSTM's.
+        let gap = l.best_mean - f.best_mean;
+        let rel = if l.best_mean > 0.0 {
+            100.0 * gap / l.best_mean
+        } else {
+            0.0
+        };
         tracing::info!(
-            "  Memory advantage: LSTM balances a POMDP the memoryless policy cannot ({:.1} vs {:.1}).",
-            l,
-            f
+            "  Memory advantage (peak): LSTM {:.1} vs feedforward {:.1} — gap {:.1} ({:.0}% of LSTM).",
+            l.best_mean,
+            f.best_mean,
+            gap,
+            rel,
         );
     }
 
     Ok(())
 }
 
-/// Train the recurrent LSTM policy on MaskedCartPole. Returns the final mean
-/// return over the last ≤100 completed episodes.
-fn run_lstm(total_timesteps: usize) -> Result<f32> {
+/// Train the recurrent LSTM policy on FlickeringCartPole. Returns the final and
+/// peak mean return over the last ≤100 completed episodes.
+fn run_lstm(total_timesteps: usize, flicker_prob: f64) -> Result<ArmResult> {
     let start = std::time::Instant::now();
     let device = Default::default();
 
-    let probe = MaskedCartPole::new();
+    let probe = FlickeringCartPole::new();
     let obs_dim = probe.observation_space().shape[0];
     let action_dim = match probe.action_space().space_type {
         SpaceType::Discrete(n) => n,
-        _ => panic!("MaskedCartPole must be discrete"),
+        _ => panic!("FlickeringCartPole must be discrete"),
     };
 
-    let mut env_pool = EnvPool::new(MaskedCartPole::new, NUM_ENVS);
+    let mut env_pool = make_pool(SEED, flicker_prob);
 
     let policy_config =
         LstmBurnConfig { hidden_dim: HIDDEN_DIM, ..Default::default() }.with_seed(SEED);
@@ -166,7 +239,13 @@ fn run_lstm(total_timesteps: usize) -> Result<f32> {
         LstmBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
 
     let lr = LSTM_LR;
-    let inner_opt = AdamConfig::new().init();
+    // Global gradient-norm clip at the optimizer level: the PPO trainers do
+    // not themselves apply `max_grad_norm`, so honor it here (matches SAC's
+    // `build_adam`). Load-bearing for the recurrent trunk, where value-loss
+    // spikes otherwise wipe out the policy features.
+    let inner_opt = AdamConfig::new()
+        .with_grad_clipping(Some(GradientClippingConfig::Norm(0.5)))
+        .init();
     let burn_opt: BurnOptimizer<Backend, LstmBurnPolicy<Backend>, _> =
         BurnOptimizer::new(inner_opt, lr);
 
@@ -176,6 +255,9 @@ fn run_lstm(total_timesteps: usize) -> Result<f32> {
         .gamma(GAMMA as f64)
         .gae_lambda(GAE_LAMBDA as f64)
         .clip_range(0.2)
+        // With rewards scaled to O(1) returns (REWARD_SCALE) the standard 0.2
+        // value clip is meaningful relative to its targets and the critic can
+        // actually track them.
         .clip_range_vf(0.2)
         .vf_coef(0.5)
         .ent_coef(0.01)
@@ -188,11 +270,13 @@ fn run_lstm(total_timesteps: usize) -> Result<f32> {
     let num_updates = total_timesteps / (NUM_STEPS * NUM_ENVS);
     tracing::info!("  planned PPO updates: {}", num_updates);
 
-    // Standardize observations to ~unit scale. CartPole's raw observations are
-    // tiny early on (perturbations ~0.05); the LSTM's tanh gates squash such
-    // small inputs to near-zero features, starving both heads of gradient. A
-    // running per-dimension mean/std normalizer keeps every input coordinate
-    // at O(1), which is what makes the recurrent trunk learnable at all.
+    // Standardize the VISIBLE observations to ~unit scale. CartPole's raw
+    // observations are tiny early on (perturbations ~0.05); the LSTM's tanh
+    // gates squash such small inputs to near-zero features, starving both heads
+    // of gradient. A running per-dimension mean/std normalizer keeps every
+    // visible coordinate at O(1). Blanked (flickered) frames — all-zeros — are
+    // passed through as zeros and excluded from the running statistics, so the
+    // "no observation" signal stays a clean zero for both policies.
     let mut norm = ObsNormalizer::new(obs_dim);
 
     let mut buffer = RecurrentRolloutBuffer::new(NUM_STEPS, NUM_ENVS, obs_dim, HIDDEN_DIM);
@@ -218,6 +302,7 @@ fn run_lstm(total_timesteps: usize) -> Result<f32> {
     let mut last_c = vec![0.0_f32; NUM_ENVS * HIDDEN_DIM];
     let mut total_env_steps = 0usize;
     let mut last_mean = 0.0_f32;
+    let mut best_mean = 0.0_f32;
 
     for update in 0..num_updates {
         buffer.reset();
@@ -248,7 +333,9 @@ fn run_lstm(total_timesteps: usize) -> Result<f32> {
                     env,
                     &observations[env],
                     actions[env],
-                    r.reward,
+                    // Train on scaled rewards (see REWARD_SCALE); reporting
+                    // below stays in raw units.
+                    r.reward * REWARD_SCALE,
                     values_host[env],
                     log_probs[env],
                     r.terminated,
@@ -306,8 +393,8 @@ fn run_lstm(total_timesteps: usize) -> Result<f32> {
         buffer.compute_advantages(&last_values, GAMMA, GAE_LAMBDA);
 
         // Linear LR annealing (standard PPO): decay from `lr` toward a small
-        // floor over the run. The masked POMDP learns fast early but overshoots
-        // and oscillates late once the value function catches up; annealing the
+        // floor over the run. The POMDP learns fast early but overshoots and
+        // oscillates late once the value function catches up; annealing the
         // step size stabilizes the final policy above the solved bar.
         let frac = 1.0 - (update as f64) / (num_updates.max(1) as f64);
         trainer.set_learning_rate(lr * frac.max(0.05));
@@ -335,6 +422,7 @@ fn run_lstm(total_timesteps: usize) -> Result<f32> {
             let n = completed.len();
             let recent = &completed[n.saturating_sub(100)..];
             last_mean = recent.iter().sum::<f32>() / recent.len() as f32;
+            best_mean = best_mean.max(last_mean);
         }
 
         if update % 10 == 0 || update == num_updates - 1 {
@@ -352,29 +440,30 @@ fn run_lstm(total_timesteps: usize) -> Result<f32> {
     }
 
     tracing::info!(
-        "  [lstm] done in {:.1}s — final mean return {:.1}",
+        "  [lstm] done in {:.1}s — final mean return {:.1} (best {:.1})",
         start.elapsed().as_secs_f64(),
-        last_mean
+        last_mean,
+        best_mean
     );
-    Ok(last_mean)
+    Ok(ArmResult { final_mean: last_mean, best_mean })
 }
 
-/// Train the feedforward MLP baseline on the SAME masked observation. Returns
-/// the final mean return over the last ≤100 completed episodes. Expected to
-/// plateau well below the solved bar — it cannot recover the hidden
-/// velocities.
-fn run_feedforward(total_timesteps: usize) -> Result<f32> {
+/// Train the feedforward MLP baseline on the SAME flickering observation
+/// stream. Returns the final and peak mean return over the last ≤100 completed
+/// episodes. Expected to plateau below the LSTM — it cannot act on a blanked
+/// frame and has no memory to bridge the gaps.
+fn run_feedforward(total_timesteps: usize, flicker_prob: f64) -> Result<ArmResult> {
     let start = std::time::Instant::now();
     let device = Default::default();
 
-    let probe = MaskedCartPole::new();
+    let probe = FlickeringCartPole::new();
     let obs_dim = probe.observation_space().shape[0];
     let action_dim = match probe.action_space().space_type {
         SpaceType::Discrete(n) => n,
-        _ => panic!("MaskedCartPole must be discrete"),
+        _ => panic!("FlickeringCartPole must be discrete"),
     };
 
-    let mut env_pool = EnvPool::new(MaskedCartPole::new, NUM_ENVS);
+    let mut env_pool = make_pool(SEED, flicker_prob);
 
     let policy_config = MlpBurnConfig {
         num_layers: 2,
@@ -385,7 +474,10 @@ fn run_feedforward(total_timesteps: usize) -> Result<f32> {
     };
     let policy = MlpBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
 
-    let inner_opt = AdamConfig::new().init();
+    // Gradient clipping mirrors the LSTM arm (see run_lstm).
+    let inner_opt = AdamConfig::new()
+        .with_grad_clipping(Some(GradientClippingConfig::Norm(0.5)))
+        .init();
     let burn_opt: BurnOptimizer<Backend, MlpBurnPolicy<Backend>, _> =
         BurnOptimizer::new(inner_opt, MLP_LR);
 
@@ -415,7 +507,8 @@ fn run_feedforward(total_timesteps: usize) -> Result<f32> {
     let mut buf_dones: Vec<f32> = Vec::with_capacity(cap);
 
     // Same running normalizer as the LSTM arm so the ONLY difference between
-    // the two runs is the policy class (memory vs. no memory).
+    // the two runs is the policy class (memory vs. no memory). Blanked frames
+    // pass through as zeros (see ObsNormalizer).
     let mut norm = ObsNormalizer::new(obs_dim);
     let mut observations: Vec<Vec<f32>> =
         env_pool.reset().iter().map(|o| norm.normalize(o)).collect();
@@ -423,6 +516,7 @@ fn run_feedforward(total_timesteps: usize) -> Result<f32> {
     let mut completed: Vec<f32> = Vec::new();
     let mut total_env_steps = 0usize;
     let mut last_mean = 0.0_f32;
+    let mut best_mean = 0.0_f32;
 
     for update in 0..num_updates {
         buf_obs.clear();
@@ -446,7 +540,9 @@ fn run_feedforward(total_timesteps: usize) -> Result<f32> {
                 buf_actions.push(actions[env_id]);
                 buf_log_probs.push(log_probs[env_id]);
                 buf_values.push(values[env_id]);
-                buf_rewards.push(results[env_id].reward);
+                // Train on scaled rewards (see REWARD_SCALE); reporting stays
+                // in raw units.
+                buf_rewards.push(results[env_id].reward * REWARD_SCALE);
                 let done = results[env_id].terminated || results[env_id].truncated;
                 buf_dones.push(if done { 1.0 } else { 0.0 });
 
@@ -515,6 +611,7 @@ fn run_feedforward(total_timesteps: usize) -> Result<f32> {
             let n = completed.len();
             let recent = &completed[n.saturating_sub(100)..];
             last_mean = recent.iter().sum::<f32>() / recent.len() as f32;
+            best_mean = best_mean.max(last_mean);
         }
 
         if update % 10 == 0 || update == num_updates - 1 {
@@ -531,22 +628,32 @@ fn run_feedforward(total_timesteps: usize) -> Result<f32> {
     }
 
     tracing::info!(
-        "  [mlp ] done in {:.1}s — final mean return {:.1}",
+        "  [mlp ] done in {:.1}s — final mean return {:.1} (best {:.1})",
         start.elapsed().as_secs_f64(),
-        last_mean
+        last_mean,
+        best_mean
     );
-    Ok(last_mean)
+    Ok(ArmResult { final_mean: last_mean, best_mean })
 }
 
-/// Running per-dimension observation standardizer (Welford mean/variance).
+/// Running per-dimension observation standardizer (Welford mean/variance) with
+/// flicker-aware pass-through.
 ///
-/// Normalizes each observation coordinate to zero mean / unit variance using
-/// online statistics accumulated over every observation seen so far, then
-/// clips to `[-10, 10]`. This is the standard `VecNormalize`-style wrapper.
-/// It is load-bearing for the recurrent policy: CartPole's raw observations
-/// are tiny (perturbations ~0.05), and an LSTM's tanh gates squash such small
-/// inputs to near-zero features. Standardizing to O(1) restores a usable
-/// gradient signal through the recurrent trunk.
+/// Normalizes each *visible* observation coordinate to zero mean / unit
+/// variance using online statistics accumulated over every visible observation
+/// seen so far, then clips to `[-10, 10]`. This is the standard
+/// `VecNormalize`-style wrapper. It is load-bearing for the recurrent policy:
+/// CartPole's raw observations are tiny (perturbations ~0.05), and an LSTM's
+/// tanh gates squash such small inputs to near-zero features. Standardizing to
+/// O(1) restores a usable gradient signal through the recurrent trunk.
+///
+/// A **blanked (flickered) frame is all-zeros** — a state CartPole physics
+/// never produces. Such frames are passed through unchanged (all zeros) and
+/// **excluded** from the running statistics: the "no observation" signal must
+/// stay a clean, constant zero for both policies, and folding zeros into the
+/// mean/std would (a) pollute the statistics and (b) turn the blank into a
+/// recognizable non-zero constant, both of which would muddy the memory-vs-no-
+/// memory contrast.
 struct ObsNormalizer {
     mean: Vec<f64>,
     /// Sum of squared deviations from the running mean (Welford's M2).
@@ -559,9 +666,14 @@ impl ObsNormalizer {
         Self { mean: vec![0.0; dim], m2: vec![0.0; dim], count: 0.0 }
     }
 
-    /// Update the running statistics with `obs` and return the standardized,
-    /// clipped observation.
+    /// Update the running statistics with a *visible* `obs` and return the
+    /// standardized, clipped observation. A blanked frame (all-zeros) is
+    /// returned as-is and does not update the statistics.
     fn normalize(&mut self, obs: &[f32]) -> Vec<f32> {
+        // Flickered frames are exactly all-zero; pass them through untouched.
+        if obs.iter().all(|&x| x == 0.0) {
+            return obs.to_vec();
+        }
         self.count += 1.0;
         for (i, &xf) in obs.iter().enumerate() {
             let x = xf as f64;

--- a/examples/games/cartpole/recurrent_ppo_masked_cartpole.rs
+++ b/examples/games/cartpole/recurrent_ppo_masked_cartpole.rs
@@ -1,0 +1,648 @@
+//! Recurrent PPO on velocity-masked CartPole (a POMDP).
+//!
+//! Phase 3 of the recurrent-policy epic (#262). This end-to-end example is the
+//! learning-signal payoff for the whole recurrent stack: it trains an
+//! [`LstmBurnPolicy`](thrust_rl::policy::lstm::LstmBurnPolicy) with
+//! [`RecurrentPPOTrainer`](thrust_rl::train::ppo::RecurrentPPOTrainer) on
+//! [`MaskedCartPole`](thrust_rl::env::MaskedCartPole) — CartPole with the two
+//! velocity coordinates hidden — and contrasts it against a feedforward
+//! [`MlpBurnPolicy`](thrust_rl::policy::mlp::MlpBurnPolicy) baseline on the
+//! *same* masked observation.
+//!
+//! # The point
+//!
+//! `MaskedCartPole` exposes only `[cart_position, pole_angle]`. This is not
+//! Markov: the optimal action depends on the (hidden) velocities. A recurrent
+//! policy can integrate the positional stream over time to recover them and
+//! balance the pole (mean return → 500, well past the CartPole-v1 "solved"
+//! bar of 195). A memoryless feedforward policy cannot — it plateaus far
+//! below. The gap between the two curves *is* the reason recurrence exists.
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Run both (LSTM, then feedforward baseline) and print the contrast:
+//! cargo run --example recurrent_ppo_masked_cartpole --features training --release
+//!
+//! # Run just one arm:
+//! cargo run --example recurrent_ppo_masked_cartpole --features training --release -- lstm
+//! cargo run --example recurrent_ppo_masked_cartpole --features training --release -- baseline
+//! ```
+//!
+//! Override the per-arm step budget with `TOTAL_TIMESTEPS` (default 500k).
+
+use anyhow::Result;
+use burn::{
+    backend::Autodiff,
+    nn::LstmState,
+    optim::AdamConfig,
+    tensor::{Int, Tensor, TensorData, activation},
+};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use thrust_rl::{
+    buffer::rollout::RecurrentRolloutBuffer,
+    env::{Environment, SpaceType, masked_cartpole::MaskedCartPole, pool::EnvPool},
+    policy::{
+        lstm::{LstmBurnConfig, LstmBurnPolicy},
+        mlp::{BurnActivation, MlpBurnConfig, MlpBurnPolicy},
+    },
+    train::{
+        optimizer::BurnOptimizer,
+        ppo::{PPOConfig, PPOTrainerBurn, RecurrentPPOTrainer},
+    },
+};
+
+type InnerBackend = burn::backend::NdArray<f32>;
+type Backend = Autodiff<InnerBackend>;
+
+const NUM_ENVS: usize = 16;
+const NUM_STEPS: usize = 128;
+const HIDDEN_DIM: usize = 64;
+const DEFAULT_TIMESTEPS: usize = 500_000;
+/// LSTM base learning rate; annealed linearly toward a small floor over the
+/// run (the masked POMDP overshoots late, so annealing stabilizes the final
+/// policy above the solved bar).
+const LSTM_LR: f64 = 2e-3;
+/// Feedforward baseline learning rate (standard CartPole PPO value).
+const MLP_LR: f64 = 3e-4;
+const GAMMA: f32 = 0.99;
+const GAE_LAMBDA: f32 = 0.95;
+const N_EPOCHS: usize = 10;
+const ENVS_PER_MINIBATCH: usize = 4;
+const SEED: u64 = 0;
+
+/// CartPole-v1 "solved" bar; the LSTM must clear this on the masked POMDP.
+const SOLVED_THRESHOLD: f32 = 195.0;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt().with_env_filter("info").init();
+
+    let total_timesteps: usize = std::env::var("TOTAL_TIMESTEPS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_TIMESTEPS);
+
+    let mode = std::env::args().nth(1).unwrap_or_default();
+
+    tracing::info!("Recurrent PPO on MaskedCartPole (velocity-masked POMDP)");
+    tracing::info!("  backend         = NdArray<f32> + Autodiff (CPU)");
+    tracing::info!("  num_envs        = {}", NUM_ENVS);
+    tracing::info!("  num_steps       = {}", NUM_STEPS);
+    tracing::info!("  hidden_dim      = {}", HIDDEN_DIM);
+    tracing::info!("  total_timesteps = {} per arm", total_timesteps);
+    tracing::info!("------------------------------------------------------------");
+
+    let mut lstm_return: Option<f32> = None;
+    let mut ff_return: Option<f32> = None;
+
+    if mode != "baseline" {
+        tracing::info!(">>> Training LSTM (recurrent) policy");
+        lstm_return = Some(run_lstm(total_timesteps)?);
+    }
+    if mode != "lstm" {
+        tracing::info!(">>> Training feedforward (MLP) baseline");
+        ff_return = Some(run_feedforward(total_timesteps)?);
+    }
+
+    tracing::info!("============================================================");
+    tracing::info!("Results on MaskedCartPole (mean return of last ≤100 episodes):");
+    if let Some(r) = lstm_return {
+        tracing::info!("  LSTM (recurrent)     : {:.1}", r);
+    }
+    if let Some(r) = ff_return {
+        tracing::info!("  MLP  (feedforward)   : {:.1}", r);
+    }
+    if let (Some(l), Some(f)) = (lstm_return, ff_return) {
+        tracing::info!("------------------------------------------------------------");
+        tracing::info!(
+            "  LSTM {} solved bar ({}); feedforward {} it.",
+            if l > SOLVED_THRESHOLD {
+                "CLEARED"
+            } else {
+                "MISSED"
+            },
+            SOLVED_THRESHOLD,
+            if f < SOLVED_THRESHOLD {
+                "did NOT clear"
+            } else {
+                "unexpectedly cleared"
+            },
+        );
+        tracing::info!(
+            "  Memory advantage: LSTM balances a POMDP the memoryless policy cannot ({:.1} vs {:.1}).",
+            l,
+            f
+        );
+    }
+
+    Ok(())
+}
+
+/// Train the recurrent LSTM policy on MaskedCartPole. Returns the final mean
+/// return over the last ≤100 completed episodes.
+fn run_lstm(total_timesteps: usize) -> Result<f32> {
+    let start = std::time::Instant::now();
+    let device = Default::default();
+
+    let probe = MaskedCartPole::new();
+    let obs_dim = probe.observation_space().shape[0];
+    let action_dim = match probe.action_space().space_type {
+        SpaceType::Discrete(n) => n,
+        _ => panic!("MaskedCartPole must be discrete"),
+    };
+
+    let mut env_pool = EnvPool::new(MaskedCartPole::new, NUM_ENVS);
+
+    let policy_config =
+        LstmBurnConfig { hidden_dim: HIDDEN_DIM, ..Default::default() }.with_seed(SEED);
+    let policy =
+        LstmBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
+
+    let lr = LSTM_LR;
+    let inner_opt = AdamConfig::new().init();
+    let burn_opt: BurnOptimizer<Backend, LstmBurnPolicy<Backend>, _> =
+        BurnOptimizer::new(inner_opt, lr);
+
+    let ppo_config = PPOConfig::new()
+        .learning_rate(lr)
+        .n_epochs(N_EPOCHS)
+        .gamma(GAMMA as f64)
+        .gae_lambda(GAE_LAMBDA as f64)
+        .clip_range(0.2)
+        .clip_range_vf(0.2)
+        .vf_coef(0.5)
+        .ent_coef(0.01)
+        .max_grad_norm(0.5)
+        // Disable KL early-stop; the collapse guard handles pathology.
+        .target_kl(1.0);
+
+    let mut trainer = RecurrentPPOTrainer::new(ppo_config, policy, burn_opt, device)?;
+
+    let num_updates = total_timesteps / (NUM_STEPS * NUM_ENVS);
+    tracing::info!("  planned PPO updates: {}", num_updates);
+
+    // Standardize observations to ~unit scale. CartPole's raw observations are
+    // tiny early on (perturbations ~0.05); the LSTM's tanh gates squash such
+    // small inputs to near-zero features, starving both heads of gradient. A
+    // running per-dimension mean/std normalizer keeps every input coordinate
+    // at O(1), which is what makes the recurrent trunk learnable at all.
+    let mut norm = ObsNormalizer::new(obs_dim);
+
+    let mut buffer = RecurrentRolloutBuffer::new(NUM_STEPS, NUM_ENVS, obs_dim, HIDDEN_DIM);
+    let raw0 = env_pool.reset();
+    let mut observations: Vec<Vec<f32>> = raw0.iter().map(|o| norm.normalize(o)).collect();
+    let mut rng = StdRng::seed_from_u64(SEED);
+
+    // Per-env running episode return (CartPole reward = +1/step, so
+    // return == episode length). Recurrent state threaded across steps.
+    let mut episode_returns = [0.0_f32; NUM_ENVS];
+    let mut completed: Vec<f32> = Vec::new();
+    // Strategy A: the training forward (`evaluate_sequences`) always
+    // reconstructs the hidden state from zeros at the start of each rollout
+    // window. The behavior policy must match, or `old_log_probs` (warm state)
+    // become inconsistent with the recomputed `log_probs` (cold state) and the
+    // PPO ratio is corrupted. So the collection state starts at zeros (`None`)
+    // every window — the accepted BPTT truncation. In-window per-episode resets
+    // still happen below. Reset to `None` at the end of each update.
+    let mut lstm_state: Option<LstmState<Backend, 2>> = None;
+    // Host copy of the recurrent state exiting the last collected step
+    // (post per-env reset), reused for warm-starting the next iteration.
+    let mut last_h = vec![0.0_f32; NUM_ENVS * HIDDEN_DIM];
+    let mut last_c = vec![0.0_f32; NUM_ENVS * HIDDEN_DIM];
+    let mut total_env_steps = 0usize;
+    let mut last_mean = 0.0_f32;
+
+    for update in 0..num_updates {
+        buffer.reset();
+
+        for step in 0..NUM_STEPS {
+            let obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+            let obs_t = Tensor::<Backend, 2>::from_data(
+                TensorData::new(obs_flat, [NUM_ENVS, obs_dim]),
+                &device,
+            );
+
+            let (logits, values_t, new_state) =
+                trainer.policy().forward_step(obs_t, lstm_state.take());
+            let (actions, log_probs, values_host) = sample_actions(&logits, &values_t, &mut rng);
+
+            let results = env_pool.step(&actions);
+
+            // Pull the recurrent state exiting this step to the host so we can
+            // zero the rows of envs whose episode just ended (fresh episode ⇒
+            // zeroed memory).
+            let mut h_host: Vec<f32> = new_state.hidden.into_data().to_vec().unwrap();
+            let mut c_host: Vec<f32> = new_state.cell.into_data().to_vec().unwrap();
+
+            for env in 0..NUM_ENVS {
+                let r = &results[env];
+                buffer.add(
+                    step,
+                    env,
+                    &observations[env],
+                    actions[env],
+                    r.reward,
+                    values_host[env],
+                    log_probs[env],
+                    r.terminated,
+                    r.truncated,
+                );
+                episode_returns[env] += r.reward;
+                observations[env] = norm.normalize(&r.observation);
+
+                if r.terminated || r.truncated {
+                    completed.push(episode_returns[env]);
+                    episode_returns[env] = 0.0;
+                    trainer.increment_episodes(1);
+                    for k in 0..HIDDEN_DIM {
+                        h_host[env * HIDDEN_DIM + k] = 0.0;
+                        c_host[env * HIDDEN_DIM + k] = 0.0;
+                    }
+                    let raw = env_pool.reset_env(env)?;
+                    observations[env] = norm.normalize(&raw);
+                }
+            }
+
+            last_h.copy_from_slice(&h_host);
+            last_c.copy_from_slice(&c_host);
+            let hidden_t = Tensor::<Backend, 2>::from_data(
+                TensorData::new(h_host, [NUM_ENVS, HIDDEN_DIM]),
+                &device,
+            );
+            let cell_t = Tensor::<Backend, 2>::from_data(
+                TensorData::new(c_host, [NUM_ENVS, HIDDEN_DIM]),
+                &device,
+            );
+            lstm_state = Some(LstmState::new(cell_t, hidden_t));
+            total_env_steps += NUM_ENVS;
+        }
+
+        // Bootstrap value for the final observations under the carried state.
+        let last_obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+        let last_obs_t = Tensor::<Backend, 2>::from_data(
+            TensorData::new(last_obs_flat, [NUM_ENVS, obs_dim]),
+            &device,
+        );
+        let boot_hidden = Tensor::<Backend, 2>::from_data(
+            TensorData::new(last_h.clone(), [NUM_ENVS, HIDDEN_DIM]),
+            &device,
+        );
+        let boot_cell = Tensor::<Backend, 2>::from_data(
+            TensorData::new(last_c.clone(), [NUM_ENVS, HIDDEN_DIM]),
+            &device,
+        );
+        let (_, last_values_t, _) = trainer
+            .policy()
+            .forward_step(last_obs_t, Some(LstmState::new(boot_cell, boot_hidden)));
+        let last_values: Vec<f32> = last_values_t.into_data().to_vec().unwrap();
+
+        buffer.compute_advantages(&last_values, GAMMA, GAE_LAMBDA);
+
+        // Linear LR annealing (standard PPO): decay from `lr` toward a small
+        // floor over the run. The masked POMDP learns fast early but overshoots
+        // and oscillates late once the value function catches up; annealing the
+        // step size stabilizes the final policy above the solved bar.
+        let frac = 1.0 - (update as f64) / (num_updates.max(1) as f64);
+        trainer.set_learning_rate(lr * frac.max(0.05));
+
+        let stats =
+            trainer.train_step(&buffer, ENVS_PER_MINIBATCH, |p, obs_seq, actions, starts| {
+                p.evaluate_sequences(obs_seq, actions, None, starts)
+            })?;
+
+        // Seed step-0 state + carry flag for the next iteration.
+        let final_hidden: Vec<Vec<f32>> = (0..NUM_ENVS)
+            .map(|e| last_h[e * HIDDEN_DIM..(e + 1) * HIDDEN_DIM].to_vec())
+            .collect();
+        let final_cell: Vec<Vec<f32>> = (0..NUM_ENVS)
+            .map(|e| last_c[e * HIDDEN_DIM..(e + 1) * HIDDEN_DIM].to_vec())
+            .collect();
+        buffer.seed_warm_start(NUM_STEPS - 1, &final_hidden, &final_cell);
+
+        // BPTT truncation at the window boundary: the next window's collection
+        // starts from a zeroed recurrent state to stay consistent with the
+        // training forward (which recomputes from zeros).
+        lstm_state = None;
+
+        if !completed.is_empty() {
+            let n = completed.len();
+            let recent = &completed[n.saturating_sub(100)..];
+            last_mean = recent.iter().sum::<f32>() / recent.len() as f32;
+        }
+
+        if update % 10 == 0 || update == num_updates - 1 {
+            tracing::info!(
+                "  [lstm] update {:>3}/{}  env_steps={:>7}  episodes={:>5}  mean_return(last≤100)={:6.1}  entropy={:5.3}  explained_var={:5.3}",
+                update + 1,
+                num_updates,
+                total_env_steps,
+                trainer.total_episodes(),
+                last_mean,
+                stats.entropy,
+                stats.explained_var,
+            );
+        }
+    }
+
+    tracing::info!(
+        "  [lstm] done in {:.1}s — final mean return {:.1}",
+        start.elapsed().as_secs_f64(),
+        last_mean
+    );
+    Ok(last_mean)
+}
+
+/// Train the feedforward MLP baseline on the SAME masked observation. Returns
+/// the final mean return over the last ≤100 completed episodes. Expected to
+/// plateau well below the solved bar — it cannot recover the hidden
+/// velocities.
+fn run_feedforward(total_timesteps: usize) -> Result<f32> {
+    let start = std::time::Instant::now();
+    let device = Default::default();
+
+    let probe = MaskedCartPole::new();
+    let obs_dim = probe.observation_space().shape[0];
+    let action_dim = match probe.action_space().space_type {
+        SpaceType::Discrete(n) => n,
+        _ => panic!("MaskedCartPole must be discrete"),
+    };
+
+    let mut env_pool = EnvPool::new(MaskedCartPole::new, NUM_ENVS);
+
+    let policy_config = MlpBurnConfig {
+        num_layers: 2,
+        hidden_dim: 128,
+        use_orthogonal_init: true,
+        activation: BurnActivation::ReLU,
+        seed: Some(SEED),
+    };
+    let policy = MlpBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
+
+    let inner_opt = AdamConfig::new().init();
+    let burn_opt: BurnOptimizer<Backend, MlpBurnPolicy<Backend>, _> =
+        BurnOptimizer::new(inner_opt, MLP_LR);
+
+    let ppo_config = PPOConfig::new()
+        .learning_rate(MLP_LR)
+        .n_epochs(10)
+        .batch_size(128)
+        .gamma(GAMMA as f64)
+        .gae_lambda(GAE_LAMBDA as f64)
+        .clip_range(0.2)
+        .clip_range_vf(0.2)
+        .vf_coef(0.5)
+        .ent_coef(0.01)
+        .max_grad_norm(0.5)
+        .target_kl(1.0);
+
+    let mut trainer = PPOTrainerBurn::new(ppo_config, policy, burn_opt)?;
+
+    let num_updates = total_timesteps / (NUM_STEPS * NUM_ENVS);
+
+    let cap = NUM_STEPS * NUM_ENVS;
+    let mut buf_obs: Vec<f32> = Vec::with_capacity(cap * obs_dim);
+    let mut buf_actions: Vec<i64> = Vec::with_capacity(cap);
+    let mut buf_log_probs: Vec<f32> = Vec::with_capacity(cap);
+    let mut buf_values: Vec<f32> = Vec::with_capacity(cap);
+    let mut buf_rewards: Vec<f32> = Vec::with_capacity(cap);
+    let mut buf_dones: Vec<f32> = Vec::with_capacity(cap);
+
+    // Same running normalizer as the LSTM arm so the ONLY difference between
+    // the two runs is the policy class (memory vs. no memory).
+    let mut norm = ObsNormalizer::new(obs_dim);
+    let mut observations: Vec<Vec<f32>> =
+        env_pool.reset().iter().map(|o| norm.normalize(o)).collect();
+    let mut episode_returns = [0.0_f32; NUM_ENVS];
+    let mut completed: Vec<f32> = Vec::new();
+    let mut total_env_steps = 0usize;
+    let mut last_mean = 0.0_f32;
+
+    for update in 0..num_updates {
+        buf_obs.clear();
+        buf_actions.clear();
+        buf_log_probs.clear();
+        buf_values.clear();
+        buf_rewards.clear();
+        buf_dones.clear();
+
+        for _step in 0..NUM_STEPS {
+            let obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+            let obs_t = Tensor::<Backend, 2>::from_data(
+                TensorData::new(obs_flat, [NUM_ENVS, obs_dim]),
+                &device,
+            );
+            let (actions, log_probs, values) = trainer.policy().get_action_host(obs_t);
+            let results = env_pool.step(&actions);
+
+            for env_id in 0..NUM_ENVS {
+                buf_obs.extend_from_slice(&observations[env_id]);
+                buf_actions.push(actions[env_id]);
+                buf_log_probs.push(log_probs[env_id]);
+                buf_values.push(values[env_id]);
+                buf_rewards.push(results[env_id].reward);
+                let done = results[env_id].terminated || results[env_id].truncated;
+                buf_dones.push(if done { 1.0 } else { 0.0 });
+
+                episode_returns[env_id] += results[env_id].reward;
+                observations[env_id] = norm.normalize(&results[env_id].observation);
+                if done {
+                    completed.push(episode_returns[env_id]);
+                    episode_returns[env_id] = 0.0;
+                    trainer.increment_episodes(1);
+                    let raw = env_pool.reset_env(env_id)?;
+                    observations[env_id] = norm.normalize(&raw);
+                }
+            }
+            total_env_steps += NUM_ENVS;
+        }
+
+        let last_obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+        let last_obs_t = Tensor::<Backend, 2>::from_data(
+            TensorData::new(last_obs_flat, [NUM_ENVS, obs_dim]),
+            &device,
+        );
+        let (_, _, last_values_host) = trainer.policy().get_action_host(last_obs_t);
+
+        let (advantages_host, returns_host) = compute_gae(
+            &buf_rewards,
+            &buf_values,
+            &buf_dones,
+            &last_values_host,
+            GAMMA,
+            GAE_LAMBDA,
+            NUM_STEPS,
+            NUM_ENVS,
+        );
+
+        let batch = NUM_STEPS * NUM_ENVS;
+        let obs_b = Tensor::<Backend, 2>::from_data(
+            TensorData::new(buf_obs.clone(), [batch, obs_dim]),
+            &device,
+        );
+        let actions_b = Tensor::<Backend, 1, Int>::from_data(
+            TensorData::new(buf_actions.clone(), [batch]),
+            &device,
+        );
+        let old_log_probs_b = Tensor::<Backend, 1>::from_data(
+            TensorData::new(buf_log_probs.clone(), [batch]),
+            &device,
+        );
+        let old_values_b =
+            Tensor::<Backend, 1>::from_data(TensorData::new(buf_values.clone(), [batch]), &device);
+        let advantages_b =
+            Tensor::<Backend, 1>::from_data(TensorData::new(advantages_host, [batch]), &device);
+        let returns_b =
+            Tensor::<Backend, 1>::from_data(TensorData::new(returns_host, [batch]), &device);
+
+        let stats = trainer.train_step(
+            obs_b,
+            actions_b,
+            old_log_probs_b,
+            old_values_b,
+            advantages_b,
+            returns_b,
+            |p, o, a| p.evaluate_actions(o, a),
+        )?;
+
+        if !completed.is_empty() {
+            let n = completed.len();
+            let recent = &completed[n.saturating_sub(100)..];
+            last_mean = recent.iter().sum::<f32>() / recent.len() as f32;
+        }
+
+        if update % 10 == 0 || update == num_updates - 1 {
+            tracing::info!(
+                "  [mlp ] update {:>3}/{}  env_steps={:>7}  episodes={:>4}  mean_return(last≤100)={:6.1}  entropy={:5.3}",
+                update + 1,
+                num_updates,
+                total_env_steps,
+                trainer.total_episodes(),
+                last_mean,
+                stats.entropy,
+            );
+        }
+    }
+
+    tracing::info!(
+        "  [mlp ] done in {:.1}s — final mean return {:.1}",
+        start.elapsed().as_secs_f64(),
+        last_mean
+    );
+    Ok(last_mean)
+}
+
+/// Running per-dimension observation standardizer (Welford mean/variance).
+///
+/// Normalizes each observation coordinate to zero mean / unit variance using
+/// online statistics accumulated over every observation seen so far, then
+/// clips to `[-10, 10]`. This is the standard `VecNormalize`-style wrapper.
+/// It is load-bearing for the recurrent policy: CartPole's raw observations
+/// are tiny (perturbations ~0.05), and an LSTM's tanh gates squash such small
+/// inputs to near-zero features. Standardizing to O(1) restores a usable
+/// gradient signal through the recurrent trunk.
+struct ObsNormalizer {
+    mean: Vec<f64>,
+    /// Sum of squared deviations from the running mean (Welford's M2).
+    m2: Vec<f64>,
+    count: f64,
+}
+
+impl ObsNormalizer {
+    fn new(dim: usize) -> Self {
+        Self { mean: vec![0.0; dim], m2: vec![0.0; dim], count: 0.0 }
+    }
+
+    /// Update the running statistics with `obs` and return the standardized,
+    /// clipped observation.
+    fn normalize(&mut self, obs: &[f32]) -> Vec<f32> {
+        self.count += 1.0;
+        for (i, &xf) in obs.iter().enumerate() {
+            let x = xf as f64;
+            let delta = x - self.mean[i];
+            self.mean[i] += delta / self.count;
+            self.m2[i] += delta * (x - self.mean[i]);
+        }
+        obs.iter()
+            .enumerate()
+            .map(|(i, &x)| {
+                let std = (self.m2[i] / self.count).sqrt().max(1e-4);
+                (((x as f64 - self.mean[i]) / std).clamp(-10.0, 10.0)) as f32
+            })
+            .collect()
+    }
+}
+
+/// Host-side categorical sampling from LSTM `forward_step` outputs.
+///
+/// `logits` is `[N_env, action_dim]`, `values` is `[N_env]`. Returns
+/// `(actions, action_log_probs, values)` as host `Vec`s. The rollout does not
+/// need gradient flow through the sampled action (only the eventual
+/// `evaluate_sequences` call matters for the surrogate), so the draw is done
+/// on the host.
+fn sample_actions(
+    logits: &Tensor<Backend, 2>,
+    values: &Tensor<Backend, 1>,
+    rng: &mut StdRng,
+) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
+    let [n, a] = logits.dims();
+    let probs = activation::softmax(logits.clone(), 1);
+    let log_probs = activation::log_softmax(logits.clone(), 1);
+    let probs_host: Vec<f32> = probs.into_data().to_vec().unwrap();
+    let log_probs_host: Vec<f32> = log_probs.into_data().to_vec().unwrap();
+    let values_host: Vec<f32> = values.clone().into_data().to_vec().unwrap();
+
+    let mut actions = Vec::with_capacity(n);
+    let mut chosen_log_probs = Vec::with_capacity(n);
+    for i in 0..n {
+        let u: f32 = rng.random();
+        let mut cum = 0.0_f32;
+        let mut chosen = a - 1;
+        for j in 0..a {
+            cum += probs_host[i * a + j];
+            if u <= cum {
+                chosen = j;
+                break;
+            }
+        }
+        actions.push(chosen as i64);
+        chosen_log_probs.push(log_probs_host[i * a + chosen]);
+    }
+    (actions, chosen_log_probs, values_host)
+}
+
+/// Per-env host-side GAE for the feedforward baseline (step-major `[T * N]`
+/// layout). Mirrors `train_cartpole_modern`.
+#[allow(clippy::too_many_arguments)]
+fn compute_gae(
+    rewards: &[f32],
+    values: &[f32],
+    dones: &[f32],
+    last_values: &[f32],
+    gamma: f32,
+    gae_lambda: f32,
+    num_steps: usize,
+    num_envs: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    let cap = num_steps * num_envs;
+    let mut advantages = vec![0.0_f32; cap];
+    let mut returns = vec![0.0_f32; cap];
+
+    let mut last_gae = vec![0.0_f32; num_envs];
+    for t in (0..num_steps).rev() {
+        for n in 0..num_envs {
+            let idx = t * num_envs + n;
+            let next_value = if t == num_steps - 1 {
+                last_values[n]
+            } else {
+                values[(t + 1) * num_envs + n]
+            };
+            let next_nonterminal = 1.0 - dones[idx];
+            let delta = rewards[idx] + gamma * next_value * next_nonterminal - values[idx];
+            last_gae[n] = delta + gamma * gae_lambda * next_nonterminal * last_gae[n];
+            advantages[idx] = last_gae[n];
+            returns[idx] = advantages[idx] + values[idx];
+        }
+    }
+
+    (advantages, returns)
+}

--- a/src/env/games/flickering_cartpole.rs
+++ b/src/env/games/flickering_cartpole.rs
@@ -1,0 +1,437 @@
+//! Flickering CartPole — a partial-observability variant of [`CartPole`].
+//!
+//! Phase 3 of the recurrent-policy epic (#262). [`FlickeringCartPole`] wraps
+//! the fully-simulated [`CartPole`] and, on every observation, with a seeded
+//! probability `p` (default 0.5) replaces the **entire** observation with
+//! zeros ("flicker"). The underlying physics, termination / truncation
+//! thresholds, reward, and `max_steps = 500` are all inherited from `CartPole`
+//! unchanged — only the *visibility* of the observation is intermittently
+//! blanked. When the frame is not flickered, the full 4-D observation
+//! `[x, x_dot, theta, theta_dot]` is exposed intact.
+//!
+//! # Why this is a POMDP (and why velocity-masking was not)
+//!
+//! An earlier attempt at a memory-load-bearing CartPole simply dropped the two
+//! velocity coordinates (`MaskedCartPole`, kept in this crate for the record).
+//! A real 500k-step training run **disproved** that as a POMDP: a memoryless
+//! reactive controller on `[x, theta]` balances the pole for hundreds of steps
+//! (measured MLP mean return ~324 vs LSTM ~222 — the feedforward policy won).
+//! Masking velocities does not make memory load-bearing, because a reactive
+//! angle/position feedback loop is sufficient to balance CartPole.
+//!
+//! Flickering closes that loophole. This is the canonical Atari-POMDP protocol
+//! from Hausknecht & Stone, *"Deep Recurrent Q-Learning for Partially
+//! Observable MDPs"* (2015): with probability `p` the observed frame is
+//! entirely blanked. A feedforward policy cannot act on a zeroed frame — it has
+//! no state to fall back on and must emit an action from `[0, 0, 0, 0]`, which
+//! is uninformative. A recurrent policy carries its hidden state across the
+//! blanked gap and integrates the intermittent stream over time, so memory
+//! becomes load-bearing **by construction**: the only way to act sensibly on a
+//! flickered frame is to remember the last visible one.
+//!
+//! # Composition, not inheritance
+//!
+//! Rust has no inheritance, so `FlickeringCartPole` **embeds** a `CartPole` and
+//! delegates every [`Environment`] method to it, intercepting only
+//! [`Environment::reset`] / [`Environment::step`] (to draw the per-frame
+//! flicker decision) and [`Environment::get_observation`] (to blank the
+//! observation when the current frame is flickered). The observation space is
+//! still reported as 4-D — flickering never changes the observation *shape*,
+//! only its contents.
+//!
+//! # Seeding and determinism
+//!
+//! The flicker decisions are drawn from a dedicated seeded [`StdRng`],
+//! independent of the physics simulation. Two `FlickeringCartPole`s constructed
+//! with [`FlickeringCartPole::with_seed`] (same seed and probability) produce
+//! the **identical** flicker pattern given the same action sequence, regardless
+//! of the (thread-RNG-seeded) physics reset. This makes the flicker schedule
+//! reproducible for tests and experiments. Snapshot / restore
+//! ([`Environment::clone_state`] / [`Environment::restore_state`]) captures the
+//! flicker RNG as well as the physics state, so a restored env reproduces the
+//! same flicker stream — a stronger determinism guarantee than the
+//! RNG-consuming envs (Snake, Pong) that snapshot only the simulation step.
+
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+use crate::env::{
+    Environment, SpaceInfo, SpaceType, StepResult,
+    games::cartpole::{CartPole, CartPoleState},
+};
+
+/// Default flicker probability — the classic Hausknecht & Stone (2015)
+/// value: each frame is blanked with probability 0.5.
+pub const DEFAULT_FLICKER_PROBABILITY: f64 = 0.5;
+
+/// Snapshot of a [`FlickeringCartPole`]: the inner physics state, the current
+/// flicker flag, and the flicker RNG. Because the RNG is captured, restoring a
+/// snapshot reproduces the subsequent flicker stream exactly (in addition to
+/// the deterministic physics inherited from [`CartPole`]).
+#[derive(Debug, Clone)]
+pub struct FlickeringCartPoleState {
+    /// Inner CartPole physics snapshot.
+    inner: CartPoleState,
+    /// Whether the observation for the current frame is blanked.
+    flickered: bool,
+    /// Flicker RNG state at snapshot time.
+    rng: StdRng,
+}
+
+/// Flickering CartPole — a partially-observable variant of [`CartPole`] where
+/// each frame's observation is blanked to zeros with a seeded probability.
+///
+/// The observation is the full 4-D CartPole state
+/// `[x, x_dot, theta, theta_dot]` on a visible frame, or `[0, 0, 0, 0]` on a
+/// flickered frame. All physics, termination, truncation, and reward semantics
+/// are delegated to the inner [`CartPole`] unchanged; flickering affects only
+/// what the agent *observes*, never the underlying dynamics or reward.
+#[derive(Debug)]
+pub struct FlickeringCartPole {
+    /// Inner fully-simulated CartPole; owns the physics.
+    inner: CartPole,
+    /// Probability that any given frame is blanked (in `[0, 1]`).
+    flicker_prob: f64,
+    /// Dedicated flicker RNG, independent of the physics simulation.
+    rng: StdRng,
+    /// Whether the current frame's observation is blanked. Set on every
+    /// [`Environment::reset`] and [`Environment::step`]; read by
+    /// [`Environment::get_observation`].
+    flickered: bool,
+}
+
+impl FlickeringCartPole {
+    /// Create a flickering CartPole with the default probability
+    /// ([`DEFAULT_FLICKER_PROBABILITY`] = 0.5) and a flicker RNG seeded from
+    /// system entropy.
+    ///
+    /// Because the flicker RNG is entropy-seeded, independent instances (e.g.
+    /// the members of an [`EnvPool`](crate::env::pool::EnvPool)) get
+    /// **different** flicker streams, which is desirable for decorrelated
+    /// parallel rollouts. Use [`FlickeringCartPole::with_seed`] when a
+    /// reproducible flicker schedule is required.
+    pub fn new() -> Self {
+        Self::with_probability(DEFAULT_FLICKER_PROBABILITY)
+    }
+
+    /// Create a flickering CartPole with a custom flicker probability and a
+    /// flicker RNG seeded from system entropy.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `flicker_prob` is not in `[0, 1]`.
+    pub fn with_probability(flicker_prob: f64) -> Self {
+        assert!(
+            (0.0..=1.0).contains(&flicker_prob),
+            "flicker probability must be in [0, 1], got {flicker_prob}"
+        );
+        Self {
+            inner: CartPole::new(),
+            flicker_prob,
+            rng: StdRng::from_os_rng(),
+            flickered: false,
+        }
+    }
+
+    /// Create a flickering CartPole with the default probability
+    /// ([`DEFAULT_FLICKER_PROBABILITY`] = 0.5) and a **seeded** flicker RNG for
+    /// a reproducible flicker schedule.
+    pub fn with_seed(seed: u64) -> Self {
+        Self::with_seed_and_probability(seed, DEFAULT_FLICKER_PROBABILITY)
+    }
+
+    /// Create a flickering CartPole with a custom flicker probability and a
+    /// **seeded** flicker RNG for a reproducible flicker schedule.
+    ///
+    /// Two instances built with the same `seed` and `flicker_prob` blank the
+    /// same frames given the same number of `reset`/`step` calls, independent
+    /// of the physics (whose reset perturbation uses the thread RNG).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `flicker_prob` is not in `[0, 1]`.
+    pub fn with_seed_and_probability(seed: u64, flicker_prob: f64) -> Self {
+        assert!(
+            (0.0..=1.0).contains(&flicker_prob),
+            "flicker probability must be in [0, 1], got {flicker_prob}"
+        );
+        Self {
+            inner: CartPole::new(),
+            flicker_prob,
+            rng: StdRng::seed_from_u64(seed),
+            flickered: false,
+        }
+    }
+
+    /// The probability that any given frame is blanked.
+    pub fn flicker_probability(&self) -> f64 {
+        self.flicker_prob
+    }
+
+    /// Whether the observation for the *current* frame is blanked (zeroed).
+    ///
+    /// Reflects the flicker decision made by the most recent
+    /// [`Environment::reset`] or [`Environment::step`]. Primarily useful for
+    /// diagnostics and determinism tests.
+    pub fn is_flickered(&self) -> bool {
+        self.flickered
+    }
+
+    /// Draw a fresh flicker decision from the seeded RNG.
+    fn draw_flicker(&mut self) -> bool {
+        // `flicker_prob == 0.0` never blanks; `== 1.0` always blanks. Drawing
+        // unconditionally keeps the RNG stream advancing at one draw per frame
+        // regardless of `p`, so the schedule is a pure function of the seed.
+        self.rng.random::<f64>() < self.flicker_prob
+    }
+
+    /// The dimensionality of the (unflickered) observation.
+    const OBS_DIM: usize = 4;
+}
+
+impl Default for FlickeringCartPole {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Environment for FlickeringCartPole {
+    type Action = i64;
+    type State = FlickeringCartPoleState;
+
+    fn reset(&mut self) {
+        self.inner.reset();
+        self.flickered = self.draw_flicker();
+    }
+
+    fn get_observation(&self) -> Vec<f32> {
+        if self.flickered {
+            vec![0.0; Self::OBS_DIM]
+        } else {
+            Environment::get_observation(&self.inner)
+        }
+    }
+
+    fn step(&mut self, action: i64) -> StepResult {
+        let mut result = self.inner.step(action);
+        self.flickered = self.draw_flicker();
+        if self.flickered {
+            // Blank the entire observation — the flicker protocol zeros the
+            // whole frame, not individual coordinates.
+            for v in result.observation.iter_mut() {
+                *v = 0.0;
+            }
+        }
+        result
+    }
+
+    fn observation_space(&self) -> SpaceInfo {
+        // Flickering never changes the observation *shape*, only its contents.
+        SpaceInfo { shape: vec![Self::OBS_DIM], space_type: SpaceType::Box }
+    }
+
+    fn action_space(&self) -> SpaceInfo {
+        self.inner.action_space()
+    }
+
+    fn render(&self) -> Vec<u8> {
+        self.inner.render()
+    }
+
+    fn close(&mut self) {
+        self.inner.close();
+    }
+
+    fn clone_state(&self) -> FlickeringCartPoleState {
+        FlickeringCartPoleState {
+            inner: self.inner.clone_state(),
+            flickered: self.flickered,
+            rng: self.rng.clone(),
+        }
+    }
+
+    fn restore_state(&mut self, state: &FlickeringCartPoleState) {
+        self.inner.restore_state(&state.inner);
+        self.flickered = state.flickered;
+        self.rng = state.rng.clone();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_observation_space_is_four_dimensional() {
+        let env = FlickeringCartPole::new();
+        let obs_space = env.observation_space();
+        assert_eq!(obs_space.shape, vec![4], "flickering obs keeps CartPole's 4-D shape");
+        assert!(matches!(obs_space.space_type, SpaceType::Box));
+    }
+
+    #[test]
+    fn test_action_space_delegates() {
+        let env = FlickeringCartPole::new();
+        let action_space = env.action_space();
+        assert!(matches!(action_space.space_type, SpaceType::Discrete(2)));
+    }
+
+    #[test]
+    fn test_default_probability() {
+        let env = FlickeringCartPole::new();
+        assert_eq!(env.flicker_probability(), DEFAULT_FLICKER_PROBABILITY);
+        assert_eq!(env.flicker_probability(), 0.5);
+    }
+
+    #[test]
+    fn test_observation_length_is_always_four() {
+        // Whether flickered or not, the observation vector is always 4 long.
+        let mut env = FlickeringCartPole::with_seed_and_probability(7, 0.5);
+        env.reset();
+        assert_eq!(env.get_observation().len(), 4);
+        for i in 0..200 {
+            let result = env.step((i % 2) as i64);
+            assert_eq!(result.observation.len(), 4, "obs length invariant under flicker");
+            if result.terminated || result.truncated {
+                env.reset();
+            }
+        }
+    }
+
+    #[test]
+    fn test_flickered_observation_is_all_zeros() {
+        // With p = 1.0 every frame is blanked: observation must be all zeros.
+        let mut env = FlickeringCartPole::with_seed_and_probability(1, 1.0);
+        env.reset();
+        assert!(env.is_flickered(), "p=1.0 must blank every frame");
+        assert_eq!(env.get_observation(), vec![0.0; 4]);
+        let result = env.step(1);
+        assert!(env.is_flickered());
+        assert_eq!(result.observation, vec![0.0; 4], "stepped obs blanked under p=1.0");
+    }
+
+    #[test]
+    fn test_never_flickers_at_zero_probability() {
+        // With p = 0.0 no frame is ever blanked; obs equals the inner CartPole.
+        let mut env = FlickeringCartPole::with_seed_and_probability(2, 0.0);
+        env.reset();
+        assert!(!env.is_flickered(), "p=0.0 must never blank");
+        for i in 0..300 {
+            let result = env.step((i % 2) as i64);
+            assert!(!env.is_flickered(), "p=0.0 must never blank");
+            // A visible frame is exactly the inner (unmasked) observation.
+            assert_eq!(result.observation, Environment::get_observation(&env.inner));
+            if result.terminated || result.truncated {
+                env.reset();
+            }
+        }
+    }
+
+    #[test]
+    fn test_flicker_schedule_is_deterministic_under_seed() {
+        // Two envs with the same seed + probability blank the same frames given
+        // the same action sequence — independent of the (thread-RNG) physics.
+        let mut a = FlickeringCartPole::with_seed_and_probability(42, 0.5);
+        let mut b = FlickeringCartPole::with_seed_and_probability(42, 0.5);
+        a.reset();
+        b.reset();
+        assert_eq!(a.is_flickered(), b.is_flickered(), "reset flicker decision must match");
+
+        let mut any_flicker = false;
+        let mut any_visible = false;
+        for i in 0..500 {
+            let action = (i % 2) as i64;
+            a.step(action);
+            b.step(action);
+            assert_eq!(a.is_flickered(), b.is_flickered(), "flicker schedule diverged at step {i}");
+            any_flicker |= a.is_flickered();
+            any_visible |= !a.is_flickered();
+        }
+        // Sanity: at p=0.5 over 500 draws we must see both states.
+        assert!(any_flicker, "expected at least one flickered frame at p=0.5");
+        assert!(any_visible, "expected at least one visible frame at p=0.5");
+    }
+
+    #[test]
+    fn test_flicker_rate_is_approximately_p() {
+        // Empirically the blank rate over many frames should track p ≈ 0.5.
+        let mut env = FlickeringCartPole::with_seed_and_probability(123, 0.5);
+        env.reset();
+        let mut blanked = 0usize;
+        let n = 5000;
+        for i in 0..n {
+            env.step((i % 2) as i64);
+            if env.is_flickered() {
+                blanked += 1;
+            }
+            // Keep stepping past episode ends without resetting flicker RNG:
+            // resetting would still keep the schedule seeded, but we just want
+            // a long stream here.
+            if env.get_observation().is_empty() {
+                unreachable!();
+            }
+        }
+        let rate = blanked as f64 / n as f64;
+        assert!((rate - 0.5).abs() < 0.05, "blank rate {rate} should be ≈ 0.5");
+    }
+
+    #[test]
+    fn test_reward_and_done_unaffected_by_flicker() {
+        // Flickering blanks only the observation; reward/termination come from
+        // the inner CartPole and are unchanged.
+        let mut env = FlickeringCartPole::with_seed_and_probability(9, 0.5);
+        env.reset();
+        for i in 0..100 {
+            let result = env.step((i % 2) as i64);
+            assert!(result.reward == 0.0 || result.reward == 1.0, "reward inherited from CartPole");
+            if result.terminated || result.truncated {
+                env.reset();
+            }
+        }
+    }
+
+    #[test]
+    fn test_clone_restore_reproduces_flicker_stream() {
+        // Snapshotting captures the flicker RNG, so restore + step reproduces
+        // the same flicker decisions (and the deterministic physics).
+        let mut env = FlickeringCartPole::with_seed_and_probability(555, 0.5);
+        env.reset();
+        for i in 0..10 {
+            env.step((i % 2) as i64);
+        }
+        let snap = env.clone_state();
+
+        let mut first = Vec::new();
+        for i in 0..20 {
+            let r = env.step((i % 2) as i64);
+            first.push((env.is_flickered(), r.observation.clone(), r.reward));
+        }
+
+        env.restore_state(&snap);
+        let mut second = Vec::new();
+        for i in 0..20 {
+            let r = env.step((i % 2) as i64);
+            second.push((env.is_flickered(), r.observation.clone(), r.reward));
+        }
+
+        assert_eq!(first, second, "restore must reproduce flicker + physics stream");
+    }
+
+    #[test]
+    fn test_hundred_random_steps_no_panic() {
+        let mut env = FlickeringCartPole::with_seed(0);
+        env.reset();
+        for i in 0..100 {
+            let result = env.step((i % 2) as i64);
+            assert_eq!(result.observation.len(), 4);
+            if result.terminated || result.truncated {
+                env.reset();
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "flicker probability must be in [0, 1]")]
+    fn test_invalid_probability_panics() {
+        let _ = FlickeringCartPole::with_probability(1.5);
+    }
+}

--- a/src/env/games/masked_cartpole.rs
+++ b/src/env/games/masked_cartpole.rs
@@ -1,0 +1,172 @@
+//! Partially-observable CartPole (velocity-masked).
+//!
+//! Phase 3 of the recurrent-policy epic (#262). [`MaskedCartPole`] wraps the
+//! fully-simulated [`CartPole`] and drops the two velocity coordinates
+//! (`x_dot`, `theta_dot`) from the observation, exposing only the positional
+//! pair `[cart_position, pole_angle]`. The underlying physics, termination /
+//! truncation thresholds, reward, and `max_steps = 500` are all inherited
+//! from `CartPole` unchanged — only the observation projection differs.
+//!
+//! # Why this is a POMDP
+//!
+//! CartPole's 4-D state `[x, x_dot, theta, theta_dot]` is Markov: a
+//! feedforward policy can act optimally from a single observation. Masking
+//! the velocities leaves `[x, theta]`, which is **not** Markov — the optimal
+//! action depends on how fast the pole is falling, information no single
+//! frame carries. A memoryless policy must therefore plateau well below the
+//! CartPole-v1 "solved" bar (500), while a recurrent policy can integrate the
+//! positional stream over time to recover the hidden velocities and balance.
+//! This contrast is the load-bearing learning signal for the recurrent PPO
+//! stack (see `docs/RECURRENT_POLICY_DESIGN.md`).
+//!
+//! # Composition, not inheritance
+//!
+//! Rust has no inheritance, so `MaskedCartPole` **embeds** a `CartPole` and
+//! delegates every [`Environment`] method to it, intercepting only
+//! [`Environment::get_observation`], [`Environment::step`] (to project the
+//! returned observation), and [`Environment::observation_space`] (to report a
+//! 2-D shape).
+
+use crate::env::{
+    Environment, SpaceInfo, SpaceType, StepResult,
+    games::cartpole::{CartPole, CartPoleState},
+};
+
+/// Velocity-masked CartPole — a partially-observable variant of
+/// [`CartPole`].
+///
+/// The observation is projected from the full 4-D state
+/// `[x, x_dot, theta, theta_dot]` down to the 2-D positional pair
+/// `[x, theta]`; the cart/pole velocities are hidden. All physics,
+/// termination, truncation, and reward semantics are delegated to the inner
+/// [`CartPole`] unchanged.
+///
+/// # Snapshot semantics
+///
+/// [`Environment::clone_state`] / [`Environment::restore_state`] delegate to
+/// the inner `CartPole`, inheriting its fully-deterministic snapshot
+/// contract: restoring a snapshot and calling `step(action)` reproduces the
+/// same [`StepResult`] (with the masked observation).
+#[derive(Debug, Default)]
+pub struct MaskedCartPole {
+    inner: CartPole,
+}
+
+impl MaskedCartPole {
+    /// Create a new velocity-masked CartPole with default physics.
+    pub fn new() -> Self {
+        Self { inner: CartPole::new() }
+    }
+
+    /// Project a full 4-D CartPole observation `[x, x_dot, theta, theta_dot]`
+    /// down to the observable 2-D pair `[x, theta]`, dropping the velocity
+    /// coordinates at indices 1 and 3.
+    fn mask(full: &[f32]) -> Vec<f32> {
+        vec![full[0], full[2]]
+    }
+}
+
+impl Environment for MaskedCartPole {
+    type Action = i64;
+    type State = CartPoleState;
+
+    fn reset(&mut self) {
+        self.inner.reset();
+    }
+
+    fn get_observation(&self) -> Vec<f32> {
+        Self::mask(&Environment::get_observation(&self.inner))
+    }
+
+    fn step(&mut self, action: i64) -> StepResult {
+        let mut result = self.inner.step(action);
+        result.observation = Self::mask(&result.observation);
+        result
+    }
+
+    fn observation_space(&self) -> SpaceInfo {
+        SpaceInfo { shape: vec![2], space_type: SpaceType::Box }
+    }
+
+    fn action_space(&self) -> SpaceInfo {
+        self.inner.action_space()
+    }
+
+    fn render(&self) -> Vec<u8> {
+        self.inner.render()
+    }
+
+    fn close(&mut self) {
+        self.inner.close();
+    }
+
+    fn clone_state(&self) -> CartPoleState {
+        self.inner.clone_state()
+    }
+
+    fn restore_state(&mut self, state: &CartPoleState) {
+        self.inner.restore_state(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_observation_is_two_dimensional() {
+        let env = MaskedCartPole::new();
+        let obs_space = env.observation_space();
+        assert_eq!(obs_space.shape, vec![2], "masked obs must be 2-D");
+        assert!(matches!(obs_space.space_type, SpaceType::Box));
+    }
+
+    #[test]
+    fn test_get_observation_drops_velocities() {
+        let mut env = MaskedCartPole::new();
+        env.reset();
+        let obs = env.get_observation();
+        assert_eq!(obs.len(), 2, "masked observation should have 2 elements");
+    }
+
+    #[test]
+    fn test_step_returns_masked_observation() {
+        let mut env = MaskedCartPole::new();
+        env.reset();
+        let result = env.step(1);
+        assert_eq!(result.observation.len(), 2, "stepped observation should be masked to 2-D");
+        assert!(result.reward == 0.0 || result.reward == 1.0, "reward inherited from CartPole");
+    }
+
+    #[test]
+    fn test_action_space_delegates() {
+        let env = MaskedCartPole::new();
+        let action_space = env.action_space();
+        assert!(matches!(action_space.space_type, SpaceType::Discrete(2)));
+    }
+
+    #[test]
+    fn test_masked_value_matches_full_positions() {
+        // The two exposed coordinates must be exactly the cart position and
+        // pole angle from the underlying full observation (indices 0 and 2).
+        let mut env = MaskedCartPole::new();
+        env.reset();
+        let full = Environment::get_observation(&env.inner);
+        let masked = env.get_observation();
+        assert_eq!(masked[0], full[0], "index 0 = cart position");
+        assert_eq!(masked[1], full[2], "index 1 = pole angle");
+    }
+
+    #[test]
+    fn test_hundred_random_steps_no_panic() {
+        let mut env = MaskedCartPole::new();
+        env.reset();
+        for i in 0..100 {
+            let result = env.step((i % 2) as i64);
+            assert_eq!(result.observation.len(), 2);
+            if result.terminated || result.truncated {
+                env.reset();
+            }
+        }
+    }
+}

--- a/src/env/games/mod.rs
+++ b/src/env/games/mod.rs
@@ -2,6 +2,15 @@
 //!
 //! This module contains various game environments for reinforcement learning:
 //! - CartPole: Classic cart-pole balancing task
+//! - FlickeringCartPole: CartPole whose 4-D observation is blanked to zeros
+//!   with a seeded probability `p` (default 0.5) — the Hausknecht & Stone
+//!   (2015) flickering-Atari POMDP protocol. Memory is load-bearing: a
+//!   feedforward policy cannot act on a blanked frame, so recurrence wins by
+//!   construction (issue #287, epic #262)
+//! - MaskedCartPole: CartPole with the two velocity coordinates dropped from
+//!   the observation. Retained as a documented NEGATIVE result — a 500k-step
+//!   run showed a memoryless `[x, theta]` controller solves it, so
+//!   velocity-masking alone does NOT make memory load-bearing (issue #287)
 //! - GridWorld: in-tree `4x4` FrozenLake-style sparse-reward navigation task
 //!   (issue #182, `i64` discrete action `0=Up/1=Right/2=Down/3=Left`, 16-dim
 //!   one-hot observation, absorbing goal/hole terminals + step-cap truncation)
@@ -30,6 +39,7 @@
 
 pub mod cartpole;
 pub mod continuous_lqr;
+pub mod flickering_cartpole;
 pub mod grid_world;
 pub mod masked_cartpole;
 #[cfg(feature = "training")]
@@ -52,6 +62,7 @@ pub mod bucket_brigade;
 pub use bucket_brigade::BucketBrigadeMaEnv;
 pub use cartpole::CartPole;
 pub use continuous_lqr::ContinuousLqr;
+pub use flickering_cartpole::FlickeringCartPole;
 pub use grid_world::GridWorld;
 pub use masked_cartpole::MaskedCartPole;
 #[cfg(feature = "training")]

--- a/src/env/games/mod.rs
+++ b/src/env/games/mod.rs
@@ -31,6 +31,7 @@
 pub mod cartpole;
 pub mod continuous_lqr;
 pub mod grid_world;
+pub mod masked_cartpole;
 #[cfg(feature = "training")]
 pub mod matching_pennies;
 pub mod mountain_car_continuous;
@@ -52,6 +53,7 @@ pub use bucket_brigade::BucketBrigadeMaEnv;
 pub use cartpole::CartPole;
 pub use continuous_lqr::ContinuousLqr;
 pub use grid_world::GridWorld;
+pub use masked_cartpole::MaskedCartPole;
 #[cfg(feature = "training")]
 pub use matching_pennies::MatchingPennies;
 pub use mountain_car_continuous::MountainCarContinuous;

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -179,9 +179,9 @@ pub mod games;
 
 // Re-export game environments for backwards compatibility
 pub use games::{
-    CartPole, ContinuousLqr, GridWorld, MaskedCartPole, MountainCarContinuous, PendulumSwingUp,
-    Pong, SimpleBandit, SnakeEnv, cartpole, continuous_lqr, grid_world, masked_cartpole,
-    mountain_car_continuous, pendulum, pong, simple_bandit, snake,
+    CartPole, ContinuousLqr, FlickeringCartPole, GridWorld, MaskedCartPole, MountainCarContinuous,
+    PendulumSwingUp, Pong, SimpleBandit, SnakeEnv, cartpole, continuous_lqr, flickering_cartpole,
+    grid_world, masked_cartpole, mountain_car_continuous, pendulum, pong, simple_bandit, snake,
 };
 // `signaling` depends on `crate::multi_agent`, which is gated behind the
 // `training` feature, so its re-export must be gated the same way.

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -179,9 +179,9 @@ pub mod games;
 
 // Re-export game environments for backwards compatibility
 pub use games::{
-    CartPole, ContinuousLqr, GridWorld, MountainCarContinuous, PendulumSwingUp, Pong, SimpleBandit,
-    SnakeEnv, cartpole, continuous_lqr, grid_world, mountain_car_continuous, pendulum, pong,
-    simple_bandit, snake,
+    CartPole, ContinuousLqr, GridWorld, MaskedCartPole, MountainCarContinuous, PendulumSwingUp,
+    Pong, SimpleBandit, SnakeEnv, cartpole, continuous_lqr, grid_world, masked_cartpole,
+    mountain_car_continuous, pendulum, pong, simple_bandit, snake,
 };
 // `signaling` depends on `crate::multi_agent`, which is gated behind the
 // `training` feature, so its re-export must be gated the same way.

--- a/src/train/ppo.rs
+++ b/src/train/ppo.rs
@@ -24,6 +24,7 @@
 pub mod actor_learner;
 pub mod config;
 pub mod loss;
+pub mod recurrent_trainer;
 pub mod stats;
 pub mod trainer;
 
@@ -36,5 +37,6 @@ pub use loss::{
     compute_entropy_loss, compute_policy_loss, compute_value_loss, generate_minibatch_indices,
     scalar_f64,
 };
+pub use recurrent_trainer::RecurrentPPOTrainer;
 pub use stats::{AggregatedStats, TrainingStats};
 pub use trainer::PPOTrainerBurn;

--- a/src/train/ppo/recurrent_trainer.rs
+++ b/src/train/ppo/recurrent_trainer.rs
@@ -1,0 +1,399 @@
+//! Recurrent PPO trainer (Burn backend).
+//!
+//! Phase 3 of the recurrent-policy epic (#262). [`RecurrentPPOTrainer`] is the
+//! rank-3 sibling of [`crate::train::ppo::trainer::PPOTrainerBurn`]: it drives
+//! the same clipped-surrogate / value-clip / entropy-bonus / KL-early-stop
+//! recipe, reusing the **unchanged** loss functions in
+//! [`crate::train::ppo::loss`], but consumes whole-trajectory sequence batches
+//! from a [`RecurrentRolloutBuffer`] instead of flattened rank-2 transitions.
+//!
+//! # Why a separate trainer
+//!
+//! The feedforward trainer's `evaluate_fn` closure is hard-typed to rank-2
+//! observations (`Tensor<B, 2>`) and rank-1 actions — it flattens time and env
+//! together, structurally erasing the temporal order a recurrent policy needs.
+//! Recurrence requires a rank-3 `[N_env, T, obs_dim]` forward that runs the
+//! LSTM step-by-step and resets `(h, c)` at episode boundaries. Rather than
+//! overload the feedforward closure, this trainer takes a rank-3 analogue:
+//!
+//! ```text
+//! evaluate_fn(&policy, obs_seq [N_env,T,obs_dim], actions [N_env,T], episode_starts [N_env,T])
+//!     -> (log_probs [N_env,T], entropy [N_env,T], values [N_env,T])
+//! ```
+//!
+//! # Rank-2 → rank-1 shape adapter
+//!
+//! [`crate::train::ppo::loss`]'s `compute_policy_loss` / `compute_value_loss` /
+//! `compute_entropy_loss` all operate on rank-1 tensors. `evaluate_sequences`
+//! returns rank-2 `[N_env, T]`. The trainer therefore flattens
+//! (`reshape([N_env * T])`) **inside** the minibatch loop, *after* the forward
+//! — the LSTM forward needs the `[N_env, T]` shape intact to run its
+//! step-by-step loop with per-step state resets. Advantage normalization runs
+//! on the flattened rank-1 view, exactly as in `PPOTrainerBurn`.
+//!
+//! # Episode-boundary contract
+//!
+//! `episode_starts` is consumed **directly** from the buffer's materialized
+//! batch (`terminated[t-1] || truncated[t-1]` shifted one step, with the
+//! cross-iteration carry at `t == 0`). GAE stays terminated-only, computed
+//! upstream by the buffer. The two masks are intentionally distinct; this
+//! trainer does not re-derive or touch either (see
+//! `docs/RECURRENT_POLICY_DESIGN.md`, Q2).
+//!
+//! # Ownership model
+//!
+//! Identical to `PPOTrainerBurn`: the policy is held in `Option<P>` and swapped
+//! through Burn's move-through optimizer on every gradient step.
+
+use anyhow::{Result, anyhow};
+use burn::{
+    module::AutodiffModule,
+    optim::{GradientsParams, Optimizer},
+    tensor::{Int, Tensor, TensorData, backend::AutodiffBackend},
+};
+
+use super::{
+    config::PPOConfig,
+    loss::{compute_entropy_loss, compute_policy_loss, compute_value_loss, scalar_f64},
+    stats::TrainingStats,
+};
+use crate::{
+    buffer::rollout::RecurrentRolloutBuffer,
+    train::optimizer::{BackendOptimizer, BurnOptimizer},
+};
+
+/// Recurrent PPO trainer (Burn backend).
+///
+/// Generic over the same three parameters as
+/// [`crate::train::ppo::trainer::PPOTrainerBurn`]:
+/// - `B: AutodiffBackend` — the Burn backend.
+/// - `P: AutodiffModule<B>` — the recurrent policy module (e.g.
+///   [`crate::policy::lstm::LstmBurnPolicy`]).
+/// - `O: Optimizer<P, B>` — the Burn optimizer.
+///
+/// The policy is held in `Option<P>` because Burn's `Optimizer::step` consumes
+/// the module by value; we `.take()` / put-back across each gradient step.
+pub struct RecurrentPPOTrainer<B, P, O>
+where
+    B: AutodiffBackend,
+    P: AutodiffModule<B>,
+    O: Optimizer<P, B>,
+{
+    config: PPOConfig,
+    policy: Option<P>,
+    optimizer: BurnOptimizer<B, P, O>,
+    device: B::Device,
+    /// Optional learning-rate override applied on the next `train_step`,
+    /// `None` ⇒ use the optimizer's configured rate. Set by
+    /// [`Self::set_learning_rate`] to support caller-driven LR schedules
+    /// (e.g. linear annealing), which stabilize the end of long PPO runs.
+    lr_override: Option<f64>,
+    total_steps: usize,
+    total_episodes: usize,
+    low_entropy_count: usize,
+}
+
+impl<B, P, O> RecurrentPPOTrainer<B, P, O>
+where
+    B: AutodiffBackend,
+    P: AutodiffModule<B> + Clone,
+    O: Optimizer<P, B>,
+{
+    /// Build a new recurrent PPO trainer.
+    ///
+    /// `device` is the Burn device the sequence-batch tensors are
+    /// materialized on (the buffer stores host `Vec` data, so — unlike the
+    /// feedforward trainer, which reads the device off the observation tensor
+    /// passed to `train_step` — the recurrent trainer must be told which
+    /// device to build minibatches on).
+    pub fn new(
+        config: PPOConfig,
+        policy: P,
+        optimizer: BurnOptimizer<B, P, O>,
+        device: B::Device,
+    ) -> Result<Self> {
+        config.validate()?;
+        Ok(Self {
+            config,
+            policy: Some(policy),
+            optimizer,
+            device,
+            lr_override: None,
+            total_steps: 0,
+            total_episodes: 0,
+            low_entropy_count: 0,
+        })
+    }
+
+    /// Override the learning rate used by subsequent `train_step` calls.
+    ///
+    /// Enables caller-driven schedules (linear annealing, warmup, …). Pass the
+    /// per-update rate before each `train_step`. Without a call, the
+    /// optimizer's configured rate is used.
+    pub fn set_learning_rate(&mut self, lr: f64) {
+        self.lr_override = Some(lr);
+    }
+
+    /// Borrow the configuration.
+    pub fn config(&self) -> &PPOConfig {
+        &self.config
+    }
+
+    /// Borrow the policy. Panics if called mid-step (the policy has been moved
+    /// into the optimizer); only safe between `train_step` invocations.
+    pub fn policy(&self) -> &P {
+        self.policy.as_ref().expect("policy is None mid-step")
+    }
+
+    /// Total completed gradient updates.
+    pub fn total_steps(&self) -> usize {
+        self.total_steps
+    }
+
+    /// Total completed episodes (caller increments).
+    pub fn total_episodes(&self) -> usize {
+        self.total_episodes
+    }
+
+    /// Increment the episode counter.
+    pub fn increment_episodes(&mut self, n: usize) {
+        self.total_episodes += n;
+    }
+
+    /// Train for one recurrent PPO update.
+    ///
+    /// Iterates `n_epochs` passes over the buffer's env-major minibatches
+    /// (whole trajectories, `envs_per_minibatch` at a time), running the
+    /// rank-3 `evaluate_fn` forward, flattening to rank-1, and applying the
+    /// shared PPO surrogate / value / entropy losses. Mirrors
+    /// [`crate::train::ppo::trainer::PPOTrainerBurn::train_step`] step-for-step
+    /// except for the sequence-batch assembly and the rank-2 → rank-1 flatten.
+    ///
+    /// * `buffer` — the recurrent rollout buffer; advantages/returns must
+    ///   already be computed (via `buffer.compute_advantages`).
+    /// * `envs_per_minibatch` — whole env-trajectories per minibatch (the
+    ///   recurrent analogue of the feedforward `batch_size`).
+    /// * `evaluate_fn` — receives `(&policy, obs_seq, actions, episode_starts)`
+    ///   and returns `(log_probs, entropy, values)`, each `[N_env, T]`.
+    pub fn train_step<F>(
+        &mut self,
+        buffer: &RecurrentRolloutBuffer,
+        envs_per_minibatch: usize,
+        mut evaluate_fn: F,
+    ) -> Result<TrainingStats>
+    where
+        F: FnMut(
+            &P,
+            Tensor<B, 3>,
+            Tensor<B, 2, Int>,
+            Tensor<B, 2>,
+        ) -> (Tensor<B, 2>, Tensor<B, 2>, Tensor<B, 2>),
+    {
+        let device = self.device.clone();
+        let mut stats_sum = TrainingStats::zeros();
+        let mut num_updates = 0;
+
+        for _epoch in 0..self.config.n_epochs {
+            for batch in buffer.to_minibatches::<B>(envs_per_minibatch, true, &device) {
+                // Take the policy out so we can move it through `step`.
+                let policy = self
+                    .policy
+                    .take()
+                    .ok_or_else(|| anyhow!("policy is None; concurrent train_step calls?"))?;
+
+                // Rank-3 forward: the LSTM needs `[N_env, T]` intact to run its
+                // per-step loop with episode-boundary resets.
+                let (log_probs, entropy, values) = evaluate_fn(
+                    &policy,
+                    batch.obs_seq.clone(),
+                    batch.actions.clone(),
+                    batch.episode_starts.clone(),
+                );
+
+                // Flatten rank-2 `[N_env, T]` → rank-1 `[N_env * T]` for the
+                // loss functions (which operate on rank-1 tensors).
+                let [n_env, t] = log_probs.dims();
+                let flat = n_env * t;
+                let log_probs = log_probs.reshape([flat]);
+                let entropy = entropy.reshape([flat]);
+                let values = values.reshape([flat]);
+                let old_log_probs = batch.old_log_probs.clone().reshape([flat]);
+                let old_values = batch.old_values.clone().reshape([flat]);
+                let advantages = batch.advantages.clone().reshape([flat]);
+                let returns = batch.returns.clone().reshape([flat]);
+
+                // Advantage normalization on the flattened 1D view (matches
+                // `PPOTrainerBurn`). Advantages come from the buffer as data —
+                // no autograd tape — so a host round-trip is safe.
+                let adv_data: Vec<f32> = advantages.into_data().to_vec().unwrap_or_default();
+                let adv_mean = host_mean(&adv_data);
+                let adv_std = host_std_biased(&adv_data, adv_mean);
+                let adv_norm: Vec<f32> = adv_data
+                    .iter()
+                    .map(|&a| (a - adv_mean as f32) / (adv_std as f32 + 1e-8))
+                    .collect();
+                let advantages =
+                    Tensor::<B, 1>::from_data(TensorData::new(adv_norm, [flat]), &device);
+
+                let (policy_loss, clip_fraction, approx_kl) = compute_policy_loss(
+                    log_probs,
+                    old_log_probs,
+                    advantages,
+                    self.config.clip_range,
+                );
+
+                let (value_loss, explained_var) =
+                    compute_value_loss(values, old_values, returns, self.config.clip_range_vf);
+
+                let entropy_loss = compute_entropy_loss(entropy.clone());
+
+                // Scalars for stat collection.
+                let policy_loss_val = scalar_f64(policy_loss.clone());
+                let value_loss_val = scalar_f64(value_loss.clone());
+                let entropy_val = scalar_f64(entropy.mean());
+
+                // total_loss = policy_loss + vf_coef * value_loss + ent_coef * entropy_loss
+                let total_loss = policy_loss
+                    + value_loss.mul_scalar(self.config.vf_coef as f32)
+                    + entropy_loss.mul_scalar(self.config.ent_coef as f32);
+                let total_loss_val = scalar_f64(total_loss.clone());
+
+                // Burn gradient flow: backward → GradientsParams → step.
+                let grads = total_loss.backward();
+                let grads = GradientsParams::from_grads(grads, &policy);
+                let lr = self.lr_override.unwrap_or_else(|| self.optimizer.learning_rate());
+                let policy = self.optimizer.inner_mut().step(lr, policy, grads);
+                self.policy = Some(policy);
+
+                let step_stats = TrainingStats::new(
+                    policy_loss_val,
+                    value_loss_val,
+                    entropy_val,
+                    total_loss_val,
+                    clip_fraction,
+                    approx_kl,
+                    explained_var,
+                );
+                stats_sum.add(&step_stats);
+                num_updates += 1;
+
+                if approx_kl > self.config.target_kl {
+                    break;
+                }
+            }
+        }
+
+        self.total_steps += num_updates;
+        let avg_stats = stats_sum.average();
+
+        // Entropy-collapse guard (matches the feedforward trainer).
+        const ENTROPY_THRESHOLD: f64 = 0.05;
+        const MAX_LOW_ENTROPY_COUNT: usize = 3;
+        if avg_stats.entropy < ENTROPY_THRESHOLD {
+            self.low_entropy_count += 1;
+            if self.low_entropy_count >= MAX_LOW_ENTROPY_COUNT {
+                return Err(anyhow!(
+                    "Training stopped due to entropy collapse (entropy < {} for {} updates)",
+                    ENTROPY_THRESHOLD,
+                    MAX_LOW_ENTROPY_COUNT
+                ));
+            }
+        } else {
+            self.low_entropy_count = 0;
+        }
+
+        Ok(avg_stats)
+    }
+}
+
+/// Host-side arithmetic mean.
+fn host_mean(xs: &[f32]) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    xs.iter().map(|&x| x as f64).sum::<f64>() / xs.len() as f64
+}
+
+/// Biased standard deviation (denominator `n`).
+fn host_std_biased(xs: &[f32], mean: f64) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    let n = xs.len() as f64;
+    let sq_dev = xs.iter().map(|&x| (x as f64 - mean).powi(2)).sum::<f64>();
+    (sq_dev / n).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::{
+        backend::{Autodiff, NdArray},
+        optim::AdamConfig,
+    };
+
+    use super::*;
+    use crate::{policy::lstm::LstmBurnPolicy, train::optimizer::BurnOptimizer};
+
+    type B = Autodiff<NdArray<f32>>;
+
+    /// Build a small synthetic recurrent buffer with deterministic data and a
+    /// computed GAE, ready to feed `train_step`.
+    fn synthetic_buffer(
+        num_steps: usize,
+        num_envs: usize,
+        obs_dim: usize,
+    ) -> RecurrentRolloutBuffer {
+        let hidden_dim = 8;
+        let mut buf = RecurrentRolloutBuffer::new(num_steps, num_envs, obs_dim, hidden_dim);
+        for step in 0..num_steps {
+            for env in 0..num_envs {
+                let obs: Vec<f32> = (0..obs_dim).map(|d| 0.1 * (step + env + d) as f32).collect();
+                // Terminate one env midway to exercise the episode-start mask.
+                let term = env == 0 && step == num_steps / 2;
+                buf.add(step, env, &obs, (step % 2) as i64, 1.0, 0.0, -0.7, term, false);
+            }
+        }
+        let last_values = vec![0.0_f32; num_envs];
+        buf.compute_advantages(&last_values, 0.99, 0.95);
+        buf
+    }
+
+    /// The recurrent trainer constructs and reports zeroed counters.
+    #[test]
+    fn recurrent_trainer_constructs() {
+        let device = Default::default();
+        let policy = LstmBurnPolicy::<B>::new(2, 2, 8, &device);
+        let inner_opt = AdamConfig::new().init();
+        let burn_opt: BurnOptimizer<B, LstmBurnPolicy<B>, _> = BurnOptimizer::new(inner_opt, 3e-4);
+        let trainer =
+            RecurrentPPOTrainer::new(PPOConfig::default(), policy, burn_opt, device).unwrap();
+        assert_eq!(trainer.total_steps(), 0);
+    }
+
+    /// End-to-end: a single `train_step` over a synthetic rank-3 batch runs
+    /// without panic, moves the policy through the optimizer, and produces
+    /// finite stats.
+    #[test]
+    fn recurrent_trainer_train_step_runs() {
+        let device = Default::default();
+        let (num_steps, num_envs, obs_dim, action_dim) = (4, 4, 2, 2);
+        let policy = LstmBurnPolicy::<B>::new(obs_dim, action_dim, 8, &device);
+        let inner_opt = AdamConfig::new().init();
+        let burn_opt: BurnOptimizer<B, LstmBurnPolicy<B>, _> = BurnOptimizer::new(inner_opt, 1e-3);
+        let config = PPOConfig::default().n_epochs(2).target_kl(1.0);
+        let mut trainer = RecurrentPPOTrainer::new(config, policy, burn_opt, device).unwrap();
+
+        let buffer = synthetic_buffer(num_steps, num_envs, obs_dim);
+
+        let stats = trainer
+            .train_step(&buffer, 2, |p, obs_seq, actions, episode_starts| {
+                p.evaluate_sequences(obs_seq, actions, None, episode_starts)
+            })
+            .unwrap();
+
+        assert!(trainer.total_steps() > 0, "at least one gradient step taken");
+        assert!(stats.policy_loss.is_finite());
+        assert!(stats.value_loss.is_finite());
+        assert!(stats.entropy.is_finite());
+    }
+}


### PR DESCRIPTION
Closes #287

Phase 3 of the recurrent-policy epic (#262), implemented per the orchestrator re-scope on the issue: the learning-signal environment is **FlickeringCartPole** (whole-observation dropout at p=0.5, Hausknecht & Stone 2015 protocol), with **MaskedCartPole retained as a documented negative result**.

## What's in this PR

**Commit 629f01c (first attempt, validated stack):**
- `src/train/ppo/recurrent_trainer.rs` — `RecurrentPPOTrainer<B,P,O>`: rank-3 sibling of `PPOTrainerBurn`; consumes `RecurrentRolloutBuffer` sequence batches, flattens `[N_env,T]` -> rank-1 for the unchanged loss fns, consumes `episode_starts` directly, caller-driven LR annealing. Unit-tested on a synthetic rank-3 batch.
- `src/env/games/masked_cartpole.rs` + example — retained as the empirical record that velocity-masking is NOT a POMDP (memoryless MLP 324.5 beat LSTM 221.9 over 500k steps; see issue thread). Doc comments state the negative result explicitly.

**Commit cfa2c35 (this re-scope):**
- `src/env/games/flickering_cartpole.rs` — composition over `CartPole`; with seeded probability `p` (default 0.5) the entire 4-D observation is zeroed. Physics/reward/termination unchanged. Snapshot/restore captures the flicker RNG. 12 unit tests: determinism under seed, blank rate ~ p, shape invariance, reward/termination unaffected, clone/restore reproduces the flicker stream.
- `examples/games/cartpole/recurrent_ppo_flickering_cartpole.rs` — end-to-end LSTM-vs-MLP contrast on the identical flickering stream (same seeds, same normalizer, same budget; only the policy class differs).

## Measured results (500k env steps per arm, p=0.5, seed 0, CPU release)

| Policy | Final mean return (last <=100 eps) | Peak | Bar |
|---|---|---|---|
| **LSTM (RecurrentPPOTrainer)** | **467.6** | **483.9** | >195: **CLEARED** (crosses ~195 by ~50k steps) |
| MLP (feedforward, same stream) | 163.0 | 177.4 | stays below bar and far below LSTM |

**Memory advantage: +306.5 peak return (63% of LSTM peak).** The LSTM curve: 18 -> 175 (43k) -> 306 (84k) -> 467 (500k). The MLP plateaus at ~130-177 from ~60k onward. Per the issue's honesty clause: the MLP does NOT stay under a hard 100 — a reactive policy still scores ~163 because i.i.d. single-frame dropouts are brief at CartPole's 50 Hz control rate — but the contrast is decisive and correctly signed.

## Optimization findings (documented in code comments, applied to BOTH arms symmetrically)

Two intermediate 500k runs produced weak/inverted contrasts and were diagnosed rather than papered over (the environment was never modified):
1. **Frozen critic under PPO2 value clipping**: with unnormalized returns ~50, `clip_range_vf=0.2` caps critic movement at ~0.2/rollout — measured `explained_var ~= 0` for an entire run (LSTM 76.1 vs MLP 134.3, inverted). Disabling the clip instead blew up the shared LSTM trunk via unbounded value-loss gradients (LSTM 24.9). Fix: **train-time reward scaling (0.02)** so returns are O(1); reported returns stay in raw units.
2. **PPO trainers do not apply `max_grad_norm`** (only SAC/A2C do), so the example enables Adam `GradientClipping::Norm(0.5)` at the optimizer level.

Also preserved from the first attempt (load-bearing, flagged in the issue re-scope): visible-frame observation standardization (LSTM tanh gates starve on CartPole's tiny raw obs; blanked frames pass through as clean zeros and are excluded from the statistics), and per-rollout-window zeroing of the behavior policy's hidden state to match `evaluate_sequences`' `initial_state: None` (Strategy A consistency).

## Verification
- `cargo test --features training`: 472 lib tests + integration suites pass, 0 failures
- `cargo clippy --all-targets --features training`: clean
- `cargo fmt --check`: clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features training`: clean
- `cargo check --no-default-features`: clean
- Example: `cargo run --example recurrent_ppo_flickering_cartpole --features training --release` (full logs in issue-visible summary above; supports `lstm`/`baseline` single-arm modes and `TOTAL_TIMESTEPS`/`FLICKER_PROB` overrides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)