### PR TITLE
fix(ppo): honor PPOConfig::max_grad_norm in both PPO trainers

### DIFF
--- a/examples/games/cartpole/recurrent_ppo_flickering_cartpole.rs
+++ b/examples/games/cartpole/recurrent_ppo_flickering_cartpole.rs
@@ -47,7 +47,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use anyhow::Result;
 use burn::{
     backend::Autodiff,
-    grad_clipping::GradientClippingConfig,
     nn::LstmState,
     optim::AdamConfig,
     tensor::{Int, Tensor, TensorData, activation},
@@ -239,13 +238,11 @@ fn run_lstm(total_timesteps: usize, flicker_prob: f64) -> Result<ArmResult> {
         LstmBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
 
     let lr = LSTM_LR;
-    // Global gradient-norm clip at the optimizer level: the PPO trainers do
-    // not themselves apply `max_grad_norm`, so honor it here (matches SAC's
-    // `build_adam`). Load-bearing for the recurrent trunk, where value-loss
+    // Gradient clipping comes from `PPOConfig::max_grad_norm` below (issue
+    // #299): the trainer applies a global gradient-norm clip before every
+    // optimizer step. Load-bearing for the recurrent trunk, where value-loss
     // spikes otherwise wipe out the policy features.
-    let inner_opt = AdamConfig::new()
-        .with_grad_clipping(Some(GradientClippingConfig::Norm(0.5)))
-        .init();
+    let inner_opt = AdamConfig::new().init();
     let burn_opt: BurnOptimizer<Backend, LstmBurnPolicy<Backend>, _> =
         BurnOptimizer::new(inner_opt, lr);
 
@@ -474,10 +471,9 @@ fn run_feedforward(total_timesteps: usize, flicker_prob: f64) -> Result<ArmResul
     };
     let policy = MlpBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
 
-    // Gradient clipping mirrors the LSTM arm (see run_lstm).
-    let inner_opt = AdamConfig::new()
-        .with_grad_clipping(Some(GradientClippingConfig::Norm(0.5)))
-        .init();
+    // Gradient clipping comes from `PPOConfig::max_grad_norm` below,
+    // mirroring the LSTM arm (see run_lstm).
+    let inner_opt = AdamConfig::new().init();
     let burn_opt: BurnOptimizer<Backend, MlpBurnPolicy<Backend>, _> =
         BurnOptimizer::new(inner_opt, MLP_LR);
 

--- a/src/multi_agent/joint.rs
+++ b/src/multi_agent/joint.rs
@@ -68,13 +68,14 @@
 
 use anyhow::{Result, anyhow};
 use burn::{
-    module::{AutodiffModule, Module, ModuleVisitor, Param},
+    module::AutodiffModule,
     optim::{GradientsParams, Optimizer},
     tensor::{Int, Tensor, backend::AutodiffBackend},
 };
 use rand::rngs::StdRng;
 
 use crate::train::{
+    grad_clip::clip_grads_by_global_norm,
     optimizer::{BackendOptimizer, BurnOptimizer},
     ppo::loss::{
         compute_policy_loss, compute_value_loss, generate_minibatch_indices_with_rng, scalar_f64,
@@ -1272,82 +1273,6 @@ where
 // Helpers
 // -----------------------------------------------------------------------
 
-/// Clip a policy's gradients to a global L2 norm (issue #239).
-///
-/// This is the standard PPO/A2C "global gradient norm clip": compute the
-/// L2 norm of the **concatenation** of every parameter's gradient, and if
-/// it exceeds `max_norm`, scale *all* gradients by
-/// `max_norm / (total_norm + eps)`. Unlike Burn's built-in
-/// `GradientClipping::Norm` (which clips each parameter tensor
-/// independently), this preserves the *direction* of the joint gradient —
-/// which is exactly what we need so the large shared-trunk value-loss
-/// gradient is tamed without distorting the relative scale of the policy
-/// and value contributions.
-///
-/// Implemented with two module visitor passes:
-/// 1. accumulate `Σ ‖g_p‖²` across all parameters `p`,
-/// 2. if the resulting norm exceeds `max_norm`, multiply every gradient by the
-///    clip coefficient and re-register it.
-///
-/// A non-finite or non-positive total norm leaves the gradients untouched.
-fn clip_grads_by_global_norm<B, M>(
-    module: &M,
-    grads: GradientsParams,
-    max_norm: f32,
-) -> GradientsParams
-where
-    B: AutodiffBackend,
-    M: Module<B>,
-{
-    // Burn stores gradient tensors on the *inner* (non-autodiff) backend,
-    // so we fetch / re-register them as `Tensor<B::InnerBackend, D>`.
-    type Inner<B> = <B as AutodiffBackend>::InnerBackend;
-
-    // Pass 1: sum of squared gradient norms.
-    struct NormAccumulator<'a, B: AutodiffBackend> {
-        grads: &'a GradientsParams,
-        sum_sq: f64,
-        _marker: core::marker::PhantomData<B>,
-    }
-    impl<B: AutodiffBackend> ModuleVisitor<B> for NormAccumulator<'_, B> {
-        fn visit_float<const D: usize>(&mut self, param: &Param<Tensor<B, D>>) {
-            if let Some(g) = self.grads.get::<Inner<B>, D>(param.id) {
-                let sq = g.powf_scalar(2.0).sum();
-                self.sum_sq += scalar_f64(sq);
-            }
-        }
-    }
-    let mut acc =
-        NormAccumulator::<B> { grads: &grads, sum_sq: 0.0, _marker: core::marker::PhantomData };
-    module.visit(&mut acc);
-
-    let total_norm = acc.sum_sq.sqrt();
-    if !total_norm.is_finite() || total_norm <= max_norm as f64 || max_norm <= 0.0 {
-        // Already within the cap (or degenerate) — nothing to scale.
-        return grads;
-    }
-    let clip_coef = (max_norm as f64 / (total_norm + 1e-6)) as f32;
-
-    // Pass 2: scale every gradient by the clip coefficient.
-    struct Scaler<'a, B: AutodiffBackend> {
-        grads: &'a mut GradientsParams,
-        coef: f32,
-        _marker: core::marker::PhantomData<B>,
-    }
-    impl<B: AutodiffBackend> ModuleVisitor<B> for Scaler<'_, B> {
-        fn visit_float<const D: usize>(&mut self, param: &Param<Tensor<B, D>>) {
-            if let Some(g) = self.grads.remove::<Inner<B>, D>(param.id) {
-                self.grads.register::<Inner<B>, D>(param.id, g.mul_scalar(self.coef));
-            }
-        }
-    }
-    let mut grads = grads;
-    let mut scaler =
-        Scaler::<B> { grads: &mut grads, coef: clip_coef, _marker: core::marker::PhantomData };
-    module.visit(&mut scaler);
-    grads
-}
-
 /// Per-agent single-trajectory GAE (host-side).
 ///
 /// Mirrors the pre-Burn `compute_gae_single_agent` helper: takes 1-D
@@ -2028,68 +1953,9 @@ mod tests {
         }
     }
 
-    /// Issue #239: the global-norm clip must (a) leave an already-small
-    /// gradient untouched and (b) scale an oversized gradient down so its
-    /// global L2 norm equals the cap.
-    #[test]
-    fn test_clip_grads_by_global_norm() {
-        let device: NdArrayDevice = Default::default();
-        let policy = MlpBurnPolicy::<B>::new(4, 3, 16, &device);
-
-        // Build a real gradient via a forward/backward so the param ids in
-        // `GradientsParams` line up with the module's params.
-        let obs = Tensor::<B, 2>::from_data(
-            burn::tensor::TensorData::new(vec![0.1_f32; 4 * 8], [8, 4]),
-            &device,
-        );
-        let logits = policy.encoder_features_joint(obs);
-        let loss = logits.powf_scalar(2.0).sum();
-        let grads = GradientsParams::from_grads(loss.backward(), &policy);
-
-        // Helper: global L2 norm of a GradientsParams over `policy`'s params.
-        fn global_norm(policy: &MlpBurnPolicy<B>, grads: &GradientsParams) -> f64 {
-            struct Acc<'a> {
-                grads: &'a GradientsParams,
-                sum_sq: f64,
-            }
-            impl ModuleVisitor<B> for Acc<'_> {
-                fn visit_float<const D: usize>(&mut self, param: &Param<Tensor<B, D>>) {
-                    if let Some(g) =
-                        self.grads.get::<<B as AutodiffBackend>::InnerBackend, D>(param.id)
-                    {
-                        self.sum_sq += scalar_f64(g.powf_scalar(2.0).sum());
-                    }
-                }
-            }
-            let mut acc = Acc { grads, sum_sq: 0.0 };
-            policy.visit(&mut acc);
-            acc.sum_sq.sqrt()
-        }
-
-        let norm_before = global_norm(&policy, &grads);
-        assert!(norm_before.is_finite() && norm_before > 0.0);
-
-        // (a) A cap well above the gradient norm is a no-op.
-        let big_cap = norm_before * 10.0;
-        let unclipped =
-            clip_grads_by_global_norm::<B, MlpBurnPolicy<B>>(&policy, grads, big_cap as f32);
-        let norm_unclipped = global_norm(&policy, &unclipped);
-        assert!(
-            (norm_unclipped - norm_before).abs() < 1e-4,
-            "cap above norm must not change gradients: {norm_before} -> {norm_unclipped}"
-        );
-
-        // (b) A small cap scales the global norm down to (approximately) the
-        // cap.
-        let small_cap = (norm_before / 4.0) as f32;
-        let clipped =
-            clip_grads_by_global_norm::<B, MlpBurnPolicy<B>>(&policy, unclipped, small_cap);
-        let norm_clipped = global_norm(&policy, &clipped);
-        assert!(
-            (norm_clipped - small_cap as f64).abs() < 1e-3 * small_cap as f64 + 1e-4,
-            "clipped global norm {norm_clipped} should equal cap {small_cap}"
-        );
-    }
+    // NOTE: the `clip_grads_by_global_norm` unit test moved to
+    // `crate::train::grad_clip::tests` when the helper was extracted for
+    // reuse by the single-agent PPO trainers (issue #299).
 
     /// Issue #239: with `iterate_all_minibatches = true` the update walks
     /// every minibatch per epoch (more gradient steps than the single-draw

--- a/src/train/grad_clip.rs
+++ b/src/train/grad_clip.rs
@@ -1,0 +1,159 @@
+//! Global gradient-norm clipping shared by the PPO trainers and the joint
+//! multi-agent trainer.
+//!
+//! Originally implemented inside the joint multi-agent trainer (issue #239)
+//! and extracted here when the single-agent PPO trainers gained
+//! `PPOConfig::max_grad_norm` support (issue #299), so all three call sites
+//! share one definition of the clip.
+
+use burn::{
+    module::{Module, ModuleVisitor, Param},
+    optim::GradientsParams,
+    tensor::{Tensor, backend::AutodiffBackend},
+};
+
+use crate::train::ppo::loss::scalar_f64;
+
+/// Burn stores gradient tensors on the *inner* (non-autodiff) backend, so we
+/// fetch / re-register them as `Tensor<B::InnerBackend, D>`.
+type Inner<B> = <B as AutodiffBackend>::InnerBackend;
+
+/// Global L2 norm of a gradient set over `module`'s parameters.
+///
+/// Computes `sqrt(Σ_p ‖g_p‖²)` across every float parameter `p` of `module`
+/// that has a gradient registered in `grads`. Parameters without a gradient
+/// contribute zero.
+pub fn global_grad_norm<B, M>(module: &M, grads: &GradientsParams) -> f64
+where
+    B: AutodiffBackend,
+    M: Module<B>,
+{
+    struct NormAccumulator<'a, B: AutodiffBackend> {
+        grads: &'a GradientsParams,
+        sum_sq: f64,
+        _marker: core::marker::PhantomData<B>,
+    }
+    impl<B: AutodiffBackend> ModuleVisitor<B> for NormAccumulator<'_, B> {
+        fn visit_float<const D: usize>(&mut self, param: &Param<Tensor<B, D>>) {
+            if let Some(g) = self.grads.get::<Inner<B>, D>(param.id) {
+                let sq = g.powf_scalar(2.0).sum();
+                self.sum_sq += scalar_f64(sq);
+            }
+        }
+    }
+    let mut acc = NormAccumulator::<B> { grads, sum_sq: 0.0, _marker: core::marker::PhantomData };
+    module.visit(&mut acc);
+    acc.sum_sq.sqrt()
+}
+
+/// Clip a module's gradients to a global L2 norm (issues #239, #299).
+///
+/// This is the standard PPO/A2C "global gradient norm clip": compute the
+/// L2 norm of the **concatenation** of every parameter's gradient, and if
+/// it exceeds `max_norm`, scale *all* gradients by
+/// `max_norm / (total_norm + eps)`. Unlike Burn's built-in
+/// `GradientClipping::Norm` (which clips each parameter tensor
+/// independently), this preserves the *direction* of the joint gradient —
+/// which is exactly what we need so a large shared-trunk value-loss
+/// gradient is tamed without distorting the relative scale of the policy
+/// and value contributions.
+///
+/// Implemented with two module visitor passes:
+/// 1. accumulate `Σ ‖g_p‖²` across all parameters `p` (see
+///    [`global_grad_norm`]),
+/// 2. if the resulting norm exceeds `max_norm`, multiply every gradient by the
+///    clip coefficient and re-register it.
+///
+/// A non-finite or non-positive total norm leaves the gradients untouched.
+pub fn clip_grads_by_global_norm<B, M>(
+    module: &M,
+    grads: GradientsParams,
+    max_norm: f32,
+) -> GradientsParams
+where
+    B: AutodiffBackend,
+    M: Module<B>,
+{
+    let total_norm = global_grad_norm::<B, M>(module, &grads);
+    if !total_norm.is_finite() || total_norm <= max_norm as f64 || max_norm <= 0.0 {
+        // Already within the cap (or degenerate) — nothing to scale.
+        return grads;
+    }
+    let clip_coef = (max_norm as f64 / (total_norm + 1e-6)) as f32;
+
+    // Pass 2: scale every gradient by the clip coefficient.
+    struct Scaler<'a, B: AutodiffBackend> {
+        grads: &'a mut GradientsParams,
+        coef: f32,
+        _marker: core::marker::PhantomData<B>,
+    }
+    impl<B: AutodiffBackend> ModuleVisitor<B> for Scaler<'_, B> {
+        fn visit_float<const D: usize>(&mut self, param: &Param<Tensor<B, D>>) {
+            if let Some(g) = self.grads.remove::<Inner<B>, D>(param.id) {
+                self.grads.register::<Inner<B>, D>(param.id, g.mul_scalar(self.coef));
+            }
+        }
+    }
+    let mut grads = grads;
+    let mut scaler =
+        Scaler::<B> { grads: &mut grads, coef: clip_coef, _marker: core::marker::PhantomData };
+    module.visit(&mut scaler);
+    grads
+}
+
+#[cfg(test)]
+mod tests {
+    use burn::{
+        backend::{Autodiff, NdArray, ndarray::NdArrayDevice},
+        optim::GradientsParams,
+        tensor::Tensor,
+    };
+
+    use super::*;
+    use crate::{multi_agent::JointPolicy as _, policy::mlp::MlpBurnPolicy};
+
+    type B = Autodiff<NdArray<f32>>;
+
+    /// Issues #239/#299: the global-norm clip must (a) leave an already-small
+    /// gradient untouched and (b) scale an oversized gradient down so its
+    /// global L2 norm equals the cap.
+    #[test]
+    fn test_clip_grads_by_global_norm() {
+        let device: NdArrayDevice = Default::default();
+        let policy = MlpBurnPolicy::<B>::new(4, 3, 16, &device);
+
+        // Build a real gradient via a forward/backward so the param ids in
+        // `GradientsParams` line up with the module's params.
+        let obs = Tensor::<B, 2>::from_data(
+            burn::tensor::TensorData::new(vec![0.1_f32; 4 * 8], [8, 4]),
+            &device,
+        );
+        let logits = policy.encoder_features_joint(obs);
+        let loss = logits.powf_scalar(2.0).sum();
+        let grads = GradientsParams::from_grads(loss.backward(), &policy);
+
+        let norm_before = global_grad_norm::<B, MlpBurnPolicy<B>>(&policy, &grads);
+        assert!(norm_before.is_finite() && norm_before > 0.0);
+
+        // (a) A cap well above the gradient norm is a no-op.
+        let big_cap = norm_before * 10.0;
+        let unclipped =
+            clip_grads_by_global_norm::<B, MlpBurnPolicy<B>>(&policy, grads, big_cap as f32);
+        let norm_unclipped = global_grad_norm::<B, MlpBurnPolicy<B>>(&policy, &unclipped);
+        assert!(
+            (norm_unclipped - norm_before).abs() < 1e-4,
+            "cap above norm must not change gradients: {norm_before} -> {norm_unclipped}"
+        );
+
+        // (b) A small cap scales the global norm down to (approximately) the
+        // cap.
+        let small_cap = (norm_before / 4.0) as f32;
+        let clipped =
+            clip_grads_by_global_norm::<B, MlpBurnPolicy<B>>(&policy, unclipped, small_cap);
+        let norm_clipped = global_grad_norm::<B, MlpBurnPolicy<B>>(&policy, &clipped);
+        assert!(
+            (norm_clipped - small_cap as f64).abs() < 1e-3 * small_cap as f64 + 1e-4,
+            "clipped global norm {norm_clipped} should equal cap {small_cap}"
+        );
+    }
+}

--- a/src/train/mod.rs
+++ b/src/train/mod.rs
@@ -8,6 +8,10 @@
 /// Burn optimizer wrapper used by both PPO and DQN.
 pub mod optimizer;
 
+/// Global gradient-norm clipping shared by the PPO trainers and the joint
+/// multi-agent trainer (issues #239, #299).
+pub mod grad_clip;
+
 pub mod a2c;
 pub mod bc;
 pub mod dqn;
@@ -17,6 +21,7 @@ pub mod sac;
 pub use a2c::{A2cConfig, A2cStats, A2cTrainer, compute_a2c_policy_loss, compute_a2c_value_loss};
 pub use bc::{BcConfig, BcEpochStats, BcTrainer, Demonstrations, compute_bc_loss};
 pub use dqn::{DQNConfig, DQNStepStatsBurn, DQNTrainerBurn};
+pub use grad_clip::{clip_grads_by_global_norm, global_grad_norm};
 pub use optimizer::{BackendOptimizer, BurnOptimizer};
 pub use ppo::{
     AggregatedStats, AsyncActorLearnerConfig, PPOConfig, PPOTrainerBurn, TrainingStats,

--- a/src/train/ppo/config.rs
+++ b/src/train/ppo/config.rs
@@ -39,7 +39,18 @@ pub struct PPOConfig {
     /// Entropy bonus coefficient
     pub ent_coef: f64,
 
-    /// Maximum gradient norm for clipping
+    /// Maximum gradient norm for clipping.
+    ///
+    /// Applied by both
+    /// [`PPOTrainerBurn`](crate::train::ppo::trainer::PPOTrainerBurn) and
+    /// [`RecurrentPPOTrainer`](crate::train::ppo::recurrent_trainer::RecurrentPPOTrainer)
+    /// as a **global** L2-norm clip (see
+    /// [`clip_grads_by_global_norm`](crate::train::grad_clip::clip_grads_by_global_norm))
+    /// over the concatenation of every parameter's gradient, immediately
+    /// before each optimizer step (issue #299; prior to that fix the field
+    /// was silently ignored by both trainers). Must be positive —
+    /// [`validate`](PPOConfig::validate) rejects non-positive values — so to
+    /// effectively disable clipping set a very large cap (e.g. `1e9`).
     pub max_grad_norm: f64,
 
     /// Target KL divergence for early stopping

--- a/src/train/ppo/recurrent_trainer.rs
+++ b/src/train/ppo/recurrent_trainer.rs
@@ -59,7 +59,10 @@ use super::{
 };
 use crate::{
     buffer::rollout::RecurrentRolloutBuffer,
-    train::optimizer::{BackendOptimizer, BurnOptimizer},
+    train::{
+        grad_clip::clip_grads_by_global_norm,
+        optimizer::{BackendOptimizer, BurnOptimizer},
+    },
 };
 
 /// Recurrent PPO trainer (Burn backend).
@@ -106,13 +109,18 @@ where
     /// feedforward trainer, which reads the device off the observation tensor
     /// passed to `train_step` — the recurrent trainer must be told which
     /// device to build minibatches on).
+    ///
+    /// Validates the config and stages the global gradient-norm cap
+    /// ([`PPOConfig::max_grad_norm`]) on the optimizer wrapper; `train_step`
+    /// applies it to the gradients of every minibatch step (issue #299).
     pub fn new(
         config: PPOConfig,
         policy: P,
-        optimizer: BurnOptimizer<B, P, O>,
+        mut optimizer: BurnOptimizer<B, P, O>,
         device: B::Device,
     ) -> Result<Self> {
         config.validate()?;
+        optimizer.clip_grad_norm(config.max_grad_norm);
         Ok(Self {
             config,
             policy: Some(policy),
@@ -261,6 +269,16 @@ where
                 // Burn gradient flow: backward → GradientsParams → step.
                 let grads = total_loss.backward();
                 let grads = GradientsParams::from_grads(grads, &policy);
+                // Global gradient-norm clip (issue #299):
+                // `PPOConfig::max_grad_norm` is staged on the wrapper in
+                // `new` and applied to the gradient slice before the
+                // move-through step, mirroring the joint trainer (#239).
+                let grads = match self.optimizer.grad_clip_norm() {
+                    Some(max_norm) if max_norm > 0.0 => {
+                        clip_grads_by_global_norm::<B, P>(&policy, grads, max_norm as f32)
+                    }
+                    _ => grads,
+                };
                 let lr = self.lr_override.unwrap_or_else(|| self.optimizer.learning_rate());
                 let policy = self.optimizer.inner_mut().step(lr, policy, grads);
                 self.policy = Some(policy);
@@ -328,6 +346,7 @@ fn host_std_biased(xs: &[f32], mean: f64) -> f64 {
 mod tests {
     use burn::{
         backend::{Autodiff, NdArray},
+        module::{Module, ModuleVisitor, Param},
         optim::AdamConfig,
     };
 
@@ -335,6 +354,33 @@ mod tests {
     use crate::{policy::lstm::LstmBurnPolicy, train::optimizer::BurnOptimizer};
 
     type B = Autodiff<NdArray<f32>>;
+
+    /// Flatten every float parameter of a module into one host vector.
+    fn params_flat<M: Module<B>>(module: &M) -> Vec<f32> {
+        struct Collect {
+            out: Vec<f32>,
+        }
+        impl ModuleVisitor<B> for Collect {
+            fn visit_float<const D: usize>(&mut self, param: &Param<Tensor<B, D>>) {
+                let host: Vec<f32> = param.val().into_data().to_vec().unwrap_or_default();
+                self.out.extend(host);
+            }
+        }
+        let mut c = Collect { out: Vec::new() };
+        module.visit(&mut c);
+        c.out
+    }
+
+    /// L2 norm of the parameter update `after - before`.
+    fn update_norm(before: &[f32], after: &[f32]) -> f64 {
+        assert_eq!(before.len(), after.len());
+        before
+            .iter()
+            .zip(after)
+            .map(|(&a, &b)| ((b - a) as f64).powi(2))
+            .sum::<f64>()
+            .sqrt()
+    }
 
     /// Build a small synthetic recurrent buffer with deterministic data and a
     /// computed GAE, ready to feed `train_step`.
@@ -395,5 +441,49 @@ mod tests {
         assert!(stats.policy_loss.is_finite());
         assert!(stats.value_loss.is_finite());
         assert!(stats.entropy.is_finite());
+    }
+
+    /// Issue #299: the recurrent trainer must apply
+    /// `PPOConfig::max_grad_norm`. Two trainers start from identical
+    /// (cloned) policies and the same synthetic buffer; the only difference
+    /// is the cap. The tiny cap scales the gradients far below Adam's
+    /// epsilon, so its parameter update must come out much smaller than the
+    /// effectively-unbounded control's (the huge-cap control doubles as the
+    /// no-clip baseline; see `train::grad_clip::tests` for the direct no-op
+    /// assertion).
+    #[test]
+    fn recurrent_trainer_applies_max_grad_norm() {
+        let device: burn::backend::ndarray::NdArrayDevice = Default::default();
+        let (num_steps, num_envs, obs_dim, action_dim) = (4, 4, 2, 2);
+        let policy = LstmBurnPolicy::<B>::new(obs_dim, action_dim, 8, &device);
+        let buffer = synthetic_buffer(num_steps, num_envs, obs_dim);
+
+        let run = |config: PPOConfig, policy: LstmBurnPolicy<B>| -> f64 {
+            let inner_opt = AdamConfig::new().init();
+            let burn_opt: BurnOptimizer<B, LstmBurnPolicy<B>, _> =
+                BurnOptimizer::new(inner_opt, 1e-3);
+            let mut trainer = RecurrentPPOTrainer::new(config, policy, burn_opt, device).unwrap();
+            let before = params_flat(trainer.policy());
+            trainer
+                .train_step(&buffer, num_envs, |p, obs_seq, actions, episode_starts| {
+                    p.evaluate_sequences(obs_seq, actions, None, episode_starts)
+                })
+                .unwrap();
+            let after = params_flat(trainer.policy());
+            update_norm(&before, &after)
+        };
+
+        // `envs_per_minibatch == num_envs` → one minibatch; `n_epochs == 1`
+        // → exactly one gradient step per trainer.
+        let base = PPOConfig::default().n_epochs(1).target_kl(1.0);
+        let clipped = run(base.clone().max_grad_norm(1e-6), policy.clone());
+        let unclipped = run(base.max_grad_norm(1e9), policy);
+
+        assert!(unclipped > 0.0, "control update must move parameters");
+        assert!(clipped > 0.0, "clipped update should still move parameters");
+        assert!(
+            clipped < 0.2 * unclipped,
+            "tiny max_grad_norm must shrink the update: clipped {clipped} vs unclipped {unclipped}"
+        );
     }
 }

--- a/src/train/ppo/trainer.rs
+++ b/src/train/ppo/trainer.rs
@@ -55,7 +55,10 @@ use super::{
     },
     stats::TrainingStats,
 };
-use crate::train::optimizer::{BackendOptimizer, BurnOptimizer};
+use crate::train::{
+    grad_clip::clip_grads_by_global_norm,
+    optimizer::{BackendOptimizer, BurnOptimizer},
+};
 
 /// Burn-backend PPO trainer.
 ///
@@ -96,9 +99,18 @@ where
     O: Optimizer<P, B>,
 {
     /// Build a new Burn PPO trainer.
-    pub fn new(config: PPOConfig, policy: P, optimizer: BurnOptimizer<B, P, O>) -> Result<Self> {
+    ///
+    /// Validates the config and stages the global gradient-norm cap
+    /// ([`PPOConfig::max_grad_norm`]) on the optimizer wrapper; `train_step`
+    /// applies it to the gradients of every minibatch step (issue #299).
+    pub fn new(
+        config: PPOConfig,
+        policy: P,
+        mut optimizer: BurnOptimizer<B, P, O>,
+    ) -> Result<Self> {
         config.validate()?;
         let rng = StdRng::seed_from_u64(config.seed);
+        optimizer.clip_grad_norm(config.max_grad_norm);
         Ok(Self {
             config,
             policy: Some(policy),
@@ -240,6 +252,16 @@ where
                 // Burn gradient flow: backward → GradientsParams → step.
                 let grads = total_loss.backward();
                 let grads = GradientsParams::from_grads(grads, &policy);
+                // Global gradient-norm clip (issue #299):
+                // `PPOConfig::max_grad_norm` is staged on the wrapper in
+                // `new` and applied to the gradient slice before the
+                // move-through step, mirroring the joint trainer (#239).
+                let grads = match self.optimizer.grad_clip_norm() {
+                    Some(max_norm) if max_norm > 0.0 => {
+                        clip_grads_by_global_norm::<B, P>(&policy, grads, max_norm as f32)
+                    }
+                    _ => grads,
+                };
                 let lr = self.optimizer.learning_rate();
                 let policy = self.optimizer.inner_mut().step(lr, policy, grads);
                 self.policy = Some(policy);
@@ -346,6 +368,7 @@ fn select_rows_int<B: AutodiffBackend>(
 mod tests {
     use burn::{
         backend::{Autodiff, NdArray},
+        module::{Module, ModuleVisitor, Param},
         optim::AdamConfig,
     };
 
@@ -353,6 +376,33 @@ mod tests {
     use crate::{policy::mlp::MlpBurnPolicy, train::optimizer::BurnOptimizer};
 
     type B = Autodiff<NdArray<f32>>;
+
+    /// Flatten every float parameter of a module into one host vector.
+    fn params_flat<M: Module<B>>(module: &M) -> Vec<f32> {
+        struct Collect {
+            out: Vec<f32>,
+        }
+        impl ModuleVisitor<B> for Collect {
+            fn visit_float<const D: usize>(&mut self, param: &Param<Tensor<B, D>>) {
+                let host: Vec<f32> = param.val().into_data().to_vec().unwrap_or_default();
+                self.out.extend(host);
+            }
+        }
+        let mut c = Collect { out: Vec::new() };
+        module.visit(&mut c);
+        c.out
+    }
+
+    /// L2 norm of the parameter update `after - before`.
+    fn update_norm(before: &[f32], after: &[f32]) -> f64 {
+        assert_eq!(before.len(), after.len());
+        before
+            .iter()
+            .zip(after)
+            .map(|(&a, &b)| ((b - a) as f64).powi(2))
+            .sum::<f64>()
+            .sqrt()
+    }
 
     /// Smoke test: a Burn PPO trainer constructs and exposes the same
     /// config back through `config()`.
@@ -429,5 +479,90 @@ mod tests {
         // Stats should be finite.
         assert!(stats.policy_loss.is_finite());
         assert!(stats.value_loss.is_finite());
+    }
+
+    /// Issue #299: `PPOConfig::max_grad_norm` must actually be applied.
+    ///
+    /// Two trainers start from identical (cloned) policies, identical
+    /// synthetic data, and identical seeds; the only difference is the cap.
+    /// The tiny cap scales the gradients far below Adam's epsilon, so its
+    /// parameter update must come out much smaller than the
+    /// effectively-unbounded control's. The huge-cap control doubles as the
+    /// no-clip baseline: gradients below the cap pass through untouched (see
+    /// `train::grad_clip::tests` for the direct no-op assertion).
+    #[test]
+    fn ppo_trainer_burn_applies_max_grad_norm() {
+        let device: burn::backend::ndarray::NdArrayDevice = Default::default();
+        let policy = MlpBurnPolicy::<B>::new(4, 2, 16, &device);
+
+        let batch = 8;
+        let make_batch = || {
+            let obs_dim = 4;
+            let obs_data: Vec<f32> = (0..batch * obs_dim).map(|i| (i as f32) * 0.01).collect();
+            let observations = Tensor::<B, 2>::from_data(
+                burn::tensor::TensorData::new(obs_data, [batch, obs_dim]),
+                &device,
+            );
+            let actions = Tensor::<B, 1, Int>::from_data(
+                burn::tensor::TensorData::new(vec![0i64, 1, 0, 1, 0, 1, 0, 1], [batch]),
+                &device,
+            );
+            let old_log_probs = Tensor::<B, 1>::from_data(
+                burn::tensor::TensorData::new(vec![-0.7f32; batch], [batch]),
+                &device,
+            );
+            let old_values = Tensor::<B, 1>::from_data(
+                burn::tensor::TensorData::new(vec![0.0f32; batch], [batch]),
+                &device,
+            );
+            let advantages = Tensor::<B, 1>::from_data(
+                burn::tensor::TensorData::new(
+                    vec![1.0f32, -1.0, 0.5, -0.5, 1.0, -1.0, 0.5, -0.5],
+                    [batch],
+                ),
+                &device,
+            );
+            let returns = Tensor::<B, 1>::from_data(
+                burn::tensor::TensorData::new(vec![1.0f32; batch], [batch]),
+                &device,
+            );
+            (observations, actions, old_log_probs, old_values, advantages, returns)
+        };
+
+        let run = |config: PPOConfig, policy: MlpBurnPolicy<B>| -> f64 {
+            let inner_opt = AdamConfig::new().init();
+            let burn_opt: BurnOptimizer<B, MlpBurnPolicy<B>, _> =
+                BurnOptimizer::new(inner_opt, 1e-3);
+            let mut trainer = PPOTrainerBurn::new(config, policy, burn_opt).unwrap();
+            let before = params_flat(trainer.policy());
+            let (observations, actions, old_log_probs, old_values, advantages, returns) =
+                make_batch();
+            trainer
+                .train_step(
+                    observations,
+                    actions,
+                    old_log_probs,
+                    old_values,
+                    advantages,
+                    returns,
+                    |p, o, a| p.evaluate_actions(o, a),
+                )
+                .unwrap();
+            let after = params_flat(trainer.policy());
+            update_norm(&before, &after)
+        };
+
+        // `batch_size == batch` → one minibatch; `n_epochs == 1` → exactly
+        // one gradient step per trainer.
+        let base = PPOConfig::default().batch_size(batch).n_epochs(1);
+        let clipped = run(base.clone().max_grad_norm(1e-6), policy.clone());
+        let unclipped = run(base.max_grad_norm(1e9), policy);
+
+        assert!(unclipped > 0.0, "control update must move parameters");
+        assert!(clipped > 0.0, "clipped update should still move parameters");
+        assert!(
+            clipped < 0.2 * unclipped,
+            "tiny max_grad_norm must shrink the update: clipped {clipped} vs unclipped {unclipped}"
+        );
     }
 }


### PR DESCRIPTION
Closes #299

## What

Both PPO trainers (`PPOTrainerBurn`, `RecurrentPPOTrainer`) read `PPOConfig::max_grad_norm`, validated it, and then silently ignored it — only SAC/A2C/joint applied any gradient clipping. This PR honors the config field in both trainers, matching the joint multi-agent trainer's pattern (issue #239).

- **`src/train/grad_clip.rs` (new)**: extracted `clip_grads_by_global_norm` (and a `global_grad_norm` helper) verbatim from `src/multi_agent/joint.rs`, where it was a private fn, so all three call sites share one definition. It clips the **global** L2 norm of the concatenated per-parameter gradients (SB3/PyTorch `clip_grad_norm_` semantics), preserving gradient direction — unlike Burn's built-in `GradientClipping::Norm`, which clips each parameter tensor independently.
- **`PPOTrainerBurn::new` / `RecurrentPPOTrainer::new`**: stage `config.max_grad_norm` on the `BurnOptimizer` wrapper (same as A2C/joint); `train_step` applies the clip to the gradient slice immediately before every move-through `inner_mut().step(...)`.
- **`src/multi_agent/joint.rs`**: now imports the shared helper; its unit test moved to `train::grad_clip::tests` unchanged.
- **`PPOConfig::max_grad_norm` doc comment** now states exactly where and how the clip is applied (criterion 4).
- **Example migration** (criterion 5): `recurrent_ppo_flickering_cartpole` dropped its optimizer-level `GradientClippingConfig::Norm(0.5)` workaround (both arms) and now relies on the `.max_grad_norm(0.5)` it already set in `PPOConfig`. Compile-checked (`cargo clippy --all-targets`); not retrained.

## Default-behavior decision (criterion 2 / regression note)

`max_grad_norm` was already a non-optional `f64` with default `0.5`, and `validate()` rejects non-positive values — i.e. the field's existing default (and every existing call site, all of which set `0.5`) **already promised clipping**. Per the curation note, this PR therefore keeps the existing type and default and documents the change as a **behavior fix**, not a silent default change:

- Configs that left the default or set `.max_grad_norm(0.5)` now actually get the clipping they were asking for. This can change training trajectories — that is the bug fix (PR #298 showed the absence of clipping blows up shared LSTM trunks).
- There is no `None`/"disable" state to preserve because the type never had one; users who genuinely want no clipping can set a very large cap (e.g. `1e9`), which is documented on the field.
- Clip semantics note: the trainers apply a *global*-norm clip (direction-preserving), while the #298 example workaround used Burn's *per-tensor* norm clip. The global-norm variant is the standard PPO clip and the one the joint trainer already uses; the example's behavior is therefore not bit-identical to the workaround, but is the intended semantics of the config field.

## Tests (criterion 3)

- `train::grad_clip::tests::test_clip_grads_by_global_norm` (moved from joint.rs): cap above the gradient norm is a no-op (no-clip control); cap below scales the global norm to the cap.
- `ppo_trainer_burn_applies_max_grad_norm` / `recurrent_trainer_applies_max_grad_norm` (new): two trainers from cloned policies, identical data/seeds, differing only in the cap — a tiny cap (`1e-6`) must produce a parameter update < 0.2x the effectively-unbounded control (`1e9`).

## Verification

- `cargo test` — full suite green
- `cargo clippy --all-targets -- -D warnings` — clean (also compile-checks all examples, including the migrated one)
- `cargo fmt --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
