### PR TITLE
docs(tutorials): guided series with CI-doc-tested tutorials 1–2 (#303)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ cargo run --release --example train_simple_bandit
 The default `training` feature builds against Burn's pure-Rust NdArray
 backend; no external libraries (libtorch, CUDA, etc.) are required.
 
+### 📚 Tutorials — a guided learning path
+
+New to Thrust? Start with the **[Tutorial Series](docs/tutorials/README.md)**: a
+dependency-ordered path from your first agent to a trained-and-deployed policy.
+Every code snippet is CI-doc-tested, so nothing rots. Begin with
+[Your first agent](docs/tutorials/01-your-first-agent.md) and
+[Solving CartPole with PPO](docs/tutorials/02-cartpole-ppo.md).
+
 ### GPU Training
 
 Burn ships several GPU backends behind feature flags. Compose them with

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -48,7 +48,16 @@ This is one of twelve runnable trainers. Browse the full
 [Example Gallery](EXAMPLES.md) for a trainer per algorithm (PPO, A2C, DQN, SAC,
 BC, PSRO, NFSP) across every environment, with copy-paste run commands.
 
-### 5. Build Documentation
+### 5. Follow the Tutorial Series
+
+Examples are reference material; the **[Tutorial Series](tutorials/README.md)**
+is a guided, dependency-ordered path from your first agent to a
+trained-and-deployed policy. Every code block is CI-doc-tested. Start with
+[Your first agent](tutorials/01-your-first-agent.md) (SimpleBandit + actor-critic,
+the rollout → loss → update loop by hand), then
+[Solving CartPole with PPO](tutorials/02-cartpole-ppo.md).
+
+### 6. Build Documentation
 
 ```bash
 cargo doc --open

--- a/docs/tutorials/01-your-first-agent.md
+++ b/docs/tutorials/01-your-first-agent.md
@@ -1,0 +1,270 @@
+# Tutorial 1 — Your first agent
+
+> **You will:** train an actor-critic policy to solve `SimpleBandit` from
+> scratch, writing the full rollout → loss → update loop by hand in ~60 lines.
+> **Prerequisites:** a Rust nightly toolchain (see
+> [GETTING_STARTED.md](../GETTING_STARTED.md)). No GPU, no libtorch — the
+> default backend is pure-Rust CPU.
+> **Time:** ~10 minutes, including the training run.
+
+This is the "hello world" of Thrust. We pick the simplest possible learning
+problem so that nothing hides behind a trainer abstraction: you will see every
+tensor, every gradient step, and exactly where the learning signal comes from.
+Later tutorials hand the boilerplate to a `PPOTrainerBurn`; here we do it by
+hand so the loop holds no mysteries.
+
+## The problem: a contextual bandit
+
+`SimpleBandit` is deliberately trivial:
+
+- The **state** is a single bit, `0.0` or `1.0`, drawn fresh each step.
+- There are **two actions**, `0` and `1`.
+- The **reward** is `1.0` if `action == state`, else `0.0`.
+- Every episode is **one step long**.
+
+The optimal policy is just `action = state`, and a perfect agent scores a
+mean reward of `1.0`. We chose this because it is a *contextual bandit*, not a
+sequential task: each state is independent of the last, so there is **no credit
+assignment across time**. That property lets us strip the advantage estimator
+down to its simplest form, which we'll explain when we get there.
+
+## The pieces
+
+Three types do the work, all re-exported from the crate's prelude:
+
+- `SimpleBandit` — the environment (implements the `Environment` trait).
+- `EnvPool` — a vectorized wrapper that steps *N* copies of the env at once, so
+  each rollout gathers a healthy batch of independent transitions.
+- `MlpBurnPolicy` — a small multi-layer perceptron with two heads: an **actor**
+  (action logits) and a **critic** (a scalar state-value estimate). This is the
+  actor-critic architecture that underpins every on-policy algorithm in Thrust.
+
+We drive the Burn tensor framework directly. The one piece of Burn ceremony to
+know up front: its optimizer has a **move-in, move-out** ownership model —
+`optim.step(...)` *consumes* the policy and returns the updated copy. There is
+no in-place update. We keep the policy in an `Option` and swap it through
+`take().unwrap() → step() → Some(...)` each iteration. This surprises everyone
+the first time; it is not a bug.
+
+## The loop
+
+Every on-policy RL update is three phases:
+
+1. **Rollout** — run the current policy in the env and record what happened
+   (observations, actions, the log-probability of each action, the critic's
+   value estimate, and the reward). No gradients here.
+2. **Advantage** — turn rewards into a learning signal: *how much better than
+   expected* was each action? For a bandit that is simply `advantage = reward −
+   value`. There is no future to bootstrap from, so — unlike CartPole in
+   Tutorial 2 — we deliberately do **not** discount or run GAE. Bootstrapping
+   from the *next* state's value would only inject noise here, because the next
+   state is random and unrelated.
+3. **Update** — nudge the actor to make high-advantage actions more likely (a
+   clipped PPO surrogate) and train the critic to predict the reward (MSE),
+   plus a small entropy bonus to keep exploring.
+
+Here is the whole thing. It compiles and runs as-is (it is a doc-test in the
+crate, so CI keeps it honest):
+
+```rust
+use burn::{
+    backend::{Autodiff, NdArray},
+    optim::{AdamConfig, GradientsParams, Optimizer},
+    tensor::{Int, Tensor, TensorData},
+};
+use thrust_rl::prelude::*;
+
+// The backend is chosen at compile time. `NdArray<f32>` is Burn's pure-Rust
+// CPU backend; `Autodiff<...>` wraps it to record gradients. Swapping in a GPU
+// backend is a one-line type change plus a Cargo feature — see BURN_BACKENDS.md.
+type Backend = Autodiff<NdArray<f32>>;
+
+// --- Hyperparameters -------------------------------------------------------
+const NUM_ENVS: usize = 4; // parallel bandit copies per rollout
+const NUM_STEPS: usize = 100; // steps collected per env per rollout
+const TOTAL_TIMESTEPS: usize = 4_000; // small so this runs fast in CI
+const LEARNING_RATE: f64 = 1e-3;
+const N_EPOCHS: usize = 10; // gradient passes over each rollout
+const CLIP_RANGE: f32 = 0.2; // PPO surrogate clip
+const VF_COEF: f32 = 0.5; // weight on the value (critic) loss
+const ENT_COEF: f32 = 0.1; // weight on the entropy bonus
+const HIDDEN_DIM: usize = 64;
+
+let device = Default::default();
+
+// --- Environment -----------------------------------------------------------
+// Probe one env for its dimensions, then build a pool of NUM_ENVS copies.
+let probe = SimpleBandit::new();
+let obs_dim = probe.observation_space().shape[0];
+let action_dim = match probe.action_space().space_type {
+    SpaceType::Discrete(n) => n,
+    SpaceType::Box => panic!("SimpleBandit is discrete"),
+};
+let mut env_pool = EnvPool::new(SimpleBandit::new, NUM_ENVS);
+
+// --- Policy + optimizer ----------------------------------------------------
+// The policy lives in an Option because Burn's optimizer moves it through
+// `step()`. `optim` is Adam; we pass the learning rate to `step`, not the
+// config, so it can be scheduled later if you want.
+let mut policy: Option<MlpBurnPolicy<Backend>> =
+    Some(MlpBurnPolicy::new(obs_dim, action_dim, HIDDEN_DIM, &device));
+let mut optim = AdamConfig::new().init();
+
+// --- Rollout buffers (host-side Vecs, reused each iteration) ---------------
+let cap = NUM_STEPS * NUM_ENVS;
+let mut buf_obs: Vec<f32> = Vec::with_capacity(cap * obs_dim);
+let mut buf_actions: Vec<i64> = Vec::with_capacity(cap);
+let mut buf_log_probs: Vec<f32> = Vec::with_capacity(cap);
+let mut buf_values: Vec<f32> = Vec::with_capacity(cap);
+let mut buf_rewards: Vec<f32> = Vec::with_capacity(cap);
+
+let mut observations = env_pool.reset();
+let num_updates = TOTAL_TIMESTEPS / cap;
+
+let mut total_reward = 0.0_f64;
+let mut total_steps = 0_usize;
+
+for _update in 0..num_updates {
+    buf_obs.clear();
+    buf_actions.clear();
+    buf_log_probs.clear();
+    buf_values.clear();
+    buf_rewards.clear();
+
+    // --- Phase 1: rollout (no gradients) ----------------------------------
+    for _step in 0..NUM_STEPS {
+        let obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+        let obs_t: Tensor<Backend, 2> =
+            Tensor::from_data(TensorData::new(obs_flat, [NUM_ENVS, obs_dim]), &device);
+
+        // `get_action_host` samples an action from the actor, and returns the
+        // sampled actions, their log-probs, and the critic's value estimates —
+        // all as plain host Vecs, so no gradient graph is retained.
+        let (actions, log_probs, values) = policy.as_ref().unwrap().get_action_host(obs_t);
+
+        let results = env_pool.step(&actions);
+
+        for env_id in 0..NUM_ENVS {
+            buf_obs.extend_from_slice(&observations[env_id]);
+            buf_actions.push(actions[env_id]);
+            buf_log_probs.push(log_probs[env_id]);
+            buf_values.push(values[env_id]);
+            buf_rewards.push(results[env_id].reward);
+
+            total_reward += results[env_id].reward as f64;
+            total_steps += 1;
+
+            observations[env_id] = results[env_id].observation.clone();
+            // One-step episodes: every step ends the episode, so reset.
+            if results[env_id].terminated || results[env_id].truncated {
+                observations[env_id] = env_pool.reset_env(env_id).unwrap();
+            }
+        }
+    }
+
+    // --- Phase 2: advantages (A = reward − value) -------------------------
+    // No discounting, no GAE: SimpleBandit is a contextual bandit, so the only
+    // signal is "did this action beat the critic's expectation?".
+    let advantages: Vec<f32> = buf_rewards
+        .iter()
+        .zip(buf_values.iter())
+        .map(|(r, v)| r - v)
+        .collect();
+    let returns: Vec<f32> = buf_rewards.clone();
+
+    // Normalize advantages to zero mean / unit std — a standard PPO trick that
+    // keeps the gradient scale stable across updates.
+    let mean = advantages.iter().sum::<f32>() / advantages.len() as f32;
+    let var = advantages.iter().map(|a| (a - mean).powi(2)).sum::<f32>() / advantages.len() as f32;
+    let std = (var + 1e-8).sqrt();
+    let advantages: Vec<f32> = advantages.iter().map(|a| (a - mean) / std).collect();
+
+    // --- Phase 3: PPO update (N_EPOCHS full-batch passes) -----------------
+    let batch = advantages.len();
+    let obs_b: Tensor<Backend, 2> =
+        Tensor::from_data(TensorData::new(buf_obs.clone(), [batch, obs_dim]), &device);
+    let actions_b: Tensor<Backend, 1, Int> =
+        Tensor::from_data(TensorData::new(buf_actions.clone(), [batch]), &device);
+    let old_log_probs_b: Tensor<Backend, 1> =
+        Tensor::from_data(TensorData::new(buf_log_probs.clone(), [batch]), &device);
+    let adv_b: Tensor<Backend, 1> =
+        Tensor::from_data(TensorData::new(advantages, [batch]), &device);
+    let returns_b: Tensor<Backend, 1> =
+        Tensor::from_data(TensorData::new(returns, [batch]), &device);
+
+    for _epoch in 0..N_EPOCHS {
+        // Move the policy out, evaluate the *current* actor/critic on the
+        // stored batch, and get back new log-probs, per-sample entropy, and
+        // fresh value predictions.
+        let p = policy.take().unwrap();
+        let (new_log_probs, entropy, values_pred) =
+            p.evaluate_actions(obs_b.clone(), actions_b.clone());
+
+        // Clipped PPO surrogate: the ratio of new-to-old action probability,
+        // clamped so a single update can't move the policy too far.
+        let ratio = (new_log_probs - old_log_probs_b.clone()).exp();
+        let unclipped = ratio.clone() * adv_b.clone();
+        let clipped = ratio.clamp(1.0 - CLIP_RANGE, 1.0 + CLIP_RANGE) * adv_b.clone();
+        let policy_loss = -unclipped.min_pair(clipped).mean();
+
+        // Critic loss: predict the return (here, the reward) via MSE.
+        let value_diff = values_pred - returns_b.clone();
+        let value_loss = (value_diff.clone() * value_diff).mean();
+
+        // Entropy bonus: subtracting entropy from the loss *encourages* it,
+        // keeping the actor exploring instead of collapsing prematurely.
+        let entropy_mean = entropy.mean();
+
+        let loss =
+            policy_loss + value_loss.mul_scalar(VF_COEF) - entropy_mean.mul_scalar(ENT_COEF);
+
+        // Burn's two-step gradient dance: backward() produces raw grads, then
+        // `from_grads` ties each grad to its parameter, then `step` consumes
+        // the policy + grads and returns the updated policy.
+        let grads = loss.backward();
+        let grads = GradientsParams::from_grads(grads, &p);
+        policy = Some(optim.step(LEARNING_RATE, p, grads));
+    }
+}
+
+// After training, the running mean reward should be well above the 0.5
+// random-chance baseline. (We assert a loose bar so the doc-test is robust.)
+let success_rate = total_reward / total_steps as f64;
+assert!(
+    success_rate > 0.5,
+    "expected better-than-random after training, got {success_rate:.3}"
+);
+```
+
+## What just happened
+
+The running success rate climbs from ~0.5 (random) toward ~1.0 as the actor
+learns `action = state`. If you print it each update (the runnable
+`train_simple_bandit` example does), you'll watch it converge within a dozen
+updates and then the entropy collapses — which is *correct* here, because the
+optimal policy is deterministic. In a sequential task you'd want to keep some
+entropy for exploration; a bandit has nothing left to explore once it's solved.
+
+The three-phase structure — rollout, advantage, update — is the skeleton of
+every on-policy algorithm in this library. Tutorial 2 keeps the exact same
+shape but swaps the by-hand loop for `PPOTrainerBurn` and adds real temporal
+credit assignment (GAE) for a task where the future actually matters.
+
+## Try it yourself
+
+- **Break it on purpose:** set `ENT_COEF = 0.0` and `NUM_STEPS = 8`. With a
+  tiny batch and no exploration pressure the policy can lock onto a wrong action
+  early. This is the failure mode entropy bonuses exist to prevent.
+- **Watch it live:** run the packaged example, which logs every 10 updates:
+  ```bash
+  cargo run --release --features training --example train_simple_bandit
+  ```
+- **Bootstrap on purpose (and regret it):** change the advantage to discount
+  future value (`gamma = 0.99`) and watch learning *degrade* — concrete proof
+  that GAE is wrong for bandits. The [SimpleBandit training
+  guide](../TRAINING_SIMPLEBANDIT.md) has the full analysis.
+
+## Next
+
+[Tutorial 2 — Solving CartPole with PPO](02-cartpole-ppo.md): a real sequential
+task, the `PPOTrainerBurn`, GAE, and reading learning curves.

--- a/docs/tutorials/02-cartpole-ppo.md
+++ b/docs/tutorials/02-cartpole-ppo.md
@@ -1,0 +1,320 @@
+# Tutorial 2 — Solving CartPole with PPO
+
+> **You will:** train a PPO agent to balance CartPole, this time letting
+> `PPOTrainerBurn` own the update step, and learn to read the learning curve it
+> produces.
+> **Prerequisites:** [Tutorial 1](01-your-first-agent.md) — you should recognize
+> the rollout → advantage → update loop and Burn's move-through optimizer.
+> **Time:** ~15 minutes.
+
+Tutorial 1 hand-wrote the whole PPO update to demystify it. Now we graduate to
+a **real sequential task** and a **real trainer**. Two things change from the
+bandit:
+
+1. **The future matters.** In CartPole, the action you take now affects the
+   states you'll see for the rest of the episode. That means we need proper
+   temporal credit assignment — **GAE** (Generalized Advantage Estimation) —
+   instead of the bandit's one-line `reward − value`.
+2. **We stop writing the loss by hand.** `PPOTrainerBurn` owns the clipped
+   surrogate, value loss, entropy bonus, gradient clipping, and the optimizer
+   step. We keep control of the rollout and the advantage computation, and hand
+   the trainer a batch of tensors. This is the division of labor you'll use for
+   every on-policy trainer in Thrust.
+
+## The problem: CartPole-v1
+
+A pole is hinged on a cart; you push the cart left (`0`) or right (`1`) each
+step to keep the pole upright. The observation is four floats
+(`[cart position, cart velocity, pole angle, pole angular velocity]`), the
+reward is `+1` per step the pole stays up, and the episode ends when the pole
+falls or at 500 steps. So **episode reward == episode length**, and a solved
+agent scores near 500. Random pushing scores ~22.
+
+## GAE, briefly
+
+The advantage answers "how much better than expected was this action?". For a
+sequential task, "expected" has to account for the future, so GAE walks the
+rollout **backwards**, discounting future rewards by `gamma` and blending
+multi-step estimates with `gae_lambda`:
+
+```text
+delta_t = r_t + gamma * V(s_{t+1}) - V(s_t)
+A_t     = delta_t + gamma * lambda * A_{t+1}
+```
+
+`gamma = 0.99` says "future reward is almost as valuable as immediate reward"
+(appropriate when episodes are long and every step matters). `gae_lambda = 0.95`
+trades a little bias for much lower variance. Contrast this with Tutorial 1,
+where we set both to `0` precisely because the bandit has no future to
+bootstrap from. We compute GAE ourselves so you can see it; the helper is at the
+bottom of the code block.
+
+## The trainer surface
+
+`PPOConfig` is where the on-policy knobs live. The important ones:
+
+- `learning_rate`, `n_epochs`, `batch_size` — optimization.
+- `gamma`, `gae_lambda` — credit assignment (must match how you compute
+  advantages).
+- `clip_range` — the PPO trust-region clip (the same `0.2` from Tutorial 1).
+- `vf_coef`, `ent_coef` — value-loss and entropy weights.
+- `max_grad_norm` — gradient clipping for stability.
+
+You build a `PPOConfig`, wrap your policy and a `BurnOptimizer` in a
+`PPOTrainerBurn`, then call `train_step` once per rollout. See
+[PPO_BEST_PRACTICES.md](../PPO_BEST_PRACTICES.md) for how to tune these.
+
+## The code
+
+This runs a short training loop (small budget so it's fast in CI; bump
+`TOTAL_TIMESTEPS` for a real run). It is a doc-test, so it always compiles
+against the current API.
+
+```rust
+use burn::{
+    backend::{Autodiff, NdArray},
+    optim::AdamConfig,
+    tensor::{Int, Tensor, TensorData},
+};
+use thrust_rl::prelude::*;
+use thrust_rl::train::optimizer::BurnOptimizer;
+
+type Backend = Autodiff<NdArray<f32>>;
+
+// --- Hyperparameters -------------------------------------------------------
+const NUM_ENVS: usize = 16; // parallel CartPole copies
+const NUM_STEPS: usize = 256; // rollout length per env
+const TOTAL_TIMESTEPS: usize = 8_192; // tiny for CI; use ~200_000 for real
+const LEARNING_RATE: f64 = 3e-4;
+const HIDDEN_DIM: usize = 128;
+const GAMMA: f32 = 0.99;
+const GAE_LAMBDA: f32 = 0.95;
+const SEED: u64 = 0; // seed policy init + resets for reproducibility
+
+let device = Default::default();
+
+// --- Environment -----------------------------------------------------------
+let probe = CartPole::new();
+let obs_dim = probe.observation_space().shape[0];
+let action_dim = match probe.action_space().space_type {
+    SpaceType::Discrete(n) => n,
+    SpaceType::Box => panic!("CartPole is discrete"),
+};
+let mut env_pool = EnvPool::new(CartPole::new, NUM_ENVS);
+
+// --- Policy: a seeded 2-layer ReLU MLP with orthogonal init ----------------
+// Seeding makes the run reproducible, which is what lets a learning-curve CSV
+// be overlaid across algorithms on the same axis (see below).
+let policy_config = MlpBurnConfig {
+    num_layers: 2,
+    hidden_dim: HIDDEN_DIM,
+    use_orthogonal_init: true,
+    activation: BurnActivation::ReLU,
+    seed: Some(SEED),
+};
+let policy = MlpBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
+
+// --- Optimizer + trainer ---------------------------------------------------
+let inner_opt = AdamConfig::new().init();
+let burn_opt: BurnOptimizer<Backend, MlpBurnPolicy<Backend>, _> =
+    BurnOptimizer::new(inner_opt, LEARNING_RATE);
+
+let ppo_config = PPOConfig::new()
+    .learning_rate(LEARNING_RATE)
+    .n_epochs(10)
+    .batch_size(128)
+    .gamma(GAMMA as f64)
+    .gae_lambda(GAE_LAMBDA as f64)
+    .clip_range(0.2)
+    .clip_range_vf(0.2)
+    .vf_coef(0.5)
+    .ent_coef(0.01)
+    .max_grad_norm(0.5)
+    // Disable KL early-stop for a short, small-budget run.
+    .target_kl(1.0);
+
+let mut trainer = PPOTrainerBurn::new(ppo_config, policy, burn_opt).unwrap();
+
+let cap = NUM_STEPS * NUM_ENVS;
+let num_updates = TOTAL_TIMESTEPS / cap;
+
+// Rollout buffers, reused each update.
+let mut buf_obs: Vec<f32> = Vec::with_capacity(cap * obs_dim);
+let mut buf_actions: Vec<i64> = Vec::with_capacity(cap);
+let mut buf_log_probs: Vec<f32> = Vec::with_capacity(cap);
+let mut buf_values: Vec<f32> = Vec::with_capacity(cap);
+let mut buf_rewards: Vec<f32> = Vec::with_capacity(cap);
+let mut buf_dones: Vec<f32> = Vec::with_capacity(cap);
+
+let mut observations = env_pool.reset();
+let mut episode_lengths = [0u32; NUM_ENVS];
+let mut completed: Vec<u32> = Vec::new();
+
+for _update in 0..num_updates {
+    buf_obs.clear();
+    buf_actions.clear();
+    buf_log_probs.clear();
+    buf_values.clear();
+    buf_rewards.clear();
+    buf_dones.clear();
+
+    // --- Phase 1: rollout -------------------------------------------------
+    for _step in 0..NUM_STEPS {
+        let obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+        let obs_t: Tensor<Backend, 2> =
+            Tensor::from_data(TensorData::new(obs_flat, [NUM_ENVS, obs_dim]), &device);
+        let (actions, log_probs, values) = trainer.policy().get_action_host(obs_t);
+        let results = env_pool.step(&actions);
+
+        for env_id in 0..NUM_ENVS {
+            buf_obs.extend_from_slice(&observations[env_id]);
+            buf_actions.push(actions[env_id]);
+            buf_log_probs.push(log_probs[env_id]);
+            buf_values.push(values[env_id]);
+            buf_rewards.push(results[env_id].reward);
+
+            let done = results[env_id].terminated || results[env_id].truncated;
+            buf_dones.push(if done { 1.0 } else { 0.0 });
+
+            episode_lengths[env_id] += 1;
+            observations[env_id] = results[env_id].observation.clone();
+            if done {
+                completed.push(episode_lengths[env_id]);
+                trainer.increment_episodes(1);
+                episode_lengths[env_id] = 0;
+                observations[env_id] = env_pool.reset_env(env_id).unwrap();
+            }
+        }
+    }
+
+    // --- Phase 2: GAE (needs a value bootstrap for the final observation) --
+    let last_obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+    let last_obs_t: Tensor<Backend, 2> =
+        Tensor::from_data(TensorData::new(last_obs_flat, [NUM_ENVS, obs_dim]), &device);
+    let (_, _, last_values) = trainer.policy().get_action_host(last_obs_t);
+
+    let (advantages, returns) = compute_gae(
+        &buf_rewards, &buf_values, &buf_dones, &last_values, GAMMA, GAE_LAMBDA, NUM_STEPS, NUM_ENVS,
+    );
+
+    // --- Phase 3: hand the batch to the trainer ---------------------------
+    let batch = cap;
+    let obs_b: Tensor<Backend, 2> =
+        Tensor::from_data(TensorData::new(buf_obs.clone(), [batch, obs_dim]), &device);
+    let actions_b: Tensor<Backend, 1, Int> =
+        Tensor::from_data(TensorData::new(buf_actions.clone(), [batch]), &device);
+    let old_log_probs_b: Tensor<Backend, 1> =
+        Tensor::from_data(TensorData::new(buf_log_probs.clone(), [batch]), &device);
+    let old_values_b: Tensor<Backend, 1> =
+        Tensor::from_data(TensorData::new(buf_values.clone(), [batch]), &device);
+    let advantages_b: Tensor<Backend, 1> =
+        Tensor::from_data(TensorData::new(advantages, [batch]), &device);
+    let returns_b: Tensor<Backend, 1> =
+        Tensor::from_data(TensorData::new(returns, [batch]), &device);
+
+    // The trainer runs n_epochs of minibatched clipped-surrogate updates and
+    // returns per-update stats. The closure tells it how to score
+    // (obs, action) batches with the current policy.
+    let _stats = trainer
+        .train_step(
+            obs_b,
+            actions_b,
+            old_log_probs_b,
+            old_values_b,
+            advantages_b,
+            returns_b,
+            |p, o, a| p.evaluate_actions(o, a),
+        )
+        .unwrap();
+}
+
+// A short CI run won't fully solve CartPole, but the trainer should have run.
+// We assert only that the loop executed, to keep the doc-test fast and
+// deterministic.
+assert!(num_updates >= 1);
+let _ = completed;
+
+/// Per-env GAE. `rewards`, `values`, `dones` are flat `[T * N]` row-major
+/// (step-major: index = step * num_envs + env_id). `last_values[n]` is the
+/// value bootstrap for env `n` at the step just past the end of the rollout.
+#[allow(clippy::too_many_arguments)]
+fn compute_gae(
+    rewards: &[f32],
+    values: &[f32],
+    dones: &[f32],
+    last_values: &[f32],
+    gamma: f32,
+    gae_lambda: f32,
+    num_steps: usize,
+    num_envs: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    let cap = num_steps * num_envs;
+    let mut advantages = vec![0.0_f32; cap];
+    let mut returns = vec![0.0_f32; cap];
+    let mut last_gae = vec![0.0_f32; num_envs];
+    // Walk the rollout in reverse per env so each advantage can fold in the
+    // (already-computed) advantage of the following step.
+    for t in (0..num_steps).rev() {
+        for n in 0..num_envs {
+            let idx = t * num_envs + n;
+            let next_value = if t == num_steps - 1 {
+                last_values[n]
+            } else {
+                values[(t + 1) * num_envs + n]
+            };
+            // If the episode ended at this step, don't bootstrap across the
+            // boundary — the next state belongs to a fresh episode.
+            let next_nonterminal = 1.0 - dones[idx];
+            let delta = rewards[idx] + gamma * next_value * next_nonterminal - values[idx];
+            last_gae[n] = delta + gamma * gae_lambda * next_nonterminal * last_gae[n];
+            advantages[idx] = last_gae[n];
+            returns[idx] = advantages[idx] + values[idx];
+        }
+    }
+    (advantages, returns)
+}
+```
+
+## Reading the learning curve
+
+The packaged `train_cartpole_modern` example is the same loop with a bigger
+budget and one extra feature: set `CURVE_CSV` and it writes one
+`env_steps,mean_episode_reward` row per update.
+
+```bash
+TOTAL_TIMESTEPS=200000 CURVE_CSV=/tmp/ppo.csv \
+    cargo run --release --features training --example train_cartpole_modern
+```
+
+Because CartPole's reward is `+1`/step, `mean_episode_reward` **is** the mean
+episode length. Plot `env_steps` (x) against `mean_episode_reward` (y) and you
+should see it climb off the ~22 random baseline and head toward 500. What to
+look for:
+
+- **A rising curve** = credit assignment is working.
+- **A curve stuck near ~22** = something is off (a common cause is a
+  `gamma`/`gae_lambda` mismatch between `PPOConfig` and your `compute_gae`
+  call — they must agree).
+- **A curve that climbs then crashes** = the policy collapsed; lower the
+  learning rate or the entropy coefficient, or re-enable `target_kl`.
+
+The seed makes runs reproducible, so two algorithms (say PPO here and A2C from
+the `train_cartpole_a2c` example) can be overlaid on the same env, seed, and
+budget for an honest comparison.
+
+## Try it yourself
+
+- **Mismatch the discount on purpose:** pass `gamma = 0.0` to `compute_gae`
+  while leaving `PPOConfig::gamma(0.99)` — the returns the critic is trained on
+  no longer match the advantages, and learning stalls. Concrete proof the two
+  must agree.
+- **Shrink the pool:** set `NUM_ENVS = 1`. Fewer parallel envs means noisier
+  gradients per update; you'll need more updates to reach the same bar.
+- **Full run:** drop the CI-sized `TOTAL_TIMESTEPS` and run the packaged
+  example above with the CSV, then plot it.
+
+## Next
+
+The path splits from here — see the [tutorial index](README.md) for the full
+dependency-ordered series. Next up (Tutorial 3) is **off-policy training with
+DQN**: replay buffers, target networks, and when to reach for DQN over PPO.

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,70 @@
+# 📚 Thrust Tutorials
+
+A guided path from `cargo add thrust-rl` to a trained, deployed policy. Where
+the [Example Gallery](../EXAMPLES.md) is a *reference* (one runnable trainer per
+algorithm), this series is a *learning path*: each tutorial is a single Markdown
+file with complete, copy-paste code, and they are meant to be read in order —
+each one assumes the concepts introduced by the ones before it.
+
+## Why these are trustworthy
+
+Every `rust` code block in a landed tutorial is a **doc-test**: it is compiled
+and run by `cargo test --features training` in CI. If the library API changes
+out from under a tutorial, CI goes red — so the copy-paste code here can never
+silently rot. The mechanism lives in
+[`src/tutorials.rs`](../../src/tutorials.rs), which pulls each Markdown file in
+via `#[doc = include_str!(...)]`.
+
+## The path
+
+The series is ordered by concept dependency. Follow it top to bottom; each
+tutorial names its prerequisites in a header block.
+
+| # | Tutorial | You'll learn | Algorithm · Environment | Status |
+|---|----------|--------------|-------------------------|--------|
+| 1 | [Your first agent](01-your-first-agent.md) | The rollout → loss → update loop, by hand; actor-critic; why bandits skip GAE | Actor-critic (PPO-style) · `SimpleBandit` | ✅ Landed |
+| 2 | [Solving CartPole with PPO](02-cartpole-ppo.md) | `EnvPool`, GAE, the `PPOConfig` surface, reading learning curves (`CURVE_CSV`) | PPO · `CartPole` | ✅ Landed |
+| 3 | Off-policy training with DQN | Replay buffers, target networks, ε-annealing; when to prefer DQN over PPO | DQN (Double-DQN) · `CartPole` / `GridWorld` | 🚧 Planned ([#309](https://github.com/rjwalters/thrust/issues/309)) |
+| 4 | Continuous control with SAC | Box action spaces, tanh action squashing, automatic entropy tuning, twin critics | SAC · `PendulumSwingUp` | 🚧 Planned ([#310](https://github.com/rjwalters/thrust/issues/310)) |
+| 5 | Memory and POMDPs | When an LSTM earns its cost; recurrent rollouts and hidden-state handling | Recurrent PPO · `FlickeringCartPole` | 🚧 Planned ([#311](https://github.com/rjwalters/thrust/issues/311)) |
+| 6 | Writing your own environment | Implementing the `Environment` trait from scratch; the seeding/determinism contract | (trait impl) · tiny gridworld | 🚧 Planned ([#312](https://github.com/rjwalters/thrust/issues/312)) |
+| 7 | Train in Rust, run in the browser | Exporting to the JSON inference format and wiring it into the WASM demo | Inference export · WASM | 🚧 Planned ([#313](https://github.com/rjwalters/thrust/issues/313)) |
+
+### Dependency order, spelled out
+
+- **1 → 2**: Tutorial 1 teaches the on-policy update loop by hand so Tutorial 2
+  can hand that loop to `PPOTrainerBurn` and focus on GAE and the config surface.
+- **2 → 3**: DQN is introduced *after* PPO so the tutorial can frame off-policy
+  learning (replay, target networks) as a contrast to the on-policy loop you
+  already understand.
+- **3 → 4**: SAC (continuous control) builds on the off-policy replay machinery
+  from DQN and adds the continuous-action pieces (squashing, entropy tuning).
+- **2 → 5**: Recurrent PPO extends the Tutorial 2 PPO loop with memory; it needs
+  the on-policy loop but not the off-policy tutorials, so it can be read right
+  after Tutorial 2 by readers chasing POMDPs.
+- **1 → 6**: Writing an environment only needs the `Environment` trait from
+  Tutorial 1; it's placed late because it's most useful once you've *used*
+  several built-in envs and want your own.
+- **any → 7**: Deployment is last because it consumes a policy trained by any of
+  the earlier tutorials and takes it to the browser.
+
+## Landing plan
+
+Tutorials 1–2 land first: they unblock the crates.io newcomer path (install →
+first agent → a real trained policy). Tutorials 3–7 follow incrementally, each
+tracked by its own child issue under
+[#303](https://github.com/rjwalters/thrust/issues/303):
+[#309](https://github.com/rjwalters/thrust/issues/309) (DQN),
+[#310](https://github.com/rjwalters/thrust/issues/310) (SAC),
+[#311](https://github.com/rjwalters/thrust/issues/311) (recurrent PPO),
+[#312](https://github.com/rjwalters/thrust/issues/312) (custom env), and
+[#313](https://github.com/rjwalters/thrust/issues/313) (WASM deploy). Each future
+tutorial must meet the same bar as 1–2: a single Markdown file, complete
+copy-paste code, CI-enforced as a doc-test.
+
+## See also
+
+- [GETTING_STARTED.md](../GETTING_STARTED.md) — install and first build.
+- [EXAMPLES.md](../EXAMPLES.md) — the reference gallery of runnable trainers.
+- [PPO_BEST_PRACTICES.md](../PPO_BEST_PRACTICES.md) — tuning the on-policy knobs.
+- [BURN_BACKENDS.md](../BURN_BACKENDS.md) — swapping in a GPU backend.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,8 @@ pub mod wasm;
 ///   and its [`MlpBurnConfig`](crate::policy::mlp::MlpBurnConfig), the trainer
 ///   configs/trainers (A2C, PPO, DQN, SAC, BC), and the
 ///   [`RolloutBuffer`](crate::buffer::rollout::RolloutBuffer) /
-///   [`ReplayBuffer`](crate::buffer::replay::ReplayBuffer) experience buffers.
+///   [`ReplayBuffer`](crate::buffer::replay::ReplayBuffer) experience buffers,
+///   and the [`EnvPool`](crate::env::pool::EnvPool) vectorized env wrapper.
 ///
 /// Training-only re-exports are `#[cfg(feature = "training")]`-gated so
 /// `--no-default-features` still compiles.
@@ -126,6 +127,8 @@ pub mod prelude {
     pub use crate::buffer::replay::ReplayBuffer;
     #[cfg(feature = "training")]
     pub use crate::buffer::rollout::RolloutBuffer;
+    #[cfg(feature = "training")]
+    pub use crate::env::pool::EnvPool;
     pub use crate::env::{CartPole, Environment, SimpleBandit, SpaceInfo, SpaceType, StepResult};
     #[cfg(feature = "training")]
     pub use crate::policy::mlp::{BurnActivation, MlpBurnConfig, MlpBurnPolicy};
@@ -135,6 +138,15 @@ pub mod prelude {
         PPOTrainerBurn, SacConfig, SacTrainer,
     };
 }
+
+/// Guided tutorial series (requires the `training` feature).
+///
+/// A dependency-ordered path from install to a trained, deployed policy.
+/// Each tutorial's code is doc-tested, so the copy-paste snippets in the
+/// prose are CI-enforced against the live API. See the module docs for the
+/// index, or read the Markdown source under `docs/tutorials/`.
+#[cfg(feature = "training")]
+pub mod tutorials;
 
 /// Current version of thrust-rl
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/tutorials.rs
+++ b/src/tutorials.rs
@@ -1,0 +1,40 @@
+//! Guided tutorial series: from `cargo add thrust-rl` to a trained,
+//! deployed policy.
+//!
+//! Each tutorial is a single Markdown file under [`docs/tutorials/`] whose
+//! `rust` code blocks are pulled in here with `#[doc = include_str!(...)]`.
+//! Because they are rendered as rustdoc, every code block is compiled and
+//! run as a doc-test by `cargo test --features training` — so the copy-paste
+//! code in the prose can never rot out of sync with the library API. This is
+//! the CI-enforced mechanism the tutorial series is built on.
+//!
+//! The Markdown files are the single source of truth: read them in
+//! [`docs/tutorials/`] (rendered nicely on GitHub) or here on docs.rs. The
+//! series is ordered by concept dependency — see
+//! [`docs/tutorials/README.md`] for the full dependency-ordered outline.
+//!
+//! [`docs/tutorials/`]: https://github.com/rjwalters/thrust/tree/main/docs/tutorials
+//! [`docs/tutorials/README.md`]: https://github.com/rjwalters/thrust/blob/main/docs/tutorials/README.md
+//!
+//! # Landed tutorials
+//!
+//! - [`tutorial_01_first_agent`](crate::tutorials::tutorial_01_first_agent) —
+//!   Your first agent (SimpleBandit + actor-critic; the rollout → loss →
+//!   update loop).
+//! - [`tutorial_02_cartpole_ppo`](crate::tutorials::tutorial_02_cartpole_ppo) —
+//!   Solving CartPole with PPO (`EnvPool`, GAE, the config surface, reading
+//!   learning curves).
+
+/// Tutorial 1 — Your first agent.
+///
+/// See the rendered Markdown at
+/// [`docs/tutorials/01-your-first-agent.md`](https://github.com/rjwalters/thrust/blob/main/docs/tutorials/01-your-first-agent.md).
+#[doc = include_str!("../docs/tutorials/01-your-first-agent.md")]
+pub mod tutorial_01_first_agent {}
+
+/// Tutorial 2 — Solving CartPole with PPO.
+///
+/// See the rendered Markdown at
+/// [`docs/tutorials/02-cartpole-ppo.md`](https://github.com/rjwalters/thrust/blob/main/docs/tutorials/02-cartpole-ppo.md).
+#[doc = include_str!("../docs/tutorials/02-cartpole-ppo.md")]
+pub mod tutorial_02_cartpole_ppo {}

--- a/src/tutorials.rs
+++ b/src/tutorials.rs
@@ -19,8 +19,8 @@
 //! # Landed tutorials
 //!
 //! - [`tutorial_01_first_agent`](crate::tutorials::tutorial_01_first_agent) —
-//!   Your first agent (SimpleBandit + actor-critic; the rollout → loss →
-//!   update loop).
+//!   Your first agent (SimpleBandit + actor-critic; the rollout → loss → update
+//!   loop).
 //! - [`tutorial_02_cartpole_ppo`](crate::tutorials::tutorial_02_cartpole_ppo) —
 //!   Solving CartPole with PPO (`EnvPool`, GAE, the config surface, reading
 //!   learning curves).


### PR DESCRIPTION
Closes #303

## What

Adds a `docs/tutorials/` **learning path** — a dependency-ordered route from
`cargo add thrust-rl` to a trained, deployed policy — complementing the
reference-style [Example Gallery](../blob/main/docs/EXAMPLES.md).

### Landed in this PR (acceptance criterion 3: tutorials 1–2 first)

| # | Tutorial | Content |
|---|----------|---------|
| 1 | [Your first agent](../blob/feature/issue-303/docs/tutorials/01-your-first-agent.md) | SimpleBandit + actor-critic; the rollout → loss → update loop written **by hand** so nothing hides behind a trainer. |
| 2 | [Solving CartPole with PPO](../blob/feature/issue-303/docs/tutorials/02-cartpole-ppo.md) | `EnvPool`, GAE, the `PPOConfig` surface, `PPOTrainerBurn`, and reading learning curves (`CURVE_CSV`). |

Plus `docs/tutorials/README.md`: the **full 7-tutorial dependency-ordered
outline** with the dependency graph spelled out, linked from the main README and
`docs/GETTING_STARTED.md`.

### CI enforcement — no rotting snippets (acceptance criterion 1)

Each tutorial is a single Markdown file whose ```` ```rust ```` code blocks are
pulled into `src/tutorials.rs` via `#[doc = include_str!(...)]`. Because they
render as rustdoc, **every code block is compiled and run as a doc-test by
`cargo test --features training`** — the same mechanism the crate already uses
for its `src/lib.rs` quick-start example. If the API changes, CI goes red. The
`tutorials` module is `#[cfg(feature = "training")]`-gated so
`--no-default-features` still compiles.

This is the CI-enforced-doc-test option the issue calls for (as opposed to a
separate `tutorials/` example target), chosen because it keeps the copy-paste
code and the prose in **one** source of truth per tutorial.

### Supporting changes

- Add `EnvPool` to the crate `prelude` (used throughout the tutorials; a natural
  addition alongside the trainers/buffers already there).
- Link the series from `README.md` (new "Tutorials" subsection under Quick
  Start) and `docs/GETTING_STARTED.md` (new step 5).

## Deferred (acceptance criterion 3: 3–7 follow incrementally)

Filed as child issues referencing #303, each with the same quality bar
(single Markdown file, copy-paste code, CI-doc-tested):

- #309 — Tutorial 3: Off-policy training with DQN
- #310 — Tutorial 4: Continuous control with SAC
- #311 — Tutorial 5: Memory and POMDPs (recurrent PPO)
- #312 — Tutorial 6: Writing your own environment
- #313 — Tutorial 7: Train in Rust, run in the browser

Landing a high-quality 1–2 + index now (rather than all 7) keeps this PR
reviewable and unblocks the crates.io newcomer path immediately; the deferred
tutorials touch distinct algorithms/subsystems and are cleanly parallelizable.

## Verification

All run locally in the worktree:

- `cargo fmt -- --check` — clean
- `cargo clippy --all-targets --features training -- -D warnings` — clean
- `cargo test --features training` — full suite passes (both tutorial
  doc-tests included: `tutorials::tutorial_01_first_agent`,
  `tutorials::tutorial_02_cartpole_ppo`)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- `cargo check --no-default-features` — clean (tutorials module correctly gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)