### PR TITLE
feat(env): memory-hard suite — T-maze POMDP + burst-structured flickering CartPole (#302)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,6 +232,24 @@ name = "recurrent_ppo_flickering_cartpole"
 path = "examples/games/cartpole/recurrent_ppo_flickering_cartpole.rs"
 required-features = ["training"]
 
+# Burst-flickering CartPole — correlated-occlusion POMDP (issue #302). Same
+# blank rate p as the i.i.d. flickering env above, but blanks arrive in Markov
+# bursts (mean run length ~4) the reactive baseline cannot bridge. Runs LSTM
+# and MLP under BOTH regimes and reports the memory gap widening vs. i.i.d.
+[[example]]
+name = "recurrent_ppo_burst_flickering_cartpole"
+path = "examples/games/cartpole/recurrent_ppo_burst_flickering_cartpole.rs"
+required-features = ["training"]
+
+# T-maze — the provably memory-hard POMDP (Bakker 2001, issue #302). A cue is
+# shown only at step 0; the agent must recall it N steps later at the junction,
+# where a memoryless policy is provably at chance. Contrasts LSTM vs MLP across
+# a corridor-length sweep N in {5, 10, 20} to locate the memory-horizon knee.
+[[example]]
+name = "recurrent_ppo_t_maze"
+path = "examples/games/t_maze/recurrent_ppo_t_maze.rs"
+required-features = ["training"]
+
 # Velocity-masked CartPole — retained as a DOCUMENTED NEGATIVE RESULT (issue
 # #287): a 500k-step run showed a memoryless [x, theta] controller solves it
 # and beats the LSTM, so velocity-masking alone is not a POMDP. Superseded by

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -28,6 +28,8 @@ the feature list, e.g. `--features "training,wgpu"`. See
 | [`train_cartpole_async`](#train_cartpole_async) | PPO (async actor-learner, V-trace) | CartPole | Single-agent |
 | [`recurrent_ppo_flickering_cartpole`](#recurrent_ppo_flickering_cartpole) | Recurrent PPO (LSTM) vs MLP | FlickeringCartPole | POMDP contrast |
 | [`recurrent_ppo_masked_cartpole`](#recurrent_ppo_masked_cartpole) | Recurrent PPO (LSTM) vs MLP | MaskedCartPole | Negative result |
+| [`recurrent_ppo_burst_flickering_cartpole`](#recurrent_ppo_burst_flickering_cartpole) | Recurrent PPO (LSTM) vs MLP | FlickeringCartPole (burst) | POMDP contrast |
+| [`recurrent_ppo_t_maze`](#recurrent_ppo_t_maze) | Recurrent PPO (LSTM) vs MLP | TMaze | POMDP contrast |
 | [`train_dqn_grid_world`](#train_dqn_grid_world) | DQN | GridWorld | Single-agent |
 | [`train_bc_cartpole`](#train_bc_cartpole) | Behavioral Cloning | CartPole | Imitation |
 | [`train_sac`](#train_sac) | SAC | PendulumSwingUp | Continuous control |
@@ -196,6 +198,43 @@ cargo run --release --features training --example recurrent_ppo_masked_cartpole
 **Environment variables:** `TOTAL_TIMESTEPS` (per arm).
 
 Source: [`examples/games/cartpole/recurrent_ppo_masked_cartpole.rs`](../examples/games/cartpole/recurrent_ppo_masked_cartpole.rs)
+
+### `recurrent_ppo_burst_flickering_cartpole`
+
+The **correlated-occlusion** counterpart of the flickering benchmark (issue
+#302): the same LSTM-vs-MLP contrast run under *both* i.i.d. and
+burst-structured (Markov) dropout at the same blank rate `p = 0.5`, so the
+effect of temporal correlation on the memory advantage is measured directly.
+Measured (200k steps/arm): i.i.d. gap 263.4 (LSTM 422 vs MLP 158.7); burst gap
+102.7 (LSTM 203.1 vs MLP 100.4) — bursts harden the task for both arms and
+narrow the absolute gap, reported honestly against the widening hypothesis.
+
+```bash
+cargo run --release --features training --example recurrent_ppo_burst_flickering_cartpole
+```
+
+**Environment variables:** `TOTAL_TIMESTEPS` (per arm), `FLICKER_PROB`
+(default `0.5`), `BURST_LEN` (mean blank-run length, default `4`).
+
+Source: [`examples/games/cartpole/recurrent_ppo_burst_flickering_cartpole.rs`](../examples/games/cartpole/recurrent_ppo_burst_flickering_cartpole.rs)
+
+### `recurrent_ppo_t_maze`
+
+The **provably memory-hard** contrast (Bakker 2001, issue #302): a cue shown
+only at step 0 must be recalled `N` steps later at the T-junction, where the
+observation is identical for both cues — a memoryless policy is at chance (50%)
+by construction. Sweeps corridor length `N ∈ {5, 10, 20}`. Measured (200k
+steps/arm): LSTM final junction accuracy 100/99/92% at N=5/10/20; MLP at chance
+(45/50/39%).
+
+```bash
+cargo run --release --features training --example recurrent_ppo_t_maze
+```
+
+**Environment variables:** `TOTAL_TIMESTEPS` (per arm), `TMAZE_SWEEP`
+(comma-separated corridor lengths, default `5,10,20`).
+
+Source: [`examples/games/t_maze/recurrent_ppo_t_maze.rs`](../examples/games/t_maze/recurrent_ppo_t_maze.rs)
 
 ### `train_dqn_grid_world`
 

--- a/examples/games/cartpole/recurrent_ppo_burst_flickering_cartpole.rs
+++ b/examples/games/cartpole/recurrent_ppo_burst_flickering_cartpole.rs
@@ -1,0 +1,671 @@
+//! Recurrent PPO on **burst-flickering** CartPole (correlated-occlusion POMDP).
+//!
+//! Part of the recurrent-policy epic (#262), issue #302. This example is the
+//! correlated-dropout counterpart of `recurrent_ppo_flickering_cartpole`
+//! (#298). It trains an [`LstmBurnPolicy`](thrust_rl::policy::lstm::LstmBurnPolicy)
+//! and a feedforward [`MlpBurnPolicy`](thrust_rl::policy::mlp::MlpBurnPolicy)
+//! baseline on [`FlickeringCartPole`](thrust_rl::env::FlickeringCartPole), under
+//! **two** dropout regimes at the *same* blank rate `p`:
+//!
+//! 1. **i.i.d.** — each frame blanked independently with probability `p` (the
+//!    #298 protocol).
+//! 2. **burst** — blanks arrive in correlated runs via a two-state Markov chain
+//!    with mean blank-run length `burst_len` (default 4) and the *same*
+//!    stationary blank fraction `p`.
+//!
+//! # Why the burst regime
+//!
+//! i.i.d. dropout is only *partially* memory-hard: a reactive controller
+//! compensates for isolated blanked frames at CartPole's control rate, so the
+//! MLP baseline does not collapse (#298 measured LSTM ~484 vs MLP ~176). Burst
+//! dropout keeps the same overall blank rate but forces the blanks into
+//! multi-step runs the reactive controller cannot bridge — its last real
+//! observation is several steps stale. The recurrent policy integrates over the
+//! gap. The hypothesis is that correlation *widens* the LSTM-vs-MLP gap relative
+//! to i.i.d. This example reports both gaps side by side so the effect is
+//! measured directly (honestly, either direction).
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Run all four arms (iid LSTM/MLP, burst LSTM/MLP) and print both gaps:
+//! cargo run --example recurrent_ppo_burst_flickering_cartpole --features training --release
+//! ```
+//!
+//! Env overrides: `TOTAL_TIMESTEPS` (per-arm budget, default 200k), `FLICKER_PROB`
+//! (blank rate, default 0.5), `BURST_LEN` (mean blank-run length, default 4).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use burn::{
+    backend::Autodiff,
+    nn::LstmState,
+    optim::AdamConfig,
+    tensor::{Int, Tensor, TensorData, activation},
+};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use thrust_rl::{
+    buffer::rollout::RecurrentRolloutBuffer,
+    env::{Environment, SpaceType, flickering_cartpole::FlickeringCartPole, pool::EnvPool},
+    policy::{
+        lstm::{LstmBurnConfig, LstmBurnPolicy},
+        mlp::{BurnActivation, MlpBurnConfig, MlpBurnPolicy},
+    },
+    train::{
+        optimizer::BurnOptimizer,
+        ppo::{PPOConfig, PPOTrainerBurn, RecurrentPPOTrainer},
+    },
+};
+
+type InnerBackend = burn::backend::NdArray<f32>;
+type Backend = Autodiff<InnerBackend>;
+
+const NUM_ENVS: usize = 16;
+const NUM_STEPS: usize = 128;
+const HIDDEN_DIM: usize = 64;
+const DEFAULT_TIMESTEPS: usize = 200_000;
+const DEFAULT_FLICKER_PROB: f64 = 0.5;
+const DEFAULT_BURST_LEN: f64 = 4.0;
+const LSTM_LR: f64 = 1.5e-3;
+const MLP_LR: f64 = 3e-4;
+const GAMMA: f32 = 0.99;
+const GAE_LAMBDA: f32 = 0.95;
+const N_EPOCHS: usize = 4;
+const ENVS_PER_MINIBATCH: usize = 4;
+const SEED: u64 = 0;
+/// Train-time reward scale (both arms, symmetric); see #298 for the rationale.
+const REWARD_SCALE: f32 = 0.02;
+const SOLVED_THRESHOLD: f32 = 195.0;
+
+/// Which dropout regime an arm uses.
+#[derive(Clone, Copy, PartialEq)]
+enum Regime {
+    /// i.i.d. per-frame dropout (the #298 protocol).
+    Iid,
+    /// Correlated bursts (Markov) with mean blank-run length `burst_len`.
+    Burst(f64),
+}
+
+impl Regime {
+    fn label(self) -> &'static str {
+        match self {
+            Regime::Iid => "iid",
+            Regime::Burst(_) => "burst",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ArmResult {
+    final_mean: f32,
+    best_mean: f32,
+}
+
+/// Build a pool of flickering CartPoles under the given dropout regime, with
+/// per-env seeded streams (env `i` gets seed `base_seed*1000 + i`). Both policy
+/// arms in a regime call this with the same `base_seed`, so they see the
+/// identical dropout stream.
+fn make_pool(base_seed: u64, flicker_prob: f64, regime: Regime) -> EnvPool<FlickeringCartPole> {
+    let ctr = AtomicU64::new(base_seed.wrapping_mul(1000));
+    EnvPool::new(
+        move || {
+            let s = ctr.fetch_add(1, Ordering::Relaxed);
+            match regime {
+                Regime::Iid => FlickeringCartPole::with_seed_and_probability(s, flicker_prob),
+                Regime::Burst(l) => {
+                    FlickeringCartPole::with_seed_probability_and_burst(s, flicker_prob, l)
+                }
+            }
+        },
+        NUM_ENVS,
+    )
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt().with_env_filter("info").init();
+
+    let total_timesteps: usize = std::env::var("TOTAL_TIMESTEPS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_TIMESTEPS);
+    let flicker_prob: f64 = std::env::var("FLICKER_PROB")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_FLICKER_PROB);
+    let burst_len: f64 = std::env::var("BURST_LEN")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_BURST_LEN);
+
+    tracing::info!("Recurrent PPO on burst-flickering CartPole (correlated-occlusion POMDP)");
+    tracing::info!("  num_envs={}  num_steps={}  hidden_dim={}", NUM_ENVS, NUM_STEPS, HIDDEN_DIM);
+    tracing::info!("  flicker_prob={}  burst_len={}", flicker_prob, burst_len);
+    tracing::info!("  total_timesteps={} per arm (4 arms)", total_timesteps);
+    tracing::info!("------------------------------------------------------------");
+
+    let regimes = [Regime::Iid, Regime::Burst(burst_len)];
+    // (regime, lstm, mlp)
+    let mut results: Vec<(Regime, ArmResult, ArmResult)> = Vec::new();
+
+    for &regime in &regimes {
+        tracing::info!("########## Regime: {} ##########", regime.label());
+        tracing::info!(">>> [{}] Training LSTM (recurrent)", regime.label());
+        let lstm = run_lstm(total_timesteps, flicker_prob, regime)?;
+        tracing::info!(">>> [{}] Training feedforward (MLP) baseline", regime.label());
+        let mlp = run_feedforward(total_timesteps, flicker_prob, regime)?;
+        results.push((regime, lstm, mlp));
+    }
+
+    tracing::info!("============================================================");
+    tracing::info!("Results (mean return of last ≤100 episodes, RAW units):");
+    let mut iid_gap = None;
+    let mut burst_gap = None;
+    for (regime, lstm, mlp) in &results {
+        let gap = lstm.best_mean - mlp.best_mean;
+        tracing::info!(
+            "  [{:<5}] LSTM final {:.1} / best {:.1}   MLP final {:.1} / best {:.1}   gap(best) {:.1}",
+            regime.label(),
+            lstm.final_mean,
+            lstm.best_mean,
+            mlp.final_mean,
+            mlp.best_mean,
+            gap,
+        );
+        tracing::info!(
+            "          LSTM {} solved bar {} (peak {:.1})",
+            if lstm.best_mean > SOLVED_THRESHOLD { "CLEARED" } else { "MISSED" },
+            SOLVED_THRESHOLD,
+            lstm.best_mean,
+        );
+        match regime {
+            Regime::Iid => iid_gap = Some(gap),
+            Regime::Burst(_) => burst_gap = Some(gap),
+        }
+    }
+
+    if let (Some(i), Some(b)) = (iid_gap, burst_gap) {
+        tracing::info!("------------------------------------------------------------");
+        tracing::info!("  i.i.d.  memory gap (LSTM-MLP, best): {:.1}", i);
+        tracing::info!("  burst   memory gap (LSTM-MLP, best): {:.1}", b);
+        let delta = b - i;
+        tracing::info!(
+            "  Correlation {} the memory advantage by {:.1} ({}).",
+            if delta > 0.0 { "WIDENED" } else { "did NOT widen" },
+            delta.abs(),
+            if delta > 0.0 {
+                "burst dropout is harder for the reactive baseline, as hypothesized"
+            } else {
+                "reported honestly against the hypothesis"
+            }
+        );
+    }
+
+    Ok(())
+}
+
+fn run_lstm(total_timesteps: usize, flicker_prob: f64, regime: Regime) -> Result<ArmResult> {
+    let start = std::time::Instant::now();
+    let device = Default::default();
+
+    let probe = FlickeringCartPole::new();
+    let obs_dim = probe.observation_space().shape[0];
+    let action_dim = match probe.action_space().space_type {
+        SpaceType::Discrete(n) => n,
+        _ => panic!("FlickeringCartPole must be discrete"),
+    };
+
+    let mut env_pool = make_pool(SEED, flicker_prob, regime);
+
+    let policy_config =
+        LstmBurnConfig { hidden_dim: HIDDEN_DIM, ..Default::default() }.with_seed(SEED);
+    let policy =
+        LstmBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
+
+    let lr = LSTM_LR;
+    let inner_opt = AdamConfig::new().init();
+    let burn_opt: BurnOptimizer<Backend, LstmBurnPolicy<Backend>, _> =
+        BurnOptimizer::new(inner_opt, lr);
+
+    let ppo_config = PPOConfig::new()
+        .learning_rate(lr)
+        .n_epochs(N_EPOCHS)
+        .gamma(GAMMA as f64)
+        .gae_lambda(GAE_LAMBDA as f64)
+        .clip_range(0.2)
+        .clip_range_vf(0.2)
+        .vf_coef(0.5)
+        .ent_coef(0.01)
+        .max_grad_norm(0.5)
+        .target_kl(1.0);
+
+    let mut trainer = RecurrentPPOTrainer::new(ppo_config, policy, burn_opt, device)?;
+    let num_updates = total_timesteps / (NUM_STEPS * NUM_ENVS);
+
+    let mut norm = ObsNormalizer::new(obs_dim);
+    let mut buffer = RecurrentRolloutBuffer::new(NUM_STEPS, NUM_ENVS, obs_dim, HIDDEN_DIM);
+    let raw0 = env_pool.reset();
+    let mut observations: Vec<Vec<f32>> = raw0.iter().map(|o| norm.normalize(o)).collect();
+    let mut rng = StdRng::seed_from_u64(SEED);
+
+    let mut episode_returns = [0.0_f32; NUM_ENVS];
+    let mut completed: Vec<f32> = Vec::new();
+    let mut lstm_state: Option<LstmState<Backend, 2>> = None;
+    let mut last_h = vec![0.0_f32; NUM_ENVS * HIDDEN_DIM];
+    let mut last_c = vec![0.0_f32; NUM_ENVS * HIDDEN_DIM];
+    let mut total_env_steps = 0usize;
+    let mut last_mean = 0.0_f32;
+    let mut best_mean = 0.0_f32;
+
+    for update in 0..num_updates {
+        buffer.reset();
+
+        for step in 0..NUM_STEPS {
+            let obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+            let obs_t = Tensor::<Backend, 2>::from_data(
+                TensorData::new(obs_flat, [NUM_ENVS, obs_dim]),
+                &device,
+            );
+
+            let (logits, values_t, new_state) =
+                trainer.policy().forward_step(obs_t, lstm_state.take());
+            let (actions, log_probs, values_host) = sample_actions(&logits, &values_t, &mut rng);
+
+            let results = env_pool.step(&actions);
+
+            let mut h_host: Vec<f32> = new_state.hidden.into_data().to_vec().unwrap();
+            let mut c_host: Vec<f32> = new_state.cell.into_data().to_vec().unwrap();
+
+            for env in 0..NUM_ENVS {
+                let r = &results[env];
+                buffer.add(
+                    step,
+                    env,
+                    &observations[env],
+                    actions[env],
+                    r.reward * REWARD_SCALE,
+                    values_host[env],
+                    log_probs[env],
+                    r.terminated,
+                    r.truncated,
+                );
+                episode_returns[env] += r.reward;
+                observations[env] = norm.normalize(&r.observation);
+
+                if r.terminated || r.truncated {
+                    completed.push(episode_returns[env]);
+                    episode_returns[env] = 0.0;
+                    trainer.increment_episodes(1);
+                    for k in 0..HIDDEN_DIM {
+                        h_host[env * HIDDEN_DIM + k] = 0.0;
+                        c_host[env * HIDDEN_DIM + k] = 0.0;
+                    }
+                    let raw = env_pool.reset_env(env)?;
+                    observations[env] = norm.normalize(&raw);
+                }
+            }
+
+            last_h.copy_from_slice(&h_host);
+            last_c.copy_from_slice(&c_host);
+            let hidden_t = Tensor::<Backend, 2>::from_data(
+                TensorData::new(h_host, [NUM_ENVS, HIDDEN_DIM]),
+                &device,
+            );
+            let cell_t = Tensor::<Backend, 2>::from_data(
+                TensorData::new(c_host, [NUM_ENVS, HIDDEN_DIM]),
+                &device,
+            );
+            lstm_state = Some(LstmState::new(cell_t, hidden_t));
+            total_env_steps += NUM_ENVS;
+        }
+
+        let last_obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+        let last_obs_t = Tensor::<Backend, 2>::from_data(
+            TensorData::new(last_obs_flat, [NUM_ENVS, obs_dim]),
+            &device,
+        );
+        let boot_hidden = Tensor::<Backend, 2>::from_data(
+            TensorData::new(last_h.clone(), [NUM_ENVS, HIDDEN_DIM]),
+            &device,
+        );
+        let boot_cell = Tensor::<Backend, 2>::from_data(
+            TensorData::new(last_c.clone(), [NUM_ENVS, HIDDEN_DIM]),
+            &device,
+        );
+        let (_, last_values_t, _) = trainer
+            .policy()
+            .forward_step(last_obs_t, Some(LstmState::new(boot_cell, boot_hidden)));
+        let last_values: Vec<f32> = last_values_t.into_data().to_vec().unwrap();
+
+        buffer.compute_advantages(&last_values, GAMMA, GAE_LAMBDA);
+
+        let frac = 1.0 - (update as f64) / (num_updates.max(1) as f64);
+        trainer.set_learning_rate(lr * frac.max(0.05));
+
+        let stats =
+            trainer.train_step(&buffer, ENVS_PER_MINIBATCH, |p, obs_seq, actions, starts| {
+                p.evaluate_sequences(obs_seq, actions, None, starts)
+            })?;
+
+        let final_hidden: Vec<Vec<f32>> = (0..NUM_ENVS)
+            .map(|e| last_h[e * HIDDEN_DIM..(e + 1) * HIDDEN_DIM].to_vec())
+            .collect();
+        let final_cell: Vec<Vec<f32>> = (0..NUM_ENVS)
+            .map(|e| last_c[e * HIDDEN_DIM..(e + 1) * HIDDEN_DIM].to_vec())
+            .collect();
+        buffer.seed_warm_start(NUM_STEPS - 1, &final_hidden, &final_cell);
+
+        lstm_state = None;
+
+        if !completed.is_empty() {
+            let n = completed.len();
+            let recent = &completed[n.saturating_sub(100)..];
+            last_mean = recent.iter().sum::<f32>() / recent.len() as f32;
+            best_mean = best_mean.max(last_mean);
+        }
+
+        if update % 10 == 0 || update == num_updates - 1 {
+            tracing::info!(
+                "  [lstm {:<5}] update {:>3}/{}  env_steps={:>7}  episodes={:>5}  mean_return(last≤100)={:6.1}  entropy={:5.3}  explained_var={:5.3}",
+                regime.label(),
+                update + 1,
+                num_updates,
+                total_env_steps,
+                trainer.total_episodes(),
+                last_mean,
+                stats.entropy,
+                stats.explained_var,
+            );
+        }
+    }
+
+    tracing::info!(
+        "  [lstm {}] done in {:.1}s — final {:.1} (best {:.1})",
+        regime.label(),
+        start.elapsed().as_secs_f64(),
+        last_mean,
+        best_mean
+    );
+    Ok(ArmResult { final_mean: last_mean, best_mean })
+}
+
+fn run_feedforward(total_timesteps: usize, flicker_prob: f64, regime: Regime) -> Result<ArmResult> {
+    let start = std::time::Instant::now();
+    let device = Default::default();
+
+    let probe = FlickeringCartPole::new();
+    let obs_dim = probe.observation_space().shape[0];
+    let action_dim = match probe.action_space().space_type {
+        SpaceType::Discrete(n) => n,
+        _ => panic!("FlickeringCartPole must be discrete"),
+    };
+
+    let mut env_pool = make_pool(SEED, flicker_prob, regime);
+
+    let policy_config = MlpBurnConfig {
+        num_layers: 2,
+        hidden_dim: 128,
+        use_orthogonal_init: true,
+        activation: BurnActivation::ReLU,
+        seed: Some(SEED),
+    };
+    let policy = MlpBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
+
+    let inner_opt = AdamConfig::new().init();
+    let burn_opt: BurnOptimizer<Backend, MlpBurnPolicy<Backend>, _> =
+        BurnOptimizer::new(inner_opt, MLP_LR);
+
+    let ppo_config = PPOConfig::new()
+        .learning_rate(MLP_LR)
+        .n_epochs(10)
+        .batch_size(128)
+        .gamma(GAMMA as f64)
+        .gae_lambda(GAE_LAMBDA as f64)
+        .clip_range(0.2)
+        .clip_range_vf(0.2)
+        .vf_coef(0.5)
+        .ent_coef(0.01)
+        .max_grad_norm(0.5)
+        .target_kl(1.0);
+
+    let mut trainer = PPOTrainerBurn::new(ppo_config, policy, burn_opt)?;
+    let num_updates = total_timesteps / (NUM_STEPS * NUM_ENVS);
+
+    let cap = NUM_STEPS * NUM_ENVS;
+    let mut buf_obs: Vec<f32> = Vec::with_capacity(cap * obs_dim);
+    let mut buf_actions: Vec<i64> = Vec::with_capacity(cap);
+    let mut buf_log_probs: Vec<f32> = Vec::with_capacity(cap);
+    let mut buf_values: Vec<f32> = Vec::with_capacity(cap);
+    let mut buf_rewards: Vec<f32> = Vec::with_capacity(cap);
+    let mut buf_dones: Vec<f32> = Vec::with_capacity(cap);
+
+    let mut norm = ObsNormalizer::new(obs_dim);
+    let mut observations: Vec<Vec<f32>> =
+        env_pool.reset().iter().map(|o| norm.normalize(o)).collect();
+    let mut episode_returns = [0.0_f32; NUM_ENVS];
+    let mut completed: Vec<f32> = Vec::new();
+    let mut total_env_steps = 0usize;
+    let mut last_mean = 0.0_f32;
+    let mut best_mean = 0.0_f32;
+
+    for update in 0..num_updates {
+        buf_obs.clear();
+        buf_actions.clear();
+        buf_log_probs.clear();
+        buf_values.clear();
+        buf_rewards.clear();
+        buf_dones.clear();
+
+        for _step in 0..NUM_STEPS {
+            let obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+            let obs_t = Tensor::<Backend, 2>::from_data(
+                TensorData::new(obs_flat, [NUM_ENVS, obs_dim]),
+                &device,
+            );
+            let (actions, log_probs, values) = trainer.policy().get_action_host(obs_t);
+            let results = env_pool.step(&actions);
+
+            for env_id in 0..NUM_ENVS {
+                buf_obs.extend_from_slice(&observations[env_id]);
+                buf_actions.push(actions[env_id]);
+                buf_log_probs.push(log_probs[env_id]);
+                buf_values.push(values[env_id]);
+                buf_rewards.push(results[env_id].reward * REWARD_SCALE);
+                let done = results[env_id].terminated || results[env_id].truncated;
+                buf_dones.push(if done { 1.0 } else { 0.0 });
+
+                episode_returns[env_id] += results[env_id].reward;
+                observations[env_id] = norm.normalize(&results[env_id].observation);
+                if done {
+                    completed.push(episode_returns[env_id]);
+                    episode_returns[env_id] = 0.0;
+                    trainer.increment_episodes(1);
+                    let raw = env_pool.reset_env(env_id)?;
+                    observations[env_id] = norm.normalize(&raw);
+                }
+            }
+            total_env_steps += NUM_ENVS;
+        }
+
+        let last_obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+        let last_obs_t = Tensor::<Backend, 2>::from_data(
+            TensorData::new(last_obs_flat, [NUM_ENVS, obs_dim]),
+            &device,
+        );
+        let (_, _, last_values_host) = trainer.policy().get_action_host(last_obs_t);
+
+        let (advantages_host, returns_host) = compute_gae(
+            &buf_rewards,
+            &buf_values,
+            &buf_dones,
+            &last_values_host,
+            GAMMA,
+            GAE_LAMBDA,
+            NUM_STEPS,
+            NUM_ENVS,
+        );
+
+        let batch = NUM_STEPS * NUM_ENVS;
+        let obs_b = Tensor::<Backend, 2>::from_data(
+            TensorData::new(buf_obs.clone(), [batch, obs_dim]),
+            &device,
+        );
+        let actions_b = Tensor::<Backend, 1, Int>::from_data(
+            TensorData::new(buf_actions.clone(), [batch]),
+            &device,
+        );
+        let old_log_probs_b = Tensor::<Backend, 1>::from_data(
+            TensorData::new(buf_log_probs.clone(), [batch]),
+            &device,
+        );
+        let old_values_b =
+            Tensor::<Backend, 1>::from_data(TensorData::new(buf_values.clone(), [batch]), &device);
+        let advantages_b =
+            Tensor::<Backend, 1>::from_data(TensorData::new(advantages_host, [batch]), &device);
+        let returns_b =
+            Tensor::<Backend, 1>::from_data(TensorData::new(returns_host, [batch]), &device);
+
+        let stats = trainer.train_step(
+            obs_b,
+            actions_b,
+            old_log_probs_b,
+            old_values_b,
+            advantages_b,
+            returns_b,
+            |p, o, a| p.evaluate_actions(o, a),
+        )?;
+
+        if !completed.is_empty() {
+            let n = completed.len();
+            let recent = &completed[n.saturating_sub(100)..];
+            last_mean = recent.iter().sum::<f32>() / recent.len() as f32;
+            best_mean = best_mean.max(last_mean);
+        }
+
+        if update % 10 == 0 || update == num_updates - 1 {
+            tracing::info!(
+                "  [mlp  {:<5}] update {:>3}/{}  env_steps={:>7}  episodes={:>4}  mean_return(last≤100)={:6.1}  entropy={:5.3}",
+                regime.label(),
+                update + 1,
+                num_updates,
+                total_env_steps,
+                trainer.total_episodes(),
+                last_mean,
+                stats.entropy,
+            );
+        }
+    }
+
+    tracing::info!(
+        "  [mlp  {}] done in {:.1}s — final {:.1} (best {:.1})",
+        regime.label(),
+        start.elapsed().as_secs_f64(),
+        last_mean,
+        best_mean
+    );
+    Ok(ArmResult { final_mean: last_mean, best_mean })
+}
+
+/// Running per-dimension observation standardizer with flicker-aware
+/// pass-through (identical to `recurrent_ppo_flickering_cartpole`). Blanked
+/// (all-zero) frames pass through unchanged and are excluded from the running
+/// statistics.
+struct ObsNormalizer {
+    mean: Vec<f64>,
+    m2: Vec<f64>,
+    count: f64,
+}
+
+impl ObsNormalizer {
+    fn new(dim: usize) -> Self {
+        Self { mean: vec![0.0; dim], m2: vec![0.0; dim], count: 0.0 }
+    }
+
+    fn normalize(&mut self, obs: &[f32]) -> Vec<f32> {
+        if obs.iter().all(|&x| x == 0.0) {
+            return obs.to_vec();
+        }
+        self.count += 1.0;
+        for (i, &xf) in obs.iter().enumerate() {
+            let x = xf as f64;
+            let delta = x - self.mean[i];
+            self.mean[i] += delta / self.count;
+            self.m2[i] += delta * (x - self.mean[i]);
+        }
+        obs.iter()
+            .enumerate()
+            .map(|(i, &x)| {
+                let std = (self.m2[i] / self.count).sqrt().max(1e-4);
+                (((x as f64 - self.mean[i]) / std).clamp(-10.0, 10.0)) as f32
+            })
+            .collect()
+    }
+}
+
+/// Host-side categorical sampling from LSTM `forward_step` outputs.
+fn sample_actions(
+    logits: &Tensor<Backend, 2>,
+    values: &Tensor<Backend, 1>,
+    rng: &mut StdRng,
+) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
+    let [n, a] = logits.dims();
+    let probs = activation::softmax(logits.clone(), 1);
+    let log_probs = activation::log_softmax(logits.clone(), 1);
+    let probs_host: Vec<f32> = probs.into_data().to_vec().unwrap();
+    let log_probs_host: Vec<f32> = log_probs.into_data().to_vec().unwrap();
+    let values_host: Vec<f32> = values.clone().into_data().to_vec().unwrap();
+
+    let mut actions = Vec::with_capacity(n);
+    let mut chosen_log_probs = Vec::with_capacity(n);
+    for i in 0..n {
+        let u: f32 = rng.random();
+        let mut cum = 0.0_f32;
+        let mut chosen = a - 1;
+        for j in 0..a {
+            cum += probs_host[i * a + j];
+            if u <= cum {
+                chosen = j;
+                break;
+            }
+        }
+        actions.push(chosen as i64);
+        chosen_log_probs.push(log_probs_host[i * a + chosen]);
+    }
+    (actions, chosen_log_probs, values_host)
+}
+
+/// Per-env host-side GAE for the feedforward baseline (step-major `[T * N]`).
+#[allow(clippy::too_many_arguments)]
+fn compute_gae(
+    rewards: &[f32],
+    values: &[f32],
+    dones: &[f32],
+    last_values: &[f32],
+    gamma: f32,
+    gae_lambda: f32,
+    num_steps: usize,
+    num_envs: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    let cap = num_steps * num_envs;
+    let mut advantages = vec![0.0_f32; cap];
+    let mut returns = vec![0.0_f32; cap];
+
+    let mut last_gae = vec![0.0_f32; num_envs];
+    for t in (0..num_steps).rev() {
+        for n in 0..num_envs {
+            let idx = t * num_envs + n;
+            let next_value = if t == num_steps - 1 {
+                last_values[n]
+            } else {
+                values[(t + 1) * num_envs + n]
+            };
+            let next_nonterminal = 1.0 - dones[idx];
+            let delta = rewards[idx] + gamma * next_value * next_nonterminal - values[idx];
+            last_gae[n] = delta + gamma * gae_lambda * next_nonterminal * last_gae[n];
+            advantages[idx] = last_gae[n];
+            returns[idx] = advantages[idx] + values[idx];
+        }
+    }
+
+    (advantages, returns)
+}

--- a/examples/games/cartpole/recurrent_ppo_burst_flickering_cartpole.rs
+++ b/examples/games/cartpole/recurrent_ppo_burst_flickering_cartpole.rs
@@ -2,10 +2,11 @@
 //!
 //! Part of the recurrent-policy epic (#262), issue #302. This example is the
 //! correlated-dropout counterpart of `recurrent_ppo_flickering_cartpole`
-//! (#298). It trains an [`LstmBurnPolicy`](thrust_rl::policy::lstm::LstmBurnPolicy)
+//! (#298). It trains an
+//! [`LstmBurnPolicy`](thrust_rl::policy::lstm::LstmBurnPolicy)
 //! and a feedforward [`MlpBurnPolicy`](thrust_rl::policy::mlp::MlpBurnPolicy)
-//! baseline on [`FlickeringCartPole`](thrust_rl::env::FlickeringCartPole), under
-//! **two** dropout regimes at the *same* blank rate `p`:
+//! baseline on [`FlickeringCartPole`](thrust_rl::env::FlickeringCartPole),
+//! under **two** dropout regimes at the *same* blank rate `p`:
 //!
 //! 1. **i.i.d.** — each frame blanked independently with probability `p` (the
 //!    #298 protocol).
@@ -21,9 +22,26 @@
 //! dropout keeps the same overall blank rate but forces the blanks into
 //! multi-step runs the reactive controller cannot bridge — its last real
 //! observation is several steps stale. The recurrent policy integrates over the
-//! gap. The hypothesis is that correlation *widens* the LSTM-vs-MLP gap relative
-//! to i.i.d. This example reports both gaps side by side so the effect is
-//! measured directly (honestly, either direction).
+//! gap. The hypothesis is that correlation *widens* the LSTM-vs-MLP gap
+//! relative to i.i.d. This example reports both gaps side by side so the effect
+//! is measured directly (honestly, either direction).
+//!
+//! # Measured results (issue #302, 200k steps/arm, p=0.5, burst_len=4, seed 0)
+//!
+//! ```text
+//! regime   LSTM (final/best)   MLP (final/best)   gap (best)
+//! iid        420.0 / 422.0       144.5 / 158.7       263.4
+//! burst      178.9 / 203.1        89.0 / 100.4       102.7
+//! ```
+//!
+//! **Honest negative on the absolute-gap hypothesis**: correlated bursts made
+//! the task harder for BOTH policy classes, and the absolute LSTM−MLP gap
+//! *narrowed* (263 → 103) rather than widened. The relative picture is more
+//! nuanced: the burst LSTM still clears the 195 solved bar (peak 203) while the
+//! burst MLP drops to ~100 — roughly half its i.i.d. ceiling — so memory
+//! remains decisively load-bearing; the LSTM simply loses more absolute return
+//! to the harder observation stream than the MLP has left to lose. Consistent
+//! with the #298 i.i.d. reference (LSTM 484 vs MLP 176 at 500k; here 200k).
 //!
 //! # Usage
 //!
@@ -32,8 +50,9 @@
 //! cargo run --example recurrent_ppo_burst_flickering_cartpole --features training --release
 //! ```
 //!
-//! Env overrides: `TOTAL_TIMESTEPS` (per-arm budget, default 200k), `FLICKER_PROB`
-//! (blank rate, default 0.5), `BURST_LEN` (mean blank-run length, default 4).
+//! Env overrides: `TOTAL_TIMESTEPS` (per-arm budget, default 200k),
+//! `FLICKER_PROB` (blank rate, default 0.5), `BURST_LEN` (mean blank-run
+//! length, default 4).
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -174,7 +193,11 @@ fn main() -> Result<()> {
         );
         tracing::info!(
             "          LSTM {} solved bar {} (peak {:.1})",
-            if lstm.best_mean > SOLVED_THRESHOLD { "CLEARED" } else { "MISSED" },
+            if lstm.best_mean > SOLVED_THRESHOLD {
+                "CLEARED"
+            } else {
+                "MISSED"
+            },
             SOLVED_THRESHOLD,
             lstm.best_mean,
         );
@@ -191,7 +214,11 @@ fn main() -> Result<()> {
         let delta = b - i;
         tracing::info!(
             "  Correlation {} the memory advantage by {:.1} ({}).",
-            if delta > 0.0 { "WIDENED" } else { "did NOT widen" },
+            if delta > 0.0 {
+                "WIDENED"
+            } else {
+                "did NOT widen"
+            },
             delta.abs(),
             if delta > 0.0 {
                 "burst dropout is harder for the reactive baseline, as hypothesized"

--- a/examples/games/t_maze/recurrent_ppo_t_maze.rs
+++ b/examples/games/t_maze/recurrent_ppo_t_maze.rs
@@ -1,0 +1,640 @@
+//! Recurrent PPO on the T-maze (a *provably* memory-hard POMDP).
+//!
+//! Part of the recurrent-policy epic (#262), completing the memory-hard
+//! environment suite alongside the flickering-CartPole contrast (#298). This
+//! example trains an
+//! [`LstmBurnPolicy`](thrust_rl::policy::lstm::LstmBurnPolicy) with
+//! [`RecurrentPPOTrainer`](thrust_rl::train::ppo::RecurrentPPOTrainer) on the
+//! [`TMaze`](thrust_rl::env::TMaze) (Bakker 2001) and contrasts it against a
+//! feedforward [`MlpBurnPolicy`](thrust_rl::policy::mlp::MlpBurnPolicy) baseline
+//! on the *same* task.
+//!
+//! # Why the T-maze (and not just flickering)
+//!
+//! FlickeringCartPole (#298) is only *approximately* memory-hard: a reactive
+//! controller partially compensates for i.i.d. blanked frames at CartPole's
+//! control rate, so the feedforward baseline does not collapse to chance. The
+//! T-maze removes that ambiguity. A cue is shown **only at step 0**; the agent
+//! must recall it `N` steps later to turn the right way at the junction, where
+//! the observation is identical for both cues. A memoryless policy is therefore
+//! *provably* at chance (50%) — no amount of capacity helps, because the cue is
+//! information-theoretically absent from the junction observation it acts on.
+//!
+//! This doubles as a **self-test on the environment**: if the feedforward
+//! baseline beats chance by a meaningful margin, the env has an information leak
+//! (a bug), not the policy a talent. The expected qualitative result is a clean
+//! separation — LSTM well above 90% junction accuracy at `N = 10`, MLP pinned at
+//! ~50%.
+//!
+//! # Corridor-length sweep
+//!
+//! The corridor length `N` is the memory horizon the policy must bridge. The
+//! example sweeps `N ∈ {5, 10, 20}` (override with `TMAZE_SWEEP="5,10,20"`) and
+//! reports junction accuracy for both arms at each `N`, documenting where the
+//! LSTM's effective memory horizon begins to degrade.
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Full sweep, both arms:
+//! cargo run --example recurrent_ppo_t_maze --features training --release
+//!
+//! # One corridor length, custom budget:
+//! TMAZE_SWEEP=10 TOTAL_TIMESTEPS=200000 \
+//!   cargo run --example recurrent_ppo_t_maze --features training --release
+//! ```
+
+use anyhow::Result;
+use burn::{
+    backend::Autodiff,
+    nn::LstmState,
+    optim::AdamConfig,
+    tensor::{Int, Tensor, TensorData, activation},
+};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use std::sync::atomic::{AtomicU64, Ordering};
+use thrust_rl::{
+    buffer::rollout::RecurrentRolloutBuffer,
+    env::{Environment, SpaceType, pool::EnvPool, t_maze::TMaze},
+    policy::{
+        lstm::{LstmBurnConfig, LstmBurnPolicy},
+        mlp::{BurnActivation, MlpBurnConfig, MlpBurnPolicy},
+    },
+    train::{
+        optimizer::BurnOptimizer,
+        ppo::{PPOConfig, PPOTrainerBurn, RecurrentPPOTrainer},
+    },
+};
+
+type InnerBackend = burn::backend::NdArray<f32>;
+type Backend = Autodiff<InnerBackend>;
+
+const NUM_ENVS: usize = 16;
+const NUM_STEPS: usize = 128;
+const HIDDEN_DIM: usize = 64;
+const DEFAULT_TIMESTEPS: usize = 200_000;
+const DEFAULT_SWEEP: &[usize] = &[5, 10, 20];
+/// LSTM learning rate (annealed linearly toward a small floor over the run).
+const LSTM_LR: f64 = 1e-3;
+/// Feedforward baseline learning rate.
+const MLP_LR: f64 = 3e-4;
+/// Discount. The reward is a single ±1 at the junction, so credit must
+/// propagate back across the whole corridor; a high gamma keeps the step-0 cue
+/// action in the loop even at `N = 20` (`0.99^20 ≈ 0.82`).
+const GAMMA: f32 = 0.99;
+const GAE_LAMBDA: f32 = 0.95;
+const N_EPOCHS: usize = 4;
+const ENVS_PER_MINIBATCH: usize = 4;
+const SEED: u64 = 0;
+
+/// Junction accuracy that counts as "solved" for the LSTM (acceptance criterion
+/// 1 at `N = 10` is >90%).
+const SOLVED_ACC: f32 = 0.90;
+
+/// Outcome of one training arm: junction accuracy over the last ≤100 episodes.
+///
+/// `final_acc` is the accuracy at the end of training; `best_acc` is the peak of
+/// the moving accuracy observed at any update — reported together so end-of-run
+/// oscillation hides nothing.
+#[derive(Clone, Copy)]
+struct ArmResult {
+    final_acc: f32,
+    best_acc: f32,
+}
+
+/// Build an [`EnvPool`] of [`TMaze`]s with per-env seeded cue streams (env `i`
+/// gets seed `base_seed*1000 + i`), reproducible yet decorrelated across the
+/// pool. Both arms call this with the same `base_seed`, so they see the
+/// identical cue stream — the only difference between the runs is the policy
+/// class (memory vs. no memory).
+fn make_pool(base_seed: u64, corridor_length: usize) -> EnvPool<TMaze> {
+    let ctr = AtomicU64::new(base_seed.wrapping_mul(1000));
+    EnvPool::new(
+        || {
+            let s = ctr.fetch_add(1, Ordering::Relaxed);
+            TMaze::with_seed_and_corridor_length(s, corridor_length)
+        },
+        NUM_ENVS,
+    )
+}
+
+/// Junction accuracy over the last ≤100 completed episodes. Each episode return
+/// is exactly `+1` (correct turn) or `-1` (wrong), so accuracy is the fraction
+/// of recent returns that are positive.
+fn recent_accuracy(completed: &[f32]) -> f32 {
+    if completed.is_empty() {
+        return 0.0;
+    }
+    let n = completed.len();
+    let recent = &completed[n.saturating_sub(100)..];
+    let correct = recent.iter().filter(|&&r| r > 0.0).count();
+    correct as f32 / recent.len() as f32
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt().with_env_filter("info").init();
+
+    let total_timesteps: usize = std::env::var("TOTAL_TIMESTEPS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_TIMESTEPS);
+    let sweep: Vec<usize> = std::env::var("TMAZE_SWEEP")
+        .ok()
+        .map(|s| s.split(',').filter_map(|t| t.trim().parse().ok()).collect())
+        .filter(|v: &Vec<usize>| !v.is_empty())
+        .unwrap_or_else(|| DEFAULT_SWEEP.to_vec());
+    let mode = std::env::args().nth(1).unwrap_or_default();
+
+    tracing::info!("Recurrent PPO on the T-maze (Bakker 2001, provably memory-hard POMDP)");
+    tracing::info!("  backend         = NdArray<f32> + Autodiff (CPU)");
+    tracing::info!("  num_envs        = {}", NUM_ENVS);
+    tracing::info!("  num_steps       = {}", NUM_STEPS);
+    tracing::info!("  hidden_dim      = {}", HIDDEN_DIM);
+    tracing::info!("  corridor sweep  = {:?}", sweep);
+    tracing::info!("  total_timesteps = {} per arm", total_timesteps);
+    tracing::info!("------------------------------------------------------------");
+
+    let mut rows: Vec<(usize, Option<ArmResult>, Option<ArmResult>)> = Vec::new();
+
+    for &n in &sweep {
+        tracing::info!("############### Corridor length N = {} ###############", n);
+        let lstm = if mode != "baseline" {
+            tracing::info!(">>> [N={}] Training LSTM (recurrent) policy", n);
+            Some(run_lstm(total_timesteps, n)?)
+        } else {
+            None
+        };
+        let mlp = if mode != "lstm" {
+            tracing::info!(">>> [N={}] Training feedforward (MLP) baseline", n);
+            Some(run_feedforward(total_timesteps, n)?)
+        } else {
+            None
+        };
+        rows.push((n, lstm, mlp));
+    }
+
+    tracing::info!("============================================================");
+    tracing::info!("T-maze junction accuracy (last ≤100 episodes) by corridor length:");
+    tracing::info!("  N      LSTM(final/best)     MLP(final/best)    verdict");
+    for (n, lstm, mlp) in &rows {
+        let ls = lstm
+            .map(|r| format!("{:.0}%/{:.0}%", r.final_acc * 100.0, r.best_acc * 100.0))
+            .unwrap_or_else(|| "   -   ".into());
+        let ms = mlp
+            .map(|r| format!("{:.0}%/{:.0}%", r.final_acc * 100.0, r.best_acc * 100.0))
+            .unwrap_or_else(|| "   -   ".into());
+        let verdict = match (lstm, mlp) {
+            (Some(l), Some(m)) => {
+                let lstm_solved = l.best_acc > SOLVED_ACC;
+                // A memoryless policy is provably at chance; flag any material
+                // over-performance as a possible env information leak.
+                let mlp_leak = m.best_acc > 0.65;
+                format!(
+                    "LSTM {} 90%; MLP {}",
+                    if lstm_solved { "CLEARS" } else { "below" },
+                    if mlp_leak {
+                        "ABOVE CHANCE (investigate leak!)"
+                    } else {
+                        "~chance (as expected)"
+                    }
+                )
+            }
+            _ => String::new(),
+        };
+        tracing::info!("  N={:<4}  {:<18}  {:<16}  {}", n, ls, ms, verdict);
+    }
+    tracing::info!("------------------------------------------------------------");
+    tracing::info!(
+        "Expectation: LSTM accuracy stays high at small N and degrades as N grows"
+    );
+    tracing::info!(
+        "past its effective memory horizon; MLP stays ~50% for all N (provable)."
+    );
+
+    Ok(())
+}
+
+/// Train the recurrent LSTM policy on a T-maze of the given corridor length.
+fn run_lstm(total_timesteps: usize, corridor_length: usize) -> Result<ArmResult> {
+    let start = std::time::Instant::now();
+    let device = Default::default();
+
+    let probe = TMaze::with_corridor_length(corridor_length);
+    let obs_dim = probe.observation_space().shape[0];
+    let action_dim = match probe.action_space().space_type {
+        SpaceType::Discrete(n) => n,
+        _ => panic!("TMaze must be discrete"),
+    };
+
+    let mut env_pool = make_pool(SEED, corridor_length);
+
+    let policy_config =
+        LstmBurnConfig { hidden_dim: HIDDEN_DIM, ..Default::default() }.with_seed(SEED);
+    let policy =
+        LstmBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
+
+    let lr = LSTM_LR;
+    let inner_opt = AdamConfig::new().init();
+    let burn_opt: BurnOptimizer<Backend, LstmBurnPolicy<Backend>, _> =
+        BurnOptimizer::new(inner_opt, lr);
+
+    let ppo_config = PPOConfig::new()
+        .learning_rate(lr)
+        .n_epochs(N_EPOCHS)
+        .gamma(GAMMA as f64)
+        .gae_lambda(GAE_LAMBDA as f64)
+        .clip_range(0.2)
+        .clip_range_vf(0.2)
+        .vf_coef(0.5)
+        .ent_coef(0.02)
+        .max_grad_norm(0.5)
+        .target_kl(1.0);
+
+    let mut trainer = RecurrentPPOTrainer::new(ppo_config, policy, burn_opt, device)?;
+
+    let num_updates = total_timesteps / (NUM_STEPS * NUM_ENVS);
+
+    // The T-maze observation is already O(1) ([±1, 0/1, 0/1]); no normalization
+    // is applied. Normalizing per-dimension would rescale the one-shot cue
+    // channel (nonzero only at step 0) by its tiny across-stream std, which
+    // would distort the memory signal. Raw observations are fed to both arms.
+    let mut buffer = RecurrentRolloutBuffer::new(NUM_STEPS, NUM_ENVS, obs_dim, HIDDEN_DIM);
+    let mut observations: Vec<Vec<f32>> = env_pool.reset();
+    let mut rng = StdRng::seed_from_u64(SEED);
+
+    let mut episode_returns = [0.0_f32; NUM_ENVS];
+    let mut completed: Vec<f32> = Vec::new();
+    let mut lstm_state: Option<LstmState<Backend, 2>> = None;
+    let mut last_h = vec![0.0_f32; NUM_ENVS * HIDDEN_DIM];
+    let mut last_c = vec![0.0_f32; NUM_ENVS * HIDDEN_DIM];
+    let mut total_env_steps = 0usize;
+    let mut last_acc = 0.0_f32;
+    let mut best_acc = 0.0_f32;
+
+    for update in 0..num_updates {
+        buffer.reset();
+
+        for step in 0..NUM_STEPS {
+            let obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+            let obs_t = Tensor::<Backend, 2>::from_data(
+                TensorData::new(obs_flat, [NUM_ENVS, obs_dim]),
+                &device,
+            );
+
+            let (logits, values_t, new_state) =
+                trainer.policy().forward_step(obs_t, lstm_state.take());
+            let (actions, log_probs, values_host) = sample_actions(&logits, &values_t, &mut rng);
+
+            let results = env_pool.step(&actions);
+
+            let mut h_host: Vec<f32> = new_state.hidden.into_data().to_vec().unwrap();
+            let mut c_host: Vec<f32> = new_state.cell.into_data().to_vec().unwrap();
+
+            for env in 0..NUM_ENVS {
+                let r = &results[env];
+                buffer.add(
+                    step,
+                    env,
+                    &observations[env],
+                    actions[env],
+                    r.reward,
+                    values_host[env],
+                    log_probs[env],
+                    r.terminated,
+                    r.truncated,
+                );
+                episode_returns[env] += r.reward;
+                observations[env] = r.observation.clone();
+
+                if r.terminated || r.truncated {
+                    completed.push(episode_returns[env]);
+                    episode_returns[env] = 0.0;
+                    trainer.increment_episodes(1);
+                    for k in 0..HIDDEN_DIM {
+                        h_host[env * HIDDEN_DIM + k] = 0.0;
+                        c_host[env * HIDDEN_DIM + k] = 0.0;
+                    }
+                    observations[env] = env_pool.reset_env(env)?;
+                }
+            }
+
+            last_h.copy_from_slice(&h_host);
+            last_c.copy_from_slice(&c_host);
+            let hidden_t = Tensor::<Backend, 2>::from_data(
+                TensorData::new(h_host, [NUM_ENVS, HIDDEN_DIM]),
+                &device,
+            );
+            let cell_t = Tensor::<Backend, 2>::from_data(
+                TensorData::new(c_host, [NUM_ENVS, HIDDEN_DIM]),
+                &device,
+            );
+            lstm_state = Some(LstmState::new(cell_t, hidden_t));
+            total_env_steps += NUM_ENVS;
+        }
+
+        let last_obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+        let last_obs_t = Tensor::<Backend, 2>::from_data(
+            TensorData::new(last_obs_flat, [NUM_ENVS, obs_dim]),
+            &device,
+        );
+        let boot_hidden = Tensor::<Backend, 2>::from_data(
+            TensorData::new(last_h.clone(), [NUM_ENVS, HIDDEN_DIM]),
+            &device,
+        );
+        let boot_cell = Tensor::<Backend, 2>::from_data(
+            TensorData::new(last_c.clone(), [NUM_ENVS, HIDDEN_DIM]),
+            &device,
+        );
+        let (_, last_values_t, _) = trainer
+            .policy()
+            .forward_step(last_obs_t, Some(LstmState::new(boot_cell, boot_hidden)));
+        let last_values: Vec<f32> = last_values_t.into_data().to_vec().unwrap();
+
+        buffer.compute_advantages(&last_values, GAMMA, GAE_LAMBDA);
+
+        let frac = 1.0 - (update as f64) / (num_updates.max(1) as f64);
+        trainer.set_learning_rate(lr * frac.max(0.05));
+
+        let stats =
+            trainer.train_step(&buffer, ENVS_PER_MINIBATCH, |p, obs_seq, actions, starts| {
+                p.evaluate_sequences(obs_seq, actions, None, starts)
+            })?;
+
+        let final_hidden: Vec<Vec<f32>> = (0..NUM_ENVS)
+            .map(|e| last_h[e * HIDDEN_DIM..(e + 1) * HIDDEN_DIM].to_vec())
+            .collect();
+        let final_cell: Vec<Vec<f32>> = (0..NUM_ENVS)
+            .map(|e| last_c[e * HIDDEN_DIM..(e + 1) * HIDDEN_DIM].to_vec())
+            .collect();
+        buffer.seed_warm_start(NUM_STEPS - 1, &final_hidden, &final_cell);
+
+        lstm_state = None;
+
+        last_acc = recent_accuracy(&completed);
+        best_acc = best_acc.max(last_acc);
+
+        if update % 10 == 0 || update == num_updates - 1 {
+            tracing::info!(
+                "  [lstm N={:>2}] update {:>3}/{}  env_steps={:>7}  episodes={:>5}  junction_acc(last≤100)={:5.1}%  entropy={:5.3}  explained_var={:5.3}",
+                corridor_length,
+                update + 1,
+                num_updates,
+                total_env_steps,
+                trainer.total_episodes(),
+                last_acc * 100.0,
+                stats.entropy,
+                stats.explained_var,
+            );
+        }
+    }
+
+    tracing::info!(
+        "  [lstm N={}] done in {:.1}s — final acc {:.1}% (best {:.1}%)",
+        corridor_length,
+        start.elapsed().as_secs_f64(),
+        last_acc * 100.0,
+        best_acc * 100.0
+    );
+    Ok(ArmResult { final_acc: last_acc, best_acc })
+}
+
+/// Train the feedforward MLP baseline on the SAME T-maze. Expected to sit at
+/// ~50% junction accuracy for every `N` — it cannot recall the step-0 cue.
+fn run_feedforward(total_timesteps: usize, corridor_length: usize) -> Result<ArmResult> {
+    let start = std::time::Instant::now();
+    let device = Default::default();
+
+    let probe = TMaze::with_corridor_length(corridor_length);
+    let obs_dim = probe.observation_space().shape[0];
+    let action_dim = match probe.action_space().space_type {
+        SpaceType::Discrete(n) => n,
+        _ => panic!("TMaze must be discrete"),
+    };
+
+    let mut env_pool = make_pool(SEED, corridor_length);
+
+    let policy_config = MlpBurnConfig {
+        num_layers: 2,
+        hidden_dim: 128,
+        use_orthogonal_init: true,
+        activation: BurnActivation::ReLU,
+        seed: Some(SEED),
+    };
+    let policy = MlpBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
+
+    let inner_opt = AdamConfig::new().init();
+    let burn_opt: BurnOptimizer<Backend, MlpBurnPolicy<Backend>, _> =
+        BurnOptimizer::new(inner_opt, MLP_LR);
+
+    let ppo_config = PPOConfig::new()
+        .learning_rate(MLP_LR)
+        .n_epochs(10)
+        .batch_size(128)
+        .gamma(GAMMA as f64)
+        .gae_lambda(GAE_LAMBDA as f64)
+        .clip_range(0.2)
+        .clip_range_vf(0.2)
+        .vf_coef(0.5)
+        .ent_coef(0.02)
+        .max_grad_norm(0.5)
+        .target_kl(1.0);
+
+    let mut trainer = PPOTrainerBurn::new(ppo_config, policy, burn_opt)?;
+
+    let num_updates = total_timesteps / (NUM_STEPS * NUM_ENVS);
+
+    let cap = NUM_STEPS * NUM_ENVS;
+    let mut buf_obs: Vec<f32> = Vec::with_capacity(cap * obs_dim);
+    let mut buf_actions: Vec<i64> = Vec::with_capacity(cap);
+    let mut buf_log_probs: Vec<f32> = Vec::with_capacity(cap);
+    let mut buf_values: Vec<f32> = Vec::with_capacity(cap);
+    let mut buf_rewards: Vec<f32> = Vec::with_capacity(cap);
+    let mut buf_dones: Vec<f32> = Vec::with_capacity(cap);
+
+    let mut observations: Vec<Vec<f32>> = env_pool.reset();
+    let mut episode_returns = [0.0_f32; NUM_ENVS];
+    let mut completed: Vec<f32> = Vec::new();
+    let mut total_env_steps = 0usize;
+    let mut last_acc = 0.0_f32;
+    let mut best_acc = 0.0_f32;
+
+    for update in 0..num_updates {
+        buf_obs.clear();
+        buf_actions.clear();
+        buf_log_probs.clear();
+        buf_values.clear();
+        buf_rewards.clear();
+        buf_dones.clear();
+
+        for _step in 0..NUM_STEPS {
+            let obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+            let obs_t = Tensor::<Backend, 2>::from_data(
+                TensorData::new(obs_flat, [NUM_ENVS, obs_dim]),
+                &device,
+            );
+            let (actions, log_probs, values) = trainer.policy().get_action_host(obs_t);
+            let results = env_pool.step(&actions);
+
+            for env_id in 0..NUM_ENVS {
+                buf_obs.extend_from_slice(&observations[env_id]);
+                buf_actions.push(actions[env_id]);
+                buf_log_probs.push(log_probs[env_id]);
+                buf_values.push(values[env_id]);
+                buf_rewards.push(results[env_id].reward);
+                let done = results[env_id].terminated || results[env_id].truncated;
+                buf_dones.push(if done { 1.0 } else { 0.0 });
+
+                episode_returns[env_id] += results[env_id].reward;
+                observations[env_id] = results[env_id].observation.clone();
+                if done {
+                    completed.push(episode_returns[env_id]);
+                    episode_returns[env_id] = 0.0;
+                    trainer.increment_episodes(1);
+                    observations[env_id] = env_pool.reset_env(env_id)?;
+                }
+            }
+            total_env_steps += NUM_ENVS;
+        }
+
+        let last_obs_flat: Vec<f32> = observations.iter().flatten().copied().collect();
+        let last_obs_t = Tensor::<Backend, 2>::from_data(
+            TensorData::new(last_obs_flat, [NUM_ENVS, obs_dim]),
+            &device,
+        );
+        let (_, _, last_values_host) = trainer.policy().get_action_host(last_obs_t);
+
+        let (advantages_host, returns_host) = compute_gae(
+            &buf_rewards,
+            &buf_values,
+            &buf_dones,
+            &last_values_host,
+            GAMMA,
+            GAE_LAMBDA,
+            NUM_STEPS,
+            NUM_ENVS,
+        );
+
+        let batch = NUM_STEPS * NUM_ENVS;
+        let obs_b = Tensor::<Backend, 2>::from_data(
+            TensorData::new(buf_obs.clone(), [batch, obs_dim]),
+            &device,
+        );
+        let actions_b = Tensor::<Backend, 1, Int>::from_data(
+            TensorData::new(buf_actions.clone(), [batch]),
+            &device,
+        );
+        let old_log_probs_b = Tensor::<Backend, 1>::from_data(
+            TensorData::new(buf_log_probs.clone(), [batch]),
+            &device,
+        );
+        let old_values_b =
+            Tensor::<Backend, 1>::from_data(TensorData::new(buf_values.clone(), [batch]), &device);
+        let advantages_b =
+            Tensor::<Backend, 1>::from_data(TensorData::new(advantages_host, [batch]), &device);
+        let returns_b =
+            Tensor::<Backend, 1>::from_data(TensorData::new(returns_host, [batch]), &device);
+
+        let stats = trainer.train_step(
+            obs_b,
+            actions_b,
+            old_log_probs_b,
+            old_values_b,
+            advantages_b,
+            returns_b,
+            |p, o, a| p.evaluate_actions(o, a),
+        )?;
+
+        last_acc = recent_accuracy(&completed);
+        best_acc = best_acc.max(last_acc);
+
+        if update % 10 == 0 || update == num_updates - 1 {
+            tracing::info!(
+                "  [mlp  N={:>2}] update {:>3}/{}  env_steps={:>7}  episodes={:>5}  junction_acc(last≤100)={:5.1}%  entropy={:5.3}",
+                corridor_length,
+                update + 1,
+                num_updates,
+                total_env_steps,
+                trainer.total_episodes(),
+                last_acc * 100.0,
+                stats.entropy,
+            );
+        }
+    }
+
+    tracing::info!(
+        "  [mlp  N={}] done in {:.1}s — final acc {:.1}% (best {:.1}%)",
+        corridor_length,
+        start.elapsed().as_secs_f64(),
+        last_acc * 100.0,
+        best_acc * 100.0
+    );
+    Ok(ArmResult { final_acc: last_acc, best_acc })
+}
+
+/// Host-side categorical sampling from LSTM `forward_step` outputs.
+fn sample_actions(
+    logits: &Tensor<Backend, 2>,
+    values: &Tensor<Backend, 1>,
+    rng: &mut StdRng,
+) -> (Vec<i64>, Vec<f32>, Vec<f32>) {
+    let [n, a] = logits.dims();
+    let probs = activation::softmax(logits.clone(), 1);
+    let log_probs = activation::log_softmax(logits.clone(), 1);
+    let probs_host: Vec<f32> = probs.into_data().to_vec().unwrap();
+    let log_probs_host: Vec<f32> = log_probs.into_data().to_vec().unwrap();
+    let values_host: Vec<f32> = values.clone().into_data().to_vec().unwrap();
+
+    let mut actions = Vec::with_capacity(n);
+    let mut chosen_log_probs = Vec::with_capacity(n);
+    for i in 0..n {
+        let u: f32 = rng.random();
+        let mut cum = 0.0_f32;
+        let mut chosen = a - 1;
+        for j in 0..a {
+            cum += probs_host[i * a + j];
+            if u <= cum {
+                chosen = j;
+                break;
+            }
+        }
+        actions.push(chosen as i64);
+        chosen_log_probs.push(log_probs_host[i * a + chosen]);
+    }
+    (actions, chosen_log_probs, values_host)
+}
+
+/// Per-env host-side GAE for the feedforward baseline (step-major `[T * N]`).
+#[allow(clippy::too_many_arguments)]
+fn compute_gae(
+    rewards: &[f32],
+    values: &[f32],
+    dones: &[f32],
+    last_values: &[f32],
+    gamma: f32,
+    gae_lambda: f32,
+    num_steps: usize,
+    num_envs: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    let cap = num_steps * num_envs;
+    let mut advantages = vec![0.0_f32; cap];
+    let mut returns = vec![0.0_f32; cap];
+
+    let mut last_gae = vec![0.0_f32; num_envs];
+    for t in (0..num_steps).rev() {
+        for n in 0..num_envs {
+            let idx = t * num_envs + n;
+            let next_value = if t == num_steps - 1 {
+                last_values[n]
+            } else {
+                values[(t + 1) * num_envs + n]
+            };
+            let next_nonterminal = 1.0 - dones[idx];
+            let delta = rewards[idx] + gamma * next_value * next_nonterminal - values[idx];
+            last_gae[n] = delta + gamma * gae_lambda * next_nonterminal * last_gae[n];
+            advantages[idx] = last_gae[n];
+            returns[idx] = advantages[idx] + values[idx];
+        }
+    }
+
+    (advantages, returns)
+}

--- a/examples/games/t_maze/recurrent_ppo_t_maze.rs
+++ b/examples/games/t_maze/recurrent_ppo_t_maze.rs
@@ -6,8 +6,8 @@
 //! [`LstmBurnPolicy`](thrust_rl::policy::lstm::LstmBurnPolicy) with
 //! [`RecurrentPPOTrainer`](thrust_rl::train::ppo::RecurrentPPOTrainer) on the
 //! [`TMaze`](thrust_rl::env::TMaze) (Bakker 2001) and contrasts it against a
-//! feedforward [`MlpBurnPolicy`](thrust_rl::policy::mlp::MlpBurnPolicy) baseline
-//! on the *same* task.
+//! feedforward [`MlpBurnPolicy`](thrust_rl::policy::mlp::MlpBurnPolicy)
+//! baseline on the *same* task.
 //!
 //! # Why the T-maze (and not just flickering)
 //!
@@ -21,10 +21,10 @@
 //! information-theoretically absent from the junction observation it acts on.
 //!
 //! This doubles as a **self-test on the environment**: if the feedforward
-//! baseline beats chance by a meaningful margin, the env has an information leak
-//! (a bug), not the policy a talent. The expected qualitative result is a clean
-//! separation — LSTM well above 90% junction accuracy at `N = 10`, MLP pinned at
-//! ~50%.
+//! baseline beats chance by a meaningful margin, the env has an information
+//! leak (a bug), not the policy a talent. The expected qualitative result is a
+//! clean separation — LSTM well above 90% junction accuracy at `N = 10`, MLP
+//! pinned at ~50%.
 //!
 //! # Corridor-length sweep
 //!
@@ -32,6 +32,22 @@
 //! example sweeps `N ∈ {5, 10, 20}` (override with `TMAZE_SWEEP="5,10,20"`) and
 //! reports junction accuracy for both arms at each `N`, documenting where the
 //! LSTM's effective memory horizon begins to degrade.
+//!
+//! # Measured results (issue #302, 200k steps/arm, seed 0, CPU NdArray)
+//!
+//! ```text
+//! N      LSTM (final/best acc)   MLP (final/best acc)
+//! N=5        100% / 100%             45% / 61%
+//! N=10        99% / 100%             50% / 60%
+//! N=20        92% / 100%             39% / 60%
+//! ```
+//!
+//! The LSTM clears the >90% bar at every swept `N`, with final accuracy
+//! beginning to degrade at `N = 20` (100 → 99 → 92%) — the onset of its
+//! effective memory horizon under this budget. The MLP's *final* accuracy sits
+//! at chance for every `N` (39–50%), as provably required; its "best" ≈ 60% is
+//! the expected maximum of a running 100-episode accuracy estimate under a
+//! ±5% binomial noise floor, not an information leak.
 //!
 //! # Usage
 //!
@@ -44,6 +60,8 @@
 //!   cargo run --example recurrent_ppo_t_maze --features training --release
 //! ```
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use anyhow::Result;
 use burn::{
     backend::Autodiff,
@@ -52,7 +70,6 @@ use burn::{
     tensor::{Int, Tensor, TensorData, activation},
 };
 use rand::{Rng, SeedableRng, rngs::StdRng};
-use std::sync::atomic::{AtomicU64, Ordering};
 use thrust_rl::{
     buffer::rollout::RecurrentRolloutBuffer,
     env::{Environment, SpaceType, pool::EnvPool, t_maze::TMaze},
@@ -93,9 +110,9 @@ const SOLVED_ACC: f32 = 0.90;
 
 /// Outcome of one training arm: junction accuracy over the last ≤100 episodes.
 ///
-/// `final_acc` is the accuracy at the end of training; `best_acc` is the peak of
-/// the moving accuracy observed at any update — reported together so end-of-run
-/// oscillation hides nothing.
+/// `final_acc` is the accuracy at the end of training; `best_acc` is the peak
+/// of the moving accuracy observed at any update — reported together so
+/// end-of-run oscillation hides nothing.
 #[derive(Clone, Copy)]
 struct ArmResult {
     final_acc: f32,
@@ -204,12 +221,8 @@ fn main() -> Result<()> {
         tracing::info!("  N={:<4}  {:<18}  {:<16}  {}", n, ls, ms, verdict);
     }
     tracing::info!("------------------------------------------------------------");
-    tracing::info!(
-        "Expectation: LSTM accuracy stays high at small N and degrades as N grows"
-    );
-    tracing::info!(
-        "past its effective memory horizon; MLP stays ~50% for all N (provable)."
-    );
+    tracing::info!("Expectation: LSTM accuracy stays high at small N and degrades as N grows");
+    tracing::info!("past its effective memory horizon; MLP stays ~50% for all N (provable).");
 
     Ok(())
 }

--- a/src/env/games/flickering_cartpole.rs
+++ b/src/env/games/flickering_cartpole.rs
@@ -32,9 +32,10 @@
 //! # I.i.d. vs. burst-structured (correlated) dropout
 //!
 //! The default dropout is **i.i.d.**: each frame is blanked independently with
-//! probability `p`. This is only *partially* memory-hard — at CartPole's control
-//! rate a reactive controller can compensate for isolated blanked frames,
-//! which is why the feedforward baseline does not collapse to chance (#298).
+//! probability `p`. This is only *partially* memory-hard — at CartPole's
+//! control rate a reactive controller can compensate for isolated blanked
+//! frames, which is why the feedforward baseline does not collapse to chance
+//! (#298).
 //!
 //! Issue #302 adds an opt-in **burst-structured** mode (a `burst_len`
 //! parameter) that closes this reactive-compensation loophole while keeping the

--- a/src/env/games/flickering_cartpole.rs
+++ b/src/env/games/flickering_cartpole.rs
@@ -29,6 +29,30 @@
 //! becomes load-bearing **by construction**: the only way to act sensibly on a
 //! flickered frame is to remember the last visible one.
 //!
+//! # I.i.d. vs. burst-structured (correlated) dropout
+//!
+//! The default dropout is **i.i.d.**: each frame is blanked independently with
+//! probability `p`. This is only *partially* memory-hard — at CartPole's control
+//! rate a reactive controller can compensate for isolated blanked frames,
+//! which is why the feedforward baseline does not collapse to chance (#298).
+//!
+//! Issue #302 adds an opt-in **burst-structured** mode (a `burst_len`
+//! parameter) that closes this reactive-compensation loophole while keeping the
+//! *same* overall blank rate `p`. Instead of drawing each frame independently,
+//! the visibility follows a two-state Markov chain (visible ↔ blank) whose mean
+//! blank-run length is `burst_len` (default [`DEFAULT_BURST_LEN`], in the 3–5
+//! range from the issue) and whose stationary blank fraction is still `p`. The
+//! mean visible-run length is set to `burst_len * (1 - p) / p` so the long-run
+//! blank rate matches the i.i.d. baseline exactly — the *only* difference is
+//! temporal correlation. Now blanks arrive in runs of several consecutive
+//! frames, which a reactive controller cannot bridge (its last real
+//! observation is several steps stale) but a recurrent policy can, by
+//! integrating over the gap. The apples-to-apples comparison (same `p`,
+//! i.i.d. vs. burst) isolates the effect of correlation on the memory
+//! advantage. Enable it with
+//! [`FlickeringCartPole::with_seed_probability_and_burst`]; the default
+//! constructors keep the i.i.d. behavior unchanged.
+//!
 //! # Composition, not inheritance
 //!
 //! Rust has no inheritance, so `FlickeringCartPole` **embeds** a `CartPole` and
@@ -62,6 +86,11 @@ use crate::env::{
 /// Default flicker probability — the classic Hausknecht & Stone (2015)
 /// value: each frame is blanked with probability 0.5.
 pub const DEFAULT_FLICKER_PROBABILITY: f64 = 0.5;
+
+/// Default mean blank-burst length for the correlated-occlusion mode (issue
+/// #302). Sits in the middle of the 3–5 range suggested by the issue: on
+/// average a blank, once started, lasts four consecutive frames.
+pub const DEFAULT_BURST_LEN: f64 = 4.0;
 
 /// Snapshot of a [`FlickeringCartPole`]: the inner physics state, the current
 /// flicker flag, and the flicker RNG. Because the RNG is captured, restoring a
@@ -97,6 +126,12 @@ pub struct FlickeringCartPole {
     /// [`Environment::reset`] and [`Environment::step`]; read by
     /// [`Environment::get_observation`].
     flickered: bool,
+    /// Mean blank-burst length for the correlated-occlusion (Markov) mode. When
+    /// `None`, dropout is i.i.d. per frame (the default / #298 behavior). When
+    /// `Some(l)`, visibility follows a two-state Markov chain whose mean
+    /// blank-run length is `l` and whose stationary blank fraction is
+    /// `flicker_prob`.
+    burst_len: Option<f64>,
 }
 
 impl FlickeringCartPole {
@@ -129,6 +164,7 @@ impl FlickeringCartPole {
             flicker_prob,
             rng: StdRng::from_os_rng(),
             flickered: false,
+            burst_len: None,
         }
     }
 
@@ -159,6 +195,38 @@ impl FlickeringCartPole {
             flicker_prob,
             rng: StdRng::seed_from_u64(seed),
             flickered: false,
+            burst_len: None,
+        }
+    }
+
+    /// Create a **burst-structured** (correlated-occlusion) flickering CartPole
+    /// with a seeded flicker RNG (issue #302).
+    ///
+    /// Visibility follows a two-state Markov chain (visible ↔ blank) with
+    /// stationary blank fraction `flicker_prob` and mean blank-run length
+    /// `burst_len`. The mean visible-run length is derived as
+    /// `burst_len * (1 - flicker_prob) / flicker_prob`, so the long-run blank
+    /// rate equals `flicker_prob` exactly — matching the i.i.d. baseline while
+    /// adding temporal correlation. See the [module docs](self) for the
+    /// rationale.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `flicker_prob` is not in the **open** interval `(0, 1)` (a
+    /// Markov burst structure is only meaningful with both states reachable) or
+    /// if `burst_len < 1.0` (a burst must last at least one frame).
+    pub fn with_seed_probability_and_burst(seed: u64, flicker_prob: f64, burst_len: f64) -> Self {
+        assert!(
+            flicker_prob > 0.0 && flicker_prob < 1.0,
+            "burst mode requires flicker probability in (0, 1), got {flicker_prob}"
+        );
+        assert!(burst_len >= 1.0, "burst length must be >= 1.0, got {burst_len}");
+        Self {
+            inner: CartPole::new(),
+            flicker_prob,
+            rng: StdRng::seed_from_u64(seed),
+            flickered: false,
+            burst_len: Some(burst_len),
         }
     }
 
@@ -176,12 +244,57 @@ impl FlickeringCartPole {
         self.flickered
     }
 
-    /// Draw a fresh flicker decision from the seeded RNG.
+    /// The mean blank-burst length for the correlated-occlusion mode, or `None`
+    /// when dropout is i.i.d. per frame (the default).
+    pub fn burst_length(&self) -> Option<f64> {
+        self.burst_len
+    }
+
+    /// Draw a flicker decision from the **stationary** distribution (blank with
+    /// probability `flicker_prob`). Used on [`Environment::reset`] for both the
+    /// i.i.d. and burst modes — in both, the stationary blank fraction is `p`,
+    /// so a fresh episode starts blank with probability `p`.
     fn draw_flicker(&mut self) -> bool {
         // `flicker_prob == 0.0` never blanks; `== 1.0` always blanks. Drawing
         // unconditionally keeps the RNG stream advancing at one draw per frame
         // regardless of `p`, so the schedule is a pure function of the seed.
         self.rng.random::<f64>() < self.flicker_prob
+    }
+
+    /// Advance the flicker state by one frame.
+    ///
+    /// - **I.i.d. mode** (`burst_len == None`): identical to [`draw_flicker`] —
+    ///   each frame is blanked independently with probability `flicker_prob`.
+    ///   Consumes exactly one RNG draw, so the schedule is byte-for-byte the
+    ///   #298 behavior.
+    /// - **Burst mode** (`burst_len == Some(l)`): a two-state Markov transition
+    ///   from the *current* `flickered` state. The per-step probability of
+    ///   switching out of a state is one over that state's mean run length
+    ///   (`1/l` out of blank; `1 / (l * (1 - p) / p)` out of visible), which
+    ///   yields geometric run lengths with the desired means and a stationary
+    ///   blank fraction of `p`.
+    ///
+    /// [`draw_flicker`]: Self::draw_flicker
+    fn advance_flicker(&mut self) -> bool {
+        match self.burst_len {
+            None => self.draw_flicker(),
+            Some(mean_blank_run) => {
+                let u = self.rng.random::<f64>();
+                if self.flickered {
+                    // Currently blank: leave the blank run with prob 1/l_b.
+                    let p_switch = (1.0 / mean_blank_run).clamp(0.0, 1.0);
+                    // Stay blank unless we switch to visible.
+                    u >= p_switch
+                } else {
+                    // Currently visible: enter a blank run with prob 1/l_v,
+                    // where l_v = l_b * (1 - p) / p.
+                    let mean_visible_run =
+                        mean_blank_run * (1.0 - self.flicker_prob) / self.flicker_prob;
+                    let p_switch = (1.0 / mean_visible_run).clamp(0.0, 1.0);
+                    u < p_switch
+                }
+            }
+        }
     }
 
     /// The dimensionality of the (unflickered) observation.
@@ -213,7 +326,7 @@ impl Environment for FlickeringCartPole {
 
     fn step(&mut self, action: i64) -> StepResult {
         let mut result = self.inner.step(action);
-        self.flickered = self.draw_flicker();
+        self.flickered = self.advance_flicker();
         if self.flickered {
             // Blank the entire observation — the flicker protocol zeros the
             // whole frame, not individual coordinates.
@@ -433,5 +546,146 @@ mod tests {
     #[should_panic(expected = "flicker probability must be in [0, 1]")]
     fn test_invalid_probability_panics() {
         let _ = FlickeringCartPole::with_probability(1.5);
+    }
+
+    // ---- Burst-structured (correlated-occlusion) mode, issue #302 ----------
+
+    /// Collect the blank/visible flicker stream over `n` frames (stepping past
+    /// episode ends without resetting, to sample a long uninterrupted stream).
+    fn collect_flicker_stream(env: &mut FlickeringCartPole, n: usize) -> Vec<bool> {
+        env.reset();
+        let mut stream = Vec::with_capacity(n);
+        for i in 0..n {
+            env.step((i % 2) as i64);
+            stream.push(env.is_flickered());
+        }
+        stream
+    }
+
+    /// Mean length of consecutive `true` (blank) runs in a boolean stream.
+    fn mean_blank_run_length(stream: &[bool]) -> f64 {
+        let mut runs = Vec::new();
+        let mut cur = 0usize;
+        for &b in stream {
+            if b {
+                cur += 1;
+            } else if cur > 0 {
+                runs.push(cur);
+                cur = 0;
+            }
+        }
+        if cur > 0 {
+            runs.push(cur);
+        }
+        if runs.is_empty() {
+            0.0
+        } else {
+            runs.iter().sum::<usize>() as f64 / runs.len() as f64
+        }
+    }
+
+    #[test]
+    fn test_burst_mode_reports_burst_length() {
+        let env = FlickeringCartPole::with_seed_probability_and_burst(1, 0.5, 4.0);
+        assert_eq!(env.burst_length(), Some(4.0));
+        // The default i.i.d. constructor reports no burst length.
+        assert_eq!(FlickeringCartPole::new().burst_length(), None);
+    }
+
+    #[test]
+    fn test_burst_observation_shape_invariant() {
+        // Burst mode never changes the observation shape (still 4-D).
+        let mut env = FlickeringCartPole::with_seed_probability_and_burst(7, 0.5, 4.0);
+        assert_eq!(env.observation_space().shape, vec![4]);
+        env.reset();
+        assert_eq!(env.get_observation().len(), 4);
+        for i in 0..200 {
+            let r = env.step((i % 2) as i64);
+            assert_eq!(r.observation.len(), 4);
+            if r.terminated || r.truncated {
+                env.reset();
+            }
+        }
+    }
+
+    #[test]
+    fn test_burst_mode_blank_rate_matches_p() {
+        // The whole point of the burst construction: the stationary blank rate
+        // still equals p, so it is an apples-to-apples comparison with i.i.d.
+        for &p in &[0.3_f64, 0.5, 0.7] {
+            let mut env = FlickeringCartPole::with_seed_probability_and_burst(123, p, 4.0);
+            let stream = collect_flicker_stream(&mut env, 20000);
+            let rate = stream.iter().filter(|&&b| b).count() as f64 / stream.len() as f64;
+            assert!(
+                (rate - p).abs() < 0.05,
+                "burst blank rate {rate} should track p={p} (same as i.i.d.)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_burst_mode_produces_longer_runs_than_iid() {
+        // Burst mode must produce meaningfully longer blank runs than i.i.d. at
+        // the same p — that temporal correlation is what closes the reactive-
+        // compensation loophole.
+        let mut burst = FlickeringCartPole::with_seed_probability_and_burst(99, 0.5, 4.0);
+        let mut iid = FlickeringCartPole::with_seed_and_probability(99, 0.5);
+
+        let burst_run = mean_blank_run_length(&collect_flicker_stream(&mut burst, 20000));
+        let iid_run = mean_blank_run_length(&collect_flicker_stream(&mut iid, 20000));
+
+        // i.i.d. at p=0.5 has mean blank-run length ~1/(1-p) = 2.
+        assert!(iid_run < 2.5, "i.i.d. mean blank run {iid_run} should be ~2");
+        // Burst mode targets a mean blank-run length of 4.
+        assert!(
+            (burst_run - 4.0).abs() < 1.0,
+            "burst mean blank run {burst_run} should be ≈ 4.0"
+        );
+        assert!(burst_run > iid_run + 1.0, "burst runs must be longer than i.i.d. runs");
+    }
+
+    #[test]
+    fn test_burst_schedule_is_deterministic_under_seed() {
+        let mut a = FlickeringCartPole::with_seed_probability_and_burst(42, 0.5, 4.0);
+        let mut b = FlickeringCartPole::with_seed_probability_and_burst(42, 0.5, 4.0);
+        let sa = collect_flicker_stream(&mut a, 2000);
+        let sb = collect_flicker_stream(&mut b, 2000);
+        assert_eq!(sa, sb, "burst schedule must be identical under the same seed");
+    }
+
+    #[test]
+    fn test_burst_clone_restore_reproduces_stream() {
+        // The Markov state lives in `flickered` + `rng`, both captured in the
+        // snapshot, so restore reproduces the correlated stream.
+        let mut env = FlickeringCartPole::with_seed_probability_and_burst(555, 0.5, 4.0);
+        env.reset();
+        for i in 0..10 {
+            env.step((i % 2) as i64);
+        }
+        let snap = env.clone_state();
+        let mut first = Vec::new();
+        for i in 0..40 {
+            env.step((i % 2) as i64);
+            first.push(env.is_flickered());
+        }
+        env.restore_state(&snap);
+        let mut second = Vec::new();
+        for i in 0..40 {
+            env.step((i % 2) as i64);
+            second.push(env.is_flickered());
+        }
+        assert_eq!(first, second, "restore must reproduce the burst stream");
+    }
+
+    #[test]
+    #[should_panic(expected = "burst mode requires flicker probability in (0, 1)")]
+    fn test_burst_invalid_probability_panics() {
+        let _ = FlickeringCartPole::with_seed_probability_and_burst(0, 0.0, 4.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "burst length must be >= 1.0")]
+    fn test_burst_invalid_length_panics() {
+        let _ = FlickeringCartPole::with_seed_probability_and_burst(0, 0.5, 0.5);
     }
 }

--- a/src/env/games/mod.rs
+++ b/src/env/games/mod.rs
@@ -11,6 +11,11 @@
 //!   the observation. Retained as a documented NEGATIVE result — a 500k-step
 //!   run showed a memoryless `[x, theta]` controller solves it, so
 //!   velocity-masking alone does NOT make memory load-bearing (issue #287)
+//! - TMaze: the provably memory-hard T-maze POMDP (Bakker 2001). A cue is
+//!   shown only at step 0; the agent must recall it `N` steps later to turn
+//!   correctly at the junction. A memoryless policy is provably at chance (50%)
+//!   — the clean qualitative memory contrast that FlickeringCartPole only
+//!   approximates (issue #302, epic #262)
 //! - GridWorld: in-tree `4x4` FrozenLake-style sparse-reward navigation task
 //!   (issue #182, `i64` discrete action `0=Up/1=Right/2=Down/3=Left`, 16-dim
 //!   one-hot observation, absorbing goal/hole terminals + step-cap truncation)
@@ -53,6 +58,7 @@ pub mod pong;
 pub mod signaling;
 pub mod simple_bandit;
 pub mod snake;
+pub mod t_maze;
 
 #[cfg(feature = "env-bucket-brigade")]
 pub mod bucket_brigade;
@@ -76,3 +82,4 @@ pub use pong::Pong;
 pub use signaling::SignalingGame;
 pub use simple_bandit::SimpleBandit;
 pub use snake::SnakeEnv;
+pub use t_maze::TMaze;

--- a/src/env/games/mod.rs
+++ b/src/env/games/mod.rs
@@ -11,10 +11,10 @@
 //!   the observation. Retained as a documented NEGATIVE result — a 500k-step
 //!   run showed a memoryless `[x, theta]` controller solves it, so
 //!   velocity-masking alone does NOT make memory load-bearing (issue #287)
-//! - TMaze: the provably memory-hard T-maze POMDP (Bakker 2001). A cue is
-//!   shown only at step 0; the agent must recall it `N` steps later to turn
-//!   correctly at the junction. A memoryless policy is provably at chance (50%)
-//!   — the clean qualitative memory contrast that FlickeringCartPole only
+//! - TMaze: the provably memory-hard T-maze POMDP (Bakker 2001). A cue is shown
+//!   only at step 0; the agent must recall it `N` steps later to turn correctly
+//!   at the junction. A memoryless policy is provably at chance (50%) — the
+//!   clean qualitative memory contrast that FlickeringCartPole only
 //!   approximates (issue #302, epic #262)
 //! - GridWorld: in-tree `4x4` FrozenLake-style sparse-reward navigation task
 //!   (issue #182, `i64` discrete action `0=Up/1=Right/2=Down/3=Left`, 16-dim

--- a/src/env/games/t_maze.rs
+++ b/src/env/games/t_maze.rs
@@ -1,0 +1,559 @@
+//! T-maze — the canonical memory-hard POMDP benchmark (Bakker 2001).
+//!
+//! Part of the recurrent-policy epic (#262), extending the memory-hard
+//! environment suite alongside [`FlickeringCartPole`](super::FlickeringCartPole)
+//! (#298). Where flickering CartPole is only *approximately* memory-hard — a
+//! reactive controller partially compensates at CartPole's control rate — the
+//! T-maze is **provably** memory-hard: a memoryless policy is at chance (50%)
+//! at the junction regardless of capacity. This is the clean qualitative
+//! contrast that `MaskedCartPole` failed to provide (#287's negative result).
+//!
+//! # The task
+//!
+//! The agent traverses a straight corridor of length `N` and, at the far end,
+//! reaches a T-junction where it must turn **up** or **down**. Which turn is
+//! rewarded is signalled by a **cue** shown *only at the start* (step 0). To act
+//! correctly at the junction the agent must carry the cue across the entire
+//! corridor in memory. From Bakker, *"Reinforcement Learning with Long
+//! Short-Term Memory"* (NeurIPS 2001).
+//!
+//! - **Corridor length `N`** (configurable, default [`DEFAULT_CORRIDOR_LENGTH`]
+//!   = 10). The episode is exactly `N + 1` steps long: the agent observes the
+//!   cue at step 0, walks the corridor over steps `1..N`, and makes the junction
+//!   decision on the observation seen at step `N`. The memory span the policy
+//!   must bridge is therefore `N` steps.
+//! - **Action:** `i64`, two discrete choices: `0 = up`, `1 = down`. The action
+//!   is only consequential at the junction; while in the corridor the agent
+//!   auto-advances and the action is ignored (a no-op). This isolates the memory
+//!   variable — corridor navigation is trivial and identical for every policy,
+//!   so the *only* thing that separates a memoryful from a memoryless policy is
+//!   recalling the cue.
+//! - **Observation:** a fixed 3-D `Vec<f32>` `[cue, corridor, junction]`:
+//!   - `cue` is `+1.0` (turn up) or `-1.0` (turn down) **only at step 0**; it is
+//!     `0.0` at every subsequent step. This is the memory-load-bearing channel.
+//!   - `corridor` is `1.0` while the agent is in the corridor (steps `0..N-1`)
+//!     and `0.0` at the junction.
+//!   - `junction` is `1.0` at the junction (step `N`) and `0.0` otherwise.
+//! - **Reward:** `0.0` for every corridor step; at the junction, [`REWARD_CORRECT`]
+//!   (`+1.0`) if the chosen turn matches the cue, else [`REWARD_WRONG`] (`-1.0`).
+//!   Episode return is therefore exactly `+1` (correct) or `-1` (wrong), so the
+//!   mean return maps directly to junction accuracy: `acc = (mean_return + 1) / 2`.
+//! - **Termination:** the episode `terminated`s the moment the junction decision
+//!   is taken (step `N`). There is no truncation in the default configuration —
+//!   the fixed-length corridor always ends at the junction.
+//!
+//! # Why a memoryless policy is provably at chance
+//!
+//! The junction observation is `[0, 0, 1]` — **identical for both cue values**.
+//! The cue appears in the observation stream exactly once, at step 0, and the
+//! cue is drawn independently and uniformly (50/50) each episode. A memoryless
+//! policy conditions its junction action only on the current observation
+//! `[0, 0, 1]`, which is a constant independent of the cue; therefore
+//! `P(correct) = P(cue = chosen turn) = 0.5` for *any* memoryless policy,
+//! regardless of network capacity. This is a hard information-theoretic bound,
+//! not an optimization artefact.
+//!
+//! **This is also a self-test on the environment.** If a feedforward baseline
+//! trained on this env beats 50% junction accuracy by a statistically
+//! meaningful margin, the environment has an information leak (e.g. the cue
+//! bleeding into a later observation) and that is a bug in the env, not a
+//! finding about the policy. The unit tests below assert the no-leak property
+//! directly.
+//!
+//! # Seeding and determinism
+//!
+//! The cue is drawn from a dedicated seeded [`StdRng`]. Two `TMaze`s built with
+//! [`TMaze::with_seed`] (same seed, same corridor length) produce the identical
+//! cue sequence across resets, independent of the actions taken. The
+//! [`TMazeState`] snapshot captures the position, cue, step counter, **and** the
+//! cue RNG, so [`Environment::restore_state`] followed by further resets
+//! reproduces the same cue stream — the same strong determinism guarantee as
+//! [`FlickeringCartPole`](super::FlickeringCartPole).
+
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+use crate::env::{Environment, SpaceInfo, SpaceType, StepInfo, StepResult};
+
+/// Default corridor length. At `N = 10` the memory span is 10 steps — the
+/// canonical Bakker setting where an LSTM clears >90% junction accuracy while a
+/// memoryless policy is pinned at chance.
+pub const DEFAULT_CORRIDOR_LENGTH: usize = 10;
+
+/// Default seed used by [`TMaze::new`].
+pub const DEFAULT_SEED: u64 = 0;
+
+/// Number of discrete actions (`0 = up`, `1 = down`).
+pub const NUM_ACTIONS: usize = 2;
+
+/// Observation dimensionality: `[cue, corridor, junction]`.
+pub const OBS_DIM: usize = 3;
+
+/// Reward for taking the junction turn that matches the cue.
+pub const REWARD_CORRECT: f32 = 1.0;
+
+/// Reward for taking the junction turn that does not match the cue.
+pub const REWARD_WRONG: f32 = -1.0;
+
+/// The cue shown at the start of the corridor: which way to turn at the
+/// junction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cue {
+    /// Turn up at the junction (rewarded action is `0`).
+    Up,
+    /// Turn down at the junction (rewarded action is `1`).
+    Down,
+}
+
+impl Cue {
+    /// The action index that is rewarded for this cue (`0 = up`, `1 = down`).
+    pub fn correct_action(self) -> i64 {
+        match self {
+            Cue::Up => 0,
+            Cue::Down => 1,
+        }
+    }
+
+    /// The value written into the `cue` observation channel at step 0
+    /// (`+1.0` for up, `-1.0` for down).
+    fn signal(self) -> f32 {
+        match self {
+            Cue::Up => 1.0,
+            Cue::Down => -1.0,
+        }
+    }
+}
+
+/// Snapshot of a [`TMaze`]: position, cue, step counter, and the cue RNG.
+///
+/// Because the RNG is captured, restoring a snapshot and then calling
+/// [`Environment::reset`] reproduces the subsequent cue stream exactly, in
+/// addition to the fully deterministic corridor dynamics.
+#[derive(Debug, Clone)]
+pub struct TMazeState {
+    /// Position along the corridor in `0..=N` (`N` is the junction).
+    position: usize,
+    /// The cue for the current episode.
+    cue: Cue,
+    /// Cue RNG state at snapshot time.
+    rng: StdRng,
+}
+
+/// T-maze — the provably memory-hard POMDP benchmark (Bakker 2001).
+///
+/// See the [module docs](self) for the full task, observation, reward, and
+/// determinism specification.
+#[derive(Debug)]
+pub struct TMaze {
+    /// Corridor length `N`. The junction is at position `N`.
+    corridor_length: usize,
+    /// Current position along the corridor in `0..=N`.
+    position: usize,
+    /// The cue for the current episode, drawn on [`Environment::reset`].
+    cue: Cue,
+    /// Dedicated cue RNG for reproducible cue sequences.
+    rng: StdRng,
+}
+
+impl TMaze {
+    /// Create a T-maze with the default corridor length
+    /// ([`DEFAULT_CORRIDOR_LENGTH`] = 10) and a **seeded** cue RNG for a
+    /// reproducible cue sequence.
+    pub fn new() -> Self {
+        Self::with_seed_and_corridor_length(DEFAULT_SEED, DEFAULT_CORRIDOR_LENGTH)
+    }
+
+    /// Create a T-maze with a custom corridor length and the default seed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `corridor_length` is zero. A zero-length corridor would place
+    /// the cue and the junction at the same step, leaking the cue into the
+    /// junction observation and destroying the memory task.
+    pub fn with_corridor_length(corridor_length: usize) -> Self {
+        Self::with_seed_and_corridor_length(DEFAULT_SEED, corridor_length)
+    }
+
+    /// Create a T-maze with the default corridor length and a custom seed.
+    pub fn with_seed(seed: u64) -> Self {
+        Self::with_seed_and_corridor_length(seed, DEFAULT_CORRIDOR_LENGTH)
+    }
+
+    /// Create a T-maze with a custom seed and corridor length.
+    ///
+    /// Two instances built with the same `seed` and `corridor_length` draw the
+    /// same cue on every reset, independent of the actions taken.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `corridor_length` is zero (see [`TMaze::with_corridor_length`]).
+    pub fn with_seed_and_corridor_length(seed: u64, corridor_length: usize) -> Self {
+        assert!(
+            corridor_length >= 1,
+            "corridor_length must be >= 1 (a zero-length corridor leaks the cue into the junction observation), got {corridor_length}"
+        );
+        let mut env = Self {
+            corridor_length,
+            position: 0,
+            cue: Cue::Up,
+            rng: StdRng::seed_from_u64(seed),
+        };
+        env.reset();
+        env
+    }
+
+    /// The corridor length `N` (the junction is at position `N`).
+    pub fn corridor_length(&self) -> usize {
+        self.corridor_length
+    }
+
+    /// The cue for the current episode (primarily for diagnostics and tests).
+    pub fn cue(&self) -> Cue {
+        self.cue
+    }
+
+    /// The current position along the corridor in `0..=N`.
+    pub fn position(&self) -> usize {
+        self.position
+    }
+
+    /// Whether the agent is currently at the junction (`position == N`).
+    pub fn at_junction(&self) -> bool {
+        self.position == self.corridor_length
+    }
+}
+
+impl Default for TMaze {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Environment for TMaze {
+    /// Discrete junction action. `0 = up`, `1 = down`; only consequential at the
+    /// junction (ignored, as a no-op, while in the corridor).
+    type Action = i64;
+
+    /// Snapshot type capturing position, cue, and the cue RNG. See
+    /// [`TMazeState`].
+    type State = TMazeState;
+
+    fn reset(&mut self) {
+        self.position = 0;
+        // Draw the cue uniformly at random from the seeded RNG (exactly one draw
+        // per episode, so the cue sequence is a pure function of the seed).
+        self.cue = if self.rng.random::<bool>() { Cue::Up } else { Cue::Down };
+    }
+
+    fn get_observation(&self) -> Vec<f32> {
+        // [cue, corridor, junction].
+        //   cue      : nonzero ONLY at step 0 (position 0) — the memory channel.
+        //   corridor : 1.0 while in the corridor (positions 0..N-1).
+        //   junction : 1.0 at the junction (position N); constant across cues.
+        let cue = if self.position == 0 { self.cue.signal() } else { 0.0 };
+        let at_junction = self.position == self.corridor_length;
+        let corridor = if at_junction { 0.0 } else { 1.0 };
+        let junction = if at_junction { 1.0 } else { 0.0 };
+        vec![cue, corridor, junction]
+    }
+
+    fn step(&mut self, action: i64) -> StepResult {
+        if self.position < self.corridor_length {
+            // In the corridor: auto-advance one cell; the action is a no-op.
+            // Reward is zero and the episode continues.
+            self.position += 1;
+            StepResult {
+                observation: self.get_observation(),
+                reward: 0.0,
+                terminated: false,
+                truncated: false,
+                info: StepInfo::default(),
+            }
+        } else {
+            // At the junction: the action is the decision. Reward +1 if it
+            // matches the cue, -1 otherwise, and the episode terminates.
+            let reward =
+                if action == self.cue.correct_action() { REWARD_CORRECT } else { REWARD_WRONG };
+            StepResult {
+                observation: self.get_observation(),
+                reward,
+                terminated: true,
+                truncated: false,
+                info: StepInfo::default(),
+            }
+        }
+    }
+
+    fn observation_space(&self) -> SpaceInfo {
+        SpaceInfo { shape: vec![OBS_DIM], space_type: SpaceType::Box }
+    }
+
+    fn action_space(&self) -> SpaceInfo {
+        SpaceInfo { shape: vec![NUM_ACTIONS], space_type: SpaceType::Discrete(NUM_ACTIONS) }
+    }
+
+    fn render(&self) -> Vec<u8> {
+        Vec::new()
+    }
+
+    fn close(&mut self) {}
+
+    fn clone_state(&self) -> TMazeState {
+        TMazeState { position: self.position, cue: self.cue, rng: self.rng.clone() }
+    }
+
+    fn restore_state(&mut self, state: &TMazeState) {
+        self.position = state.position;
+        self.cue = state.cue;
+        self.rng = state.rng.clone();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const UP: i64 = 0;
+    const DOWN: i64 = 1;
+
+    /// Walk the corridor from a fresh reset to the junction, returning the
+    /// observation seen at each step (including the post-reset observation) and
+    /// leaving the env poised at the junction.
+    fn walk_to_junction(env: &mut TMaze) -> Vec<Vec<f32>> {
+        env.reset();
+        let mut obs = vec![env.get_observation()];
+        for _ in 0..env.corridor_length() {
+            let r = env.step(UP);
+            obs.push(r.observation);
+        }
+        obs
+    }
+
+    #[test]
+    fn observation_space_is_three_dimensional_box() {
+        let env = TMaze::new();
+        let space = env.observation_space();
+        assert_eq!(space.shape, vec![OBS_DIM]);
+        assert!(matches!(space.space_type, SpaceType::Box));
+    }
+
+    #[test]
+    fn action_space_is_discrete_two() {
+        let env = TMaze::new();
+        let space = env.action_space();
+        assert_eq!(space.shape, vec![NUM_ACTIONS]);
+        assert!(matches!(space.space_type, SpaceType::Discrete(NUM_ACTIONS)));
+    }
+
+    #[test]
+    fn cue_is_only_visible_at_step_zero() {
+        // The cue channel (obs[0]) must be nonzero at step 0 and zero at every
+        // subsequent step, all the way to and including the junction.
+        for seed in 0..16u64 {
+            let mut env = TMaze::with_seed_and_corridor_length(seed, 10);
+            let obs = walk_to_junction(&mut env);
+            assert_ne!(obs[0][0], 0.0, "cue must be visible at step 0 (seed {seed})");
+            for (i, o) in obs.iter().enumerate().skip(1) {
+                assert_eq!(o[0], 0.0, "cue leaked at step {i} (seed {seed}): {o:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn junction_observation_is_identical_across_cues() {
+        // The no-leak property: the junction observation must be the SAME for
+        // an up-cue episode and a down-cue episode. This is what makes a
+        // memoryless policy provably at chance.
+        let mut up_env = None;
+        let mut down_env = None;
+        // Find one seed producing each cue.
+        for seed in 0..64u64 {
+            let env = TMaze::with_seed_and_corridor_length(seed, 8);
+            match env.cue() {
+                Cue::Up if up_env.is_none() => up_env = Some(env),
+                Cue::Down if down_env.is_none() => down_env = Some(env),
+                _ => {}
+            }
+            if up_env.is_some() && down_env.is_some() {
+                break;
+            }
+        }
+        let mut up_env = up_env.expect("some seed yields an up cue");
+        let mut down_env = down_env.expect("some seed yields a down cue");
+        assert_eq!(up_env.cue(), Cue::Up);
+        assert_eq!(down_env.cue(), Cue::Down);
+
+        let up_obs = walk_to_junction(&mut up_env);
+        let down_obs = walk_to_junction(&mut down_env);
+        // Step 0 differs (the cue), every later step (incl. junction) matches.
+        assert_ne!(up_obs[0], down_obs[0], "cue must differ at step 0");
+        let junction_up = up_obs.last().unwrap();
+        let junction_down = down_obs.last().unwrap();
+        assert_eq!(
+            junction_up, junction_down,
+            "junction observation must be identical across cues (no leak)"
+        );
+        assert_eq!(junction_up, &vec![0.0, 0.0, 1.0], "junction obs is [0,0,1]");
+    }
+
+    #[test]
+    fn corridor_and_junction_channels_track_position() {
+        let mut env = TMaze::with_seed_and_corridor_length(3, 5);
+        let obs = walk_to_junction(&mut env);
+        // obs has N+1 entries (steps 0..=N). Corridor channel is 1 for the
+        // first N, then 0 at the junction; junction channel is the complement.
+        for (i, o) in obs.iter().enumerate() {
+            if i < env.corridor_length() {
+                assert_eq!(o[1], 1.0, "corridor channel should be 1 at step {i}");
+                assert_eq!(o[2], 0.0, "junction channel should be 0 at step {i}");
+            } else {
+                assert_eq!(o[1], 0.0, "corridor channel should be 0 at junction");
+                assert_eq!(o[2], 1.0, "junction channel should be 1 at junction");
+            }
+        }
+    }
+
+    #[test]
+    fn episode_length_is_corridor_length_plus_one() {
+        for n in [1usize, 5, 10, 20] {
+            let mut env = TMaze::with_seed_and_corridor_length(1, n);
+            env.reset();
+            let mut steps = 0;
+            loop {
+                let r = env.step(UP);
+                steps += 1;
+                if r.terminated || r.truncated {
+                    break;
+                }
+                assert!(steps <= n + 1, "episode overran for N={n}");
+            }
+            // The junction decision is the (N+1)-th step (positions advance N
+            // times through the corridor, then one decision step).
+            assert_eq!(steps, n + 1, "episode length must be N+1 for N={n}");
+        }
+    }
+
+    #[test]
+    fn correct_turn_rewards_plus_one_and_terminates() {
+        // Drive both cue values and check the junction reward semantics.
+        for seed in 0..32u64 {
+            let mut env = TMaze::with_seed_and_corridor_length(seed, 6);
+            env.reset();
+            let cue = env.cue();
+            for _ in 0..env.corridor_length() {
+                let r = env.step(UP);
+                assert_eq!(r.reward, 0.0, "corridor steps yield zero reward");
+                assert!(!r.terminated);
+            }
+            // Now at the junction: the correct action rewards +1.
+            let r = env.step(cue.correct_action());
+            assert_eq!(r.reward, REWARD_CORRECT, "correct turn rewards +1");
+            assert!(r.terminated, "junction decision terminates the episode");
+            assert!(!r.truncated);
+        }
+    }
+
+    #[test]
+    fn wrong_turn_rewards_minus_one_and_terminates() {
+        for seed in 0..32u64 {
+            let mut env = TMaze::with_seed_and_corridor_length(seed, 6);
+            env.reset();
+            let cue = env.cue();
+            for _ in 0..env.corridor_length() {
+                env.step(UP);
+            }
+            let wrong = 1 - cue.correct_action();
+            let r = env.step(wrong);
+            assert_eq!(r.reward, REWARD_WRONG, "wrong turn rewards -1");
+            assert!(r.terminated);
+        }
+    }
+
+    #[test]
+    fn corridor_actions_are_noops() {
+        // The action taken in the corridor must not affect position, reward, or
+        // the eventual junction outcome — only the junction action matters.
+        let mut a = TMaze::with_seed_and_corridor_length(11, 7);
+        let mut b = TMaze::with_seed_and_corridor_length(11, 7);
+        a.reset();
+        b.reset();
+        assert_eq!(a.cue(), b.cue());
+        let cue = a.cue();
+        // a walks with UP actions, b walks with DOWN actions.
+        for _ in 0..a.corridor_length() {
+            let ra = a.step(UP);
+            let rb = b.step(DOWN);
+            assert_eq!(ra.observation, rb.observation, "corridor obs independent of action");
+            assert_eq!(ra.reward, rb.reward);
+            assert_eq!(a.position(), b.position());
+        }
+        // Both reach the junction identically; the correct turn still pays +1.
+        assert!(a.at_junction() && b.at_junction());
+        assert_eq!(a.step(cue.correct_action()).reward, REWARD_CORRECT);
+        assert_eq!(b.step(cue.correct_action()).reward, REWARD_CORRECT);
+    }
+
+    #[test]
+    fn cue_sequence_is_deterministic_under_seed() {
+        // Two envs with the same seed draw the same cue on every reset.
+        let mut a = TMaze::with_seed_and_corridor_length(42, 4);
+        let mut b = TMaze::with_seed_and_corridor_length(42, 4);
+        for _ in 0..100 {
+            a.reset();
+            b.reset();
+            assert_eq!(a.cue(), b.cue(), "cue sequence diverged under identical seeds");
+        }
+    }
+
+    #[test]
+    fn cue_is_approximately_balanced() {
+        // Over many resets the cue should be ~50/50 up/down (uniform draw).
+        let mut env = TMaze::with_seed_and_corridor_length(123, 4);
+        let mut up = 0usize;
+        let n = 5000;
+        for _ in 0..n {
+            env.reset();
+            if env.cue() == Cue::Up {
+                up += 1;
+            }
+        }
+        let rate = up as f64 / n as f64;
+        assert!((rate - 0.5).abs() < 0.05, "up-cue rate {rate} should be ≈ 0.5");
+    }
+
+    #[test]
+    fn clone_restore_reproduces_cue_stream() {
+        // Snapshot captures the cue RNG, so restore + reset reproduces the same
+        // subsequent cue sequence.
+        let mut env = TMaze::with_seed_and_corridor_length(555, 5);
+        for _ in 0..5 {
+            env.reset();
+        }
+        let snap = env.clone_state();
+
+        let mut first = Vec::new();
+        for _ in 0..20 {
+            env.reset();
+            first.push(env.cue());
+        }
+
+        env.restore_state(&snap);
+        let mut second = Vec::new();
+        for _ in 0..20 {
+            env.reset();
+            second.push(env.cue());
+        }
+        assert_eq!(first, second, "restore must reproduce the cue stream");
+    }
+
+    #[test]
+    #[should_panic(expected = "corridor_length must be >= 1")]
+    fn zero_corridor_length_panics() {
+        let _ = TMaze::with_corridor_length(0);
+    }
+
+    #[test]
+    fn correct_action_mapping() {
+        assert_eq!(Cue::Up.correct_action(), UP);
+        assert_eq!(Cue::Down.correct_action(), DOWN);
+    }
+}

--- a/src/env/games/t_maze.rs
+++ b/src/env/games/t_maze.rs
@@ -1,46 +1,49 @@
 //! T-maze — the canonical memory-hard POMDP benchmark (Bakker 2001).
 //!
 //! Part of the recurrent-policy epic (#262), extending the memory-hard
-//! environment suite alongside [`FlickeringCartPole`](super::FlickeringCartPole)
-//! (#298). Where flickering CartPole is only *approximately* memory-hard — a
-//! reactive controller partially compensates at CartPole's control rate — the
-//! T-maze is **provably** memory-hard: a memoryless policy is at chance (50%)
-//! at the junction regardless of capacity. This is the clean qualitative
-//! contrast that `MaskedCartPole` failed to provide (#287's negative result).
+//! environment suite alongside
+//! [`FlickeringCartPole`](super::FlickeringCartPole) (#298). Where flickering
+//! CartPole is only *approximately* memory-hard — a reactive controller
+//! partially compensates at CartPole's control rate — the T-maze is provably
+//! memory-hard: a memoryless policy is at chance (50%) at the junction
+//! regardless of capacity. This is the clean qualitative contrast that
+//! `MaskedCartPole` failed to provide (#287's negative result).
 //!
 //! # The task
 //!
 //! The agent traverses a straight corridor of length `N` and, at the far end,
 //! reaches a T-junction where it must turn **up** or **down**. Which turn is
-//! rewarded is signalled by a **cue** shown *only at the start* (step 0). To act
-//! correctly at the junction the agent must carry the cue across the entire
+//! rewarded is signalled by a **cue** shown *only at the start* (step 0). To
+//! act correctly at the junction the agent must carry the cue across the entire
 //! corridor in memory. From Bakker, *"Reinforcement Learning with Long
 //! Short-Term Memory"* (NeurIPS 2001).
 //!
 //! - **Corridor length `N`** (configurable, default [`DEFAULT_CORRIDOR_LENGTH`]
 //!   = 10). The episode is exactly `N + 1` steps long: the agent observes the
-//!   cue at step 0, walks the corridor over steps `1..N`, and makes the junction
-//!   decision on the observation seen at step `N`. The memory span the policy
-//!   must bridge is therefore `N` steps.
+//!   cue at step 0, walks the corridor over steps `1..N`, and makes the
+//!   junction decision on the observation seen at step `N`. The memory span the
+//!   policy must bridge is therefore `N` steps.
 //! - **Action:** `i64`, two discrete choices: `0 = up`, `1 = down`. The action
 //!   is only consequential at the junction; while in the corridor the agent
-//!   auto-advances and the action is ignored (a no-op). This isolates the memory
-//!   variable — corridor navigation is trivial and identical for every policy,
-//!   so the *only* thing that separates a memoryful from a memoryless policy is
-//!   recalling the cue.
+//!   auto-advances and the action is ignored (a no-op). This isolates the
+//!   memory variable — corridor navigation is trivial and identical for every
+//!   policy, so the *only* thing that separates a memoryful from a memoryless
+//!   policy is recalling the cue.
 //! - **Observation:** a fixed 3-D `Vec<f32>` `[cue, corridor, junction]`:
-//!   - `cue` is `+1.0` (turn up) or `-1.0` (turn down) **only at step 0**; it is
-//!     `0.0` at every subsequent step. This is the memory-load-bearing channel.
+//!   - `cue` is `+1.0` (turn up) or `-1.0` (turn down) **only at step 0**; it
+//!     is `0.0` at every subsequent step. This is the memory-load-bearing
+//!     channel.
 //!   - `corridor` is `1.0` while the agent is in the corridor (steps `0..N-1`)
 //!     and `0.0` at the junction.
 //!   - `junction` is `1.0` at the junction (step `N`) and `0.0` otherwise.
-//! - **Reward:** `0.0` for every corridor step; at the junction, [`REWARD_CORRECT`]
-//!   (`+1.0`) if the chosen turn matches the cue, else [`REWARD_WRONG`] (`-1.0`).
-//!   Episode return is therefore exactly `+1` (correct) or `-1` (wrong), so the
-//!   mean return maps directly to junction accuracy: `acc = (mean_return + 1) / 2`.
-//! - **Termination:** the episode `terminated`s the moment the junction decision
-//!   is taken (step `N`). There is no truncation in the default configuration —
-//!   the fixed-length corridor always ends at the junction.
+//! - **Reward:** `0.0` for every corridor step; at the junction,
+//!   [`REWARD_CORRECT`] (`+1.0`) if the chosen turn matches the cue, else
+//!   [`REWARD_WRONG`] (`-1.0`). Episode return is therefore exactly `+1`
+//!   (correct) or `-1` (wrong), so the mean return maps directly to junction
+//!   accuracy: `acc = (mean_return + 1) / 2`.
+//! - **Termination:** the episode `terminated`s the moment the junction
+//!   decision is taken (step `N`). There is no truncation in the default
+//!   configuration — the fixed-length corridor always ends at the junction.
 //!
 //! # Why a memoryless policy is provably at chance
 //!
@@ -65,8 +68,8 @@
 //! The cue is drawn from a dedicated seeded [`StdRng`]. Two `TMaze`s built with
 //! [`TMaze::with_seed`] (same seed, same corridor length) produce the identical
 //! cue sequence across resets, independent of the actions taken. The
-//! [`TMazeState`] snapshot captures the position, cue, step counter, **and** the
-//! cue RNG, so [`Environment::restore_state`] followed by further resets
+//! [`TMazeState`] snapshot captures the position, cue, step counter, **and**
+//! the cue RNG, so [`Environment::restore_state`] followed by further resets
 //! reproduces the same cue stream — the same strong determinism guarantee as
 //! [`FlickeringCartPole`](super::FlickeringCartPole).
 
@@ -185,18 +188,15 @@ impl TMaze {
     ///
     /// # Panics
     ///
-    /// Panics if `corridor_length` is zero (see [`TMaze::with_corridor_length`]).
+    /// Panics if `corridor_length` is zero (see
+    /// [`TMaze::with_corridor_length`]).
     pub fn with_seed_and_corridor_length(seed: u64, corridor_length: usize) -> Self {
         assert!(
             corridor_length >= 1,
             "corridor_length must be >= 1 (a zero-length corridor leaks the cue into the junction observation), got {corridor_length}"
         );
-        let mut env = Self {
-            corridor_length,
-            position: 0,
-            cue: Cue::Up,
-            rng: StdRng::seed_from_u64(seed),
-        };
+        let mut env =
+            Self { corridor_length, position: 0, cue: Cue::Up, rng: StdRng::seed_from_u64(seed) };
         env.reset();
         env
     }
@@ -229,8 +229,8 @@ impl Default for TMaze {
 }
 
 impl Environment for TMaze {
-    /// Discrete junction action. `0 = up`, `1 = down`; only consequential at the
-    /// junction (ignored, as a no-op, while in the corridor).
+    /// Discrete junction action. `0 = up`, `1 = down`; only consequential at
+    /// the junction (ignored, as a no-op, while in the corridor).
     type Action = i64;
 
     /// Snapshot type capturing position, cue, and the cue RNG. See
@@ -241,7 +241,11 @@ impl Environment for TMaze {
         self.position = 0;
         // Draw the cue uniformly at random from the seeded RNG (exactly one draw
         // per episode, so the cue sequence is a pure function of the seed).
-        self.cue = if self.rng.random::<bool>() { Cue::Up } else { Cue::Down };
+        self.cue = if self.rng.random::<bool>() {
+            Cue::Up
+        } else {
+            Cue::Down
+        };
     }
 
     fn get_observation(&self) -> Vec<f32> {
@@ -249,7 +253,11 @@ impl Environment for TMaze {
         //   cue      : nonzero ONLY at step 0 (position 0) — the memory channel.
         //   corridor : 1.0 while in the corridor (positions 0..N-1).
         //   junction : 1.0 at the junction (position N); constant across cues.
-        let cue = if self.position == 0 { self.cue.signal() } else { 0.0 };
+        let cue = if self.position == 0 {
+            self.cue.signal()
+        } else {
+            0.0
+        };
         let at_junction = self.position == self.corridor_length;
         let corridor = if at_junction { 0.0 } else { 1.0 };
         let junction = if at_junction { 1.0 } else { 0.0 };
@@ -271,8 +279,11 @@ impl Environment for TMaze {
         } else {
             // At the junction: the action is the decision. Reward +1 if it
             // matches the cue, -1 otherwise, and the episode terminates.
-            let reward =
-                if action == self.cue.correct_action() { REWARD_CORRECT } else { REWARD_WRONG };
+            let reward = if action == self.cue.correct_action() {
+                REWARD_CORRECT
+            } else {
+                REWARD_WRONG
+            };
             StepResult {
                 observation: self.get_observation(),
                 reward,

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -180,8 +180,9 @@ pub mod games;
 // Re-export game environments for backwards compatibility
 pub use games::{
     CartPole, ContinuousLqr, FlickeringCartPole, GridWorld, MaskedCartPole, MountainCarContinuous,
-    PendulumSwingUp, Pong, SimpleBandit, SnakeEnv, cartpole, continuous_lqr, flickering_cartpole,
-    grid_world, masked_cartpole, mountain_car_continuous, pendulum, pong, simple_bandit, snake,
+    PendulumSwingUp, Pong, SimpleBandit, SnakeEnv, TMaze, cartpole, continuous_lqr,
+    flickering_cartpole, grid_world, masked_cartpole, mountain_car_continuous, pendulum, pong,
+    simple_bandit, snake, t_maze,
 };
 // `signaling` depends on `crate::multi_agent`, which is gated behind the
 // `training` feature, so its re-export must be gated the same way.


### PR DESCRIPTION
## Summary

Adds the two memory-hard POMDP environments requested in #302, completing the recurrent-RL story from #298:

- **`TMaze`** (`src/env/games/t_maze.rs`) — Bakker (2001) T-maze: cue observed only at step 0, junction decision N steps later, +1/-1 reward, discrete actions. Configurable corridor length. A memoryless policy is provably at chance.
- **Burst-structured flicker** — extends the existing `FlickeringCartPole` with Markov on/off occlusion (`burst_len` parameter) instead of i.i.d. dropout, per the issue's prefer-extend guidance.
- One example per env contrasting `RecurrentPPOTrainer` (LSTM) vs an MLP baseline under the #298 honest-reporting protocol, plus unit tests for seed determinism, observation shapes, and cue/occlusion semantics. Examples cataloged in `docs/EXAMPLES.md`.

## Measured results (seeded, commands documented in the examples)

**T-maze corridor sweep (LSTM / MLP junction accuracy):**

| N | LSTM | MLP |
|---|------|-----|
| 5 | 100% | 45% |
| 10 | 99% | 50% |
| 20 | 92% | 39% |

LSTM clears the >90% bar at all N including N=20; MLP is statistically at chance everywhere (no information leak). Acceptance criteria 1 and 3 met.

**Burst-flicker CartPole (best eval return):** LSTM 203.1 (clears the 195 solved bar) vs MLP 100.4 — memory gap 102.7. The i.i.d. baseline gap from #298 is 263.4, so correlation did **not** widen the memory advantage (hypothesis expected a wider gap). Reported honestly against the hypothesis per the #298 protocol; no tuning was done to force the expected direction. Acceptance criterion 2 met.

## Quality gates

- `cargo fmt -- --check` clean
- `cargo clippy --all-targets --features training -- -D warnings` clean
- `cargo test --lib --features training`: 500 passed / 0 failed
- `cargo test --doc --features training`: 11 passed / 0 failed
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean
- `cargo check --no-default-features` clean
- Integration test binaries pass individually, **except** `test_psro_n_player_matching_pennies`, which deterministically deadlocks on this host inside burn-autodiff mutexes — pre-existing, unrelated to this envs+examples+docs diff, filed as #307, and green in CI.

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)
