### PR TITLE
fix(psro): serialize best-response backward passes to dodge burn-autodiff deadlock

### DIFF
--- a/examples/games/bucket_brigade/train_psro.rs
+++ b/examples/games/bucket_brigade/train_psro.rs
@@ -332,6 +332,9 @@ fn main() -> Result<()> {
         max_payoff_evals_per_iteration,
         br_reward_scale,
         seed: base_seed(),
+        // Serialize per-agent BR backward passes to avoid the burn-autodiff
+        // 0.21 graph-lock deadlock on many-core hosts (issue #307).
+        serialize_br_updates: true,
     };
     let joint_config = JointTrainerConfig {
         num_agents: NUM_AGENTS,

--- a/src/multi_agent/psro.rs
+++ b/src/multi_agent/psro.rs
@@ -1002,6 +1002,40 @@ pub struct PsroConfig {
     pub br_reward_scale: f32,
     /// RNG seed for opponent sampling and deterministic tests.
     pub seed: u64,
+    /// Serialize the per-agent best-response `update` (backward) calls to
+    /// avoid a concurrent-`backward()` deadlock in `burn-autodiff 0.21` on
+    /// some many-core hosts (issue #307).
+    ///
+    /// The #232 parallel path dispatches `num_agents` independent
+    /// best-response tasks via `rayon`, so all agents' `joint_loss.backward()`
+    /// passes run concurrently on worker threads. `burn-autodiff 0.21`
+    /// guards its `GraphLocator`/`GraphState` singletons with `parking_lot`
+    /// mutexes acquired in an inconsistent order across the two backward
+    /// code paths, producing a lock-order inversion that deterministically
+    /// wedges on macOS arm64 (8-core M-series) with `N = 4` concurrent
+    /// backward passes. Linux CI (2-core x86) rarely hits the race window.
+    ///
+    /// When `true` (the default until the upstream burn issue is resolved
+    /// — no `burn 0.22` exists on crates.io yet), the parallel `par_iter`
+    /// is replaced by a serial `.map()` that trains each agent's BR in
+    /// fixed agent order, so at most one backward graph is live at a time.
+    /// When `false`, all agents' backward passes run concurrently under
+    /// `rayon` (the original #232 path).
+    ///
+    /// # Determinism
+    ///
+    /// This flag does **not** affect results. All shared-mutable draws are
+    /// hoisted into the fixed-order pre-pass in
+    /// `train_best_responses_parallel` before any dispatch, and each
+    /// BR is a pure function of its pre-drawn inputs, collected by index.
+    /// Serial vs. parallel dispatch therefore yields bit-identical
+    /// `PsroStats` for a given seed; only wall-clock concurrency of the
+    /// backward passes changes. The #232 thread-count-invariance guarantee
+    /// is preserved in both modes.
+    ///
+    /// Set this back to `false` once a burn version that fixes the
+    /// autodiff graph-lock inversion is adopted (tracked in #307).
+    pub serialize_br_updates: bool,
 }
 
 impl Default for PsroConfig {
@@ -1014,6 +1048,7 @@ impl Default for PsroConfig {
             max_payoff_evals_per_iteration: None,
             br_reward_scale: 1.0,
             seed: 0,
+            serialize_br_updates: true,
         }
     }
 }
@@ -1968,24 +2003,35 @@ where
         let optimizer_factory = &self.optimizer_factory;
         let env_factory = &self.env_factory;
 
-        // --- Parallel region: one independent BR per agent. ---
-        let results: Vec<Result<(JointStats, P)>> = (0..num_agents)
-            .into_par_iter()
-            .map(|active_agent| {
-                train_best_response_pure::<B, P, O, E, _, _, _>(
-                    active_agent,
-                    &opp_indices[active_agent],
-                    init_seeds[active_agent],
-                    populations,
-                    config,
-                    joint_config,
-                    device,
-                    policy_factory,
-                    optimizer_factory,
-                    env_factory,
-                )
-            })
-            .collect();
+        // --- BR region: one independent BR per agent. ---
+        //
+        // The closure body is a pure function of the pre-drawn inputs and
+        // collected by index, so serial vs. parallel dispatch is
+        // bit-identical (see `PsroConfig::serialize_br_updates`). When
+        // `serialize_br_updates` is set (the default), the BRs run in a
+        // serial `.map()` so at most one `burn-autodiff` backward graph is
+        // live at a time, side-stepping the 0.21 `GraphLocator`/`GraphState`
+        // lock-order deadlock (issue #307). Otherwise they run concurrently
+        // under `rayon` (the #232 parallel path).
+        let run_br = |active_agent: usize| {
+            train_best_response_pure::<B, P, O, E, _, _, _>(
+                active_agent,
+                &opp_indices[active_agent],
+                init_seeds[active_agent],
+                populations,
+                config,
+                joint_config,
+                device,
+                policy_factory,
+                optimizer_factory,
+                env_factory,
+            )
+        };
+        let results: Vec<Result<(JointStats, P)>> = if config.serialize_br_updates {
+            (0..num_agents).map(run_br).collect()
+        } else {
+            (0..num_agents).into_par_iter().map(run_br).collect()
+        };
 
         // --- Join: unpack results in fixed agent order, propagating the
         // first error deterministically. The immutable borrow of
@@ -2905,6 +2951,7 @@ mod tests {
             max_payoff_evals_per_iteration: None,
             br_reward_scale: 1.0,
             seed: 0,
+            serialize_br_updates: true,
         };
         let joint_config = JointTrainerConfig {
             num_agents: 2,
@@ -3253,6 +3300,7 @@ mod tests {
             max_payoff_evals_per_iteration: None,
             br_reward_scale: 1.0,
             seed: 12345,
+            serialize_br_updates: true,
         };
         let joint_config = JointTrainerConfig {
             num_agents: 2,
@@ -3344,6 +3392,7 @@ mod tests {
             max_payoff_evals_per_iteration: None,
             br_reward_scale: 1.0,
             seed: 0xC0FF_EE12,
+            serialize_br_updates: true,
         };
         let joint_config = JointTrainerConfig {
             num_agents: 2,
@@ -3465,6 +3514,7 @@ mod tests {
             max_payoff_evals_per_iteration: None,
             br_reward_scale: 1.0,
             seed: 0x5EED_2323,
+            serialize_br_updates: true,
         };
         let joint_config = JointTrainerConfig {
             num_agents: 2,

--- a/tests/test_psro_bucket_brigade.rs
+++ b/tests/test_psro_bucket_brigade.rs
@@ -376,6 +376,7 @@ fn test_psro_beats_ppo_on_no_convergence_cells() {
             max_payoff_evals_per_iteration: None,
             br_reward_scale: 1.0,
             seed: SEED.wrapping_add(cell_idx as u64),
+            serialize_br_updates: true,
         };
         let joint_config = JointTrainerConfig {
             num_agents: NUM_AGENTS,

--- a/tests/test_psro_matching_pennies.rs
+++ b/tests/test_psro_matching_pennies.rs
@@ -92,6 +92,7 @@ fn psro_matching_pennies_smoke_runs_and_is_finite() {
         max_payoff_evals_per_iteration: None,
         br_reward_scale: 1.0,
         seed: 17,
+        serialize_br_updates: true,
     };
     let joint_config = JointTrainerConfig {
         num_agents: 2,
@@ -171,6 +172,7 @@ fn test_psro_converges_to_uniform_on_matching_pennies() {
         max_payoff_evals_per_iteration: None,
         br_reward_scale: 1.0,
         seed: 17,
+        serialize_br_updates: true,
     };
     let joint_config = JointTrainerConfig {
         num_agents: 2,
@@ -303,6 +305,7 @@ fn test_psro_exploitability_non_increasing_trend_on_matching_pennies() {
             max_payoff_evals_per_iteration: None,
             br_reward_scale: 1.0,
             seed,
+            serialize_br_updates: true,
         };
         let mut trainer = PsroTrainer::new(
             psro_config,

--- a/tests/test_psro_n_player_matching_pennies.rs
+++ b/tests/test_psro_n_player_matching_pennies.rs
@@ -168,6 +168,10 @@ fn run_psro_n4_cfg(
         max_payoff_evals_per_iteration: None,
         br_reward_scale,
         seed,
+        // Serialize per-agent BR backward passes to avoid the burn-autodiff
+        // 0.21 GraphLocator/GraphState lock-order deadlock on many-core
+        // hosts (issue #307). Does not affect results (determinism holds).
+        serialize_br_updates: true,
     };
     let joint_config = JointTrainerConfig {
         num_agents,
@@ -275,6 +279,62 @@ fn psro_n4_smoke_runs_and_is_finite() {
             (sum - 1.0).abs() <= 1e-3,
             "agent {agent} marginal must sum to ~1, got {sum} on {marginal:?}"
         );
+    }
+}
+
+/// Issue #307 regression guard: two independent N=4 PSRO runs with the
+/// same seed must produce bit-identical `PsroStats`. This pins down two
+/// properties at once on every CI run:
+///
+/// 1. **Hang-free completion.** The serialized best-response path
+///    (`PsroConfig::serialize_br_updates = true`, the default) that side-steps
+///    the burn-autodiff 0.21 `GraphLocator`/`GraphState` lock-order deadlock
+///    (issue #307) drives the full N=4 control flow to completion twice without
+///    wedging.
+///
+/// 2. **Determinism (#232 invariant preserved).** Serializing the BR backward
+///    passes must not change the mathematical result: all shared-mutable draws
+///    are still hoisted into the fixed-order pre-pass and each BR is a pure
+///    function of its pre-drawn inputs, so the per-iteration NashConv and
+///    per-agent meta-Nash marginals must match bit-for-bit between the two
+///    runs.
+#[test]
+fn psro_n4_serialized_br_is_deterministic_issue307() {
+    let max_iterations = 2_usize;
+    let seed = 19_u64;
+    let (_t_a, stats_a) = run_psro_n4(max_iterations, seed);
+    let (_t_b, stats_b) = run_psro_n4(max_iterations, seed);
+
+    assert_eq!(
+        stats_a.iterations.len(),
+        stats_b.iterations.len(),
+        "both runs must record the same number of iterations"
+    );
+    for (i, (a, b)) in stats_a.iterations.iter().zip(stats_b.iterations.iter()).enumerate() {
+        assert_eq!(
+            a.exploitability.to_bits(),
+            b.exploitability.to_bits(),
+            "iteration {i}: NashConv must be bit-identical across seeded runs \
+             ({} vs {})",
+            a.exploitability,
+            b.exploitability
+        );
+        assert_eq!(
+            a.meta_nash_per_agent.len(),
+            b.meta_nash_per_agent.len(),
+            "iteration {i}: both runs must report the same agent count"
+        );
+        for (agent, (ma, mb)) in
+            a.meta_nash_per_agent.iter().zip(b.meta_nash_per_agent.iter()).enumerate()
+        {
+            let bits_a: Vec<u32> = ma.iter().map(|x| x.to_bits()).collect();
+            let bits_b: Vec<u32> = mb.iter().map(|x| x.to_bits()).collect();
+            assert_eq!(
+                bits_a, bits_b,
+                "iteration {i}, agent {agent}: meta-Nash marginal must be \
+                 bit-identical across seeded runs ({ma:?} vs {mb:?})"
+            );
+        }
     }
 }
 

--- a/tests/test_seeded_reproducibility.rs
+++ b/tests/test_seeded_reproducibility.rs
@@ -44,6 +44,7 @@ fn psro_exploitability_trace(seed: u64) -> Vec<f32> {
         max_payoff_evals_per_iteration: None,
         br_reward_scale: 1.0,
         seed,
+        serialize_br_updates: true,
     };
     let joint_config = JointTrainerConfig {
         num_agents: 2,


### PR DESCRIPTION
## Summary

Fixes the local N=4 PSRO deadlock (#307) where `test_psro_n_player_matching_pennies` deterministically wedges at ~0% CPU on macOS arm64. The root cause is a lock-order inversion between the `#232` rayon-parallel best-response training (four concurrent `Autodiff<NdArray>` backward passes) and `burn-autodiff 0.21`'s internal `GraphLocator`/`GraphState` `parking_lot` mutexes.

**Approach chosen: config knob (Direction C1), not a burn bump (Direction B).** Per the curator's guidance I checked crates.io first — `burn`/`burn-ndarray` max out at `0.21.0` (verified via `cargo info burn` and the crates.io API: `max_version: 0.21.0`). No `0.22` exists, so the upstream bump that would fix the deadlock at the source is not yet possible. The knob is the fully-reversible immediate fix; set it back to `false` once a fixed burn is adopted.

## Changes

- Add `PsroConfig::serialize_br_updates: bool` (default `true`), documented with the #307 root cause, the determinism rationale, and a note to restore `false` after the burn bump.
- Branch `PsroTrainer::train_best_responses_parallel`: bind the per-agent BR closure once and dispatch via serial `.map()` when `serialize_br_updates` is set, else the original `into_par_iter().map()`. Only backward-pass concurrency changes; the fixed-order RNG pre-pass and collect-by-index join are untouched. Not gated behind `cfg(target_os)`.
- Add regression guard `psro_n4_serialized_br_is_deterministic_issue307`: runs two seeded N=4 runs and asserts bit-identical NashConv + per-agent meta-Nash marginals (guards both hang-free completion and the #232 determinism invariant on every CI run).
- Propagate the new field (`true`) to every explicit `PsroConfig { .. }` construction across `src/`, `tests/`, and the bucket-brigade example.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `test_psro_n_player_matching_pennies` completes < 3 min, 5 consecutive runs, no `__psynch_cvwait` stall (macOS arm64) | ✅ | 5-run loop of the fast test: all `ok`, 17–24s each; full binary also completes in ~30–88s |
| Same command passes with `--test-threads=1` | ✅ | Ran `-- --test-threads=1`: 2 passed, finished in 31.31s |
| `cargo test --features training` stays green on Linux CI | ✅ | Full suite green locally (500 lib + all integration binaries, 0 failed); change is host-agnostic |
| `psro_n4_smoke_runs_and_is_finite` + `psro_n4_issue215_knobs_run_and_are_finite` pass in default config | ✅ | Both pass under default (`serialize_br_updates: true`) |
| Result unchanged for a fixed seed (determinism / #232 preserved) | ✅ | New `psro_n4_serialized_br_is_deterministic_issue307` asserts bit-identical `PsroStats` across two seed=19 runs; passes |
| `serialize_br_updates` documented with #307 ref + when to reset to `false` | ✅ | Doc comment on the field |
| burn version bump | N/A | No burn 0.22 on crates.io; Direction C1 used instead |

## Test Plan

- `cargo test --features training` — full suite green (all binaries 0 failed).
- `test_psro_n_player_matching_pennies` run 5 consecutive times + once with `--test-threads=1` — no hang, all pass.
- `cargo clippy --all-targets --features training -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features training` — clean.

Closes #307