### PR TITLE
feat(env-atari): AtariEnv subprocess adapter behind the env-atari feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
       # silently the way the base gate does for `training`.
       - name: cargo clippy --all-targets --features "training,env-bucket-brigade" -- -D warnings
         run: cargo clippy --all-targets --features "training,env-bucket-brigade" -- -D warnings
+      # Also lint the optional env-atari feature. Option D (subprocess via
+      # ale-py) adds no native dep, so this compiles safely on a bare runner
+      # with no ALE present; the live-emulator tests are runtime-skipped when
+      # ale-py is absent. See docs/ALE_BINDING_STRATEGY.md.
+      - name: cargo clippy --all-targets --features "training,env-atari" -- -D warnings
+        run: cargo clippy --all-targets --features "training,env-atari" -- -D warnings
 
   # Cheap "does it parse" check without the training stack.
   # `--no-default-features` drops the `training` feature (and thus `burn`).
@@ -174,7 +180,11 @@ jobs:
           cargo package --list --no-default-features --allow-dirty > /tmp/pkg-files.txt
           echo "Tarball contains $(wc -l < /tmp/pkg-files.txt) files:"
           cat /tmp/pkg-files.txt
-          if grep -E '(^|/)models/|\.safetensors$|\.pt$|\.onnx$|(^|/)web/|(^|/)envs/|(^|/)scripts/|(^|/)\.loom/|(^|/)\.claude/|(^|/)\.github/' /tmp/pkg-files.txt; then
+          # ROM binaries (.bin/.rom/.a26) must never enter the tarball either
+          # (env-atari, Option D). ROMs are copyrighted and are resolved at
+          # runtime from the user's ale-py environment — see
+          # docs/ALE_BINDING_STRATEGY.md.
+          if grep -E '(^|/)models/|\.safetensors$|\.pt$|\.onnx$|\.bin$|\.rom$|\.a26$|(^|/)web/|(^|/)envs/|(^|/)scripts/|(^|/)\.loom/|(^|/)\.claude/|(^|/)\.github/' /tmp/pkg-files.txt; then
             echo "::error::Publish tarball includes excluded non-library assets (see matches above). Fix the exclude = [...] list in Cargo.toml."
             exit 1
           fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,12 @@ wasm = ["wasm-bindgen", "web-sys", "js-sys", "console_error_panic_hook"]  # Pure
 # gated and will simply be omitted from the published crate. Re-enable
 # locally by uncommenting both this line and the dependency above.
 env-bucket-brigade = ["bucket-brigade-core"]
+# Atari (ALE) env adapter. Option D (subprocess via ale-py) — see
+# docs/ALE_BINDING_STRATEGY.md. No native/path dependency: the emulator runs as
+# an external `ale-py` process invoked at runtime, so this is a pure compile-time
+# flag with no `[dependencies]` entry and no publish `sed` workaround. Compose
+# with `training`, e.g. `--features "training,env-atari"`.
+env-atari = []
 
 [dev-dependencies]
 criterion = "0.5"

--- a/envs/atari/ale_worker.py
+++ b/envs/atari/ale_worker.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""ALE subprocess worker for thrust's ``env-atari`` feature.
+
+thrust's ``AtariEnv`` (Rust) spawns this script and drives it over a tiny
+length-prefixed binary protocol on stdin/stdout. This keeps the emulator —
+Farama's ``ale-py``, which is GPL-2.0-or-later — as a *separate program* so the
+thrust crate stays MIT/Apache and pulls no native build dependency (Option D of
+docs/ALE_BINDING_STRATEGY.md).
+
+This script is a standalone program, not a package: no ``setup.py``, no
+``__init__.py``. Its only third-party dependency is ``ale-py`` (which brings
+``numpy``); everything else is the Python standard library.
+
+Wire format (must stay in lock-step with ``src/env/games/atari/protocol.rs``):
+
+  * every message = 4-byte little-endian length prefix + that many payload bytes
+  * payload[0] is a tag byte; the rest is tag-specific
+
+  Rust -> Python (commands):
+    0x01 RESET          8-byte LE u64 seed
+    0x02 STEP           4-byte LE i32 action index (into the minimal action set)
+    0x03 CLONE_STATE    (empty)
+    0x04 RESTORE_STATE  opaque state bytes from a prior STATE response
+    0x05 CLOSE          (empty)
+
+  Python -> Rust (responses):
+    0x81 OBS    1-byte terminated, 1-byte truncated, 4-byte LE f32 reward,
+                then H*W*C little-endian f32 pixels (raw 210x160x3 RGB)
+    0x82 STATE  opaque ALE cloneSystemState blob
+    0x83 ERROR  UTF-8 error string
+"""
+
+import os
+import struct
+import sys
+
+# Command tags (Rust -> Python).
+TAG_RESET = 0x01
+TAG_STEP = 0x02
+TAG_CLONE_STATE = 0x03
+TAG_RESTORE_STATE = 0x04
+TAG_CLOSE = 0x05
+
+# Response tags (Python -> Rust).
+TAG_OBS = 0x81
+TAG_STATE = 0x82
+TAG_ERROR = 0x83
+
+
+def _read_exact(n):
+    """Read exactly ``n`` bytes from stdin, or return ``None`` on clean EOF."""
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sys.stdin.buffer.read(n - len(buf))
+        if not chunk:
+            return None
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def read_frame():
+    """Read one length-prefixed frame payload, or ``None`` at EOF."""
+    header = _read_exact(4)
+    if header is None:
+        return None
+    (length,) = struct.unpack("<I", header)
+    if length == 0:
+        return b""
+    payload = _read_exact(length)
+    if payload is None:
+        return None
+    return payload
+
+
+def write_frame(payload):
+    """Write one length-prefixed frame and flush."""
+    sys.stdout.buffer.write(struct.pack("<I", len(payload)))
+    sys.stdout.buffer.write(payload)
+    sys.stdout.buffer.flush()
+
+
+def send_error(message):
+    write_frame(bytes([TAG_ERROR]) + message.encode("utf-8"))
+
+
+def send_state(blob):
+    write_frame(bytes([TAG_STATE]) + bytes(blob))
+
+
+def send_obs(terminated, truncated, reward, pixel_bytes):
+    header = bytes([TAG_OBS, 1 if terminated else 0, 1 if truncated else 0])
+    write_frame(header + struct.pack("<f", float(reward)) + pixel_bytes)
+
+
+def _resolve_rom(rom_id):
+    """Resolve a ROM path from ALE_ROM_PATH, or ``None`` to defer to ale-py.
+
+    ``ALE_ROM_PATH`` may point at a specific ``.bin`` file or a directory
+    containing ``<rom_id>.bin``. When unset, return ``None`` so the caller can
+    fall back to ale-py's own ROM resolution.
+    """
+    path = os.environ.get("ALE_ROM_PATH")
+    if not path:
+        return None
+    if os.path.isdir(path):
+        candidate = os.path.join(path, rom_id + ".bin")
+        if os.path.isfile(candidate):
+            return candidate
+        raise FileNotFoundError(
+            "ROM '%s' not found in ALE_ROM_PATH directory %s" % (rom_id, path)
+        )
+    if os.path.isfile(path):
+        return path
+    raise FileNotFoundError("ALE_ROM_PATH '%s' is neither a file nor a directory" % path)
+
+
+def _load_ale(rom_id, seed):
+    """Import ale-py and return an initialised (ALEInterface, minimal_actions).
+
+    Raises with an actionable message on any failure so the Rust side can turn
+    it into a typed error.
+    """
+    try:
+        from ale_py import ALEInterface
+    except Exception as exc:  # pragma: no cover - exercised only with ale-py absent
+        raise RuntimeError(
+            "ale-py could not be imported (%s). Install it with: pip install ale-py" % exc
+        )
+
+    ale = ALEInterface()
+    ale.setInt("random_seed", int(seed) & 0x7FFFFFFF)
+
+    rom_path = _resolve_rom(rom_id)
+    if rom_path is None:
+        # Defer to ale-py's bundled ROM resolution (AutoROM / packaged ROMs).
+        try:
+            from ale_py import roms as ale_roms
+        except Exception as exc:
+            raise RuntimeError(
+                "ROM '%s' could not be resolved and ale-py's ROM registry is "
+                "unavailable (%s). Set ALE_ROM_PATH or run "
+                "'AutoROM --accept-license'." % (rom_id, exc)
+            )
+        # ale-py exposes ROMs as attributes named in TitleCase (e.g. Pong).
+        attr = rom_id[:1].upper() + rom_id[1:]
+        rom_path = getattr(ale_roms, attr, None)
+        if rom_path is None and hasattr(ale_roms, "get_rom_path"):
+            rom_path = ale_roms.get_rom_path(rom_id)
+        if rom_path is None:
+            raise FileNotFoundError(
+                "ROM '%s' not found in ale-py's ROM registry. Set ALE_ROM_PATH "
+                "or run 'AutoROM --accept-license'." % rom_id
+            )
+
+    ale.loadROM(rom_path)
+    minimal_actions = list(ale.getMinimalActionSet())
+    return ale, minimal_actions
+
+
+def _screen_bytes(ale, np):
+    """Return the current RGB screen as row-major little-endian f32 bytes."""
+    screen = ale.getScreenRGB()  # numpy uint8 array, shape (H, W, 3)
+    return screen.astype("<f4").tobytes()
+
+
+def _clone_state_bytes(ale):
+    """Serialise the full ALE system state to opaque bytes."""
+    state = ale.cloneSystemState()
+    # ale-py exposes several serialisation surfaces across versions; try the
+    # documented ones in order.
+    if hasattr(ale, "encodeState"):
+        return bytes(ale.encodeState(state))
+    if hasattr(state, "serialize"):
+        return bytes(state.serialize())
+    raise RuntimeError("this ale-py build exposes no state serialisation API")
+
+
+def _restore_state_bytes(ale, blob):
+    """Restore the ALE system state from opaque bytes produced by clone."""
+    if hasattr(ale, "decodeState"):
+        ale.restoreSystemState(ale.decodeState(blob))
+        return
+    raise RuntimeError("this ale-py build exposes no state deserialisation API")
+
+
+def main():
+    if len(sys.argv) < 2:
+        send_error("usage: ale_worker.py <rom_id>")
+        return 2
+    rom_id = sys.argv[1]
+
+    try:
+        import numpy as np
+        ale, minimal_actions = _load_ale(rom_id, 0)
+    except Exception as exc:
+        send_error(str(exc))
+        return 1
+
+    while True:
+        payload = read_frame()
+        if payload is None:  # peer closed the pipe
+            return 0
+        if len(payload) == 0:
+            send_error("received an empty (untagged) frame")
+            return 1
+        tag = payload[0]
+        body = payload[1:]
+
+        try:
+            if tag == TAG_RESET:
+                (seed,) = struct.unpack("<Q", body)
+                ale.setInt("random_seed", int(seed) & 0x7FFFFFFF)
+                ale.reset_game()
+                send_obs(ale.game_over(), False, 0.0, _screen_bytes(ale, np))
+            elif tag == TAG_STEP:
+                (action_index,) = struct.unpack("<i", body)
+                if 0 <= action_index < len(minimal_actions):
+                    action = minimal_actions[action_index]
+                else:
+                    action = minimal_actions[0]
+                reward = ale.act(action)
+                terminated = ale.game_over()
+                send_obs(terminated, False, reward, _screen_bytes(ale, np))
+            elif tag == TAG_CLONE_STATE:
+                send_state(_clone_state_bytes(ale))
+            elif tag == TAG_RESTORE_STATE:
+                _restore_state_bytes(ale, body)
+                send_obs(ale.game_over(), False, 0.0, _screen_bytes(ale, np))
+            elif tag == TAG_CLOSE:
+                return 0
+            else:
+                send_error("unknown command tag 0x%02x" % tag)
+                return 1
+        except Exception as exc:  # pragma: no cover - runtime emulator errors
+            send_error("worker error handling tag 0x%02x: %s" % (tag, exc))
+            return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/envs/atari/ale_worker.py
+++ b/envs/atari/ale_worker.py
@@ -114,8 +114,49 @@ def _resolve_rom(rom_id):
     raise FileNotFoundError("ALE_ROM_PATH '%s' is neither a file nor a directory" % path)
 
 
+def _resolve_rom_path(rom_id):
+    """Resolve the ROM file path for ``rom_id`` (env override or ale-py registry).
+
+    Raises ``FileNotFoundError`` with an actionable message if nothing resolves.
+    """
+    rom_path = _resolve_rom(rom_id)
+    if rom_path is not None:
+        return rom_path
+    # Defer to ale-py's bundled ROM resolution (AutoROM / packaged ROMs).
+    try:
+        from ale_py import roms as ale_roms
+    except Exception as exc:
+        raise RuntimeError(
+            "ROM '%s' could not be resolved and ale-py's ROM registry is "
+            "unavailable (%s). Set ALE_ROM_PATH or run "
+            "'AutoROM --accept-license'." % (rom_id, exc)
+        )
+    # ale-py exposes ROMs as attributes named in TitleCase (e.g. Pong).
+    attr = rom_id[:1].upper() + rom_id[1:]
+    rom_path = getattr(ale_roms, attr, None)
+    if rom_path is None and hasattr(ale_roms, "get_rom_path"):
+        rom_path = ale_roms.get_rom_path(rom_id)
+    if rom_path is None:
+        raise FileNotFoundError(
+            "ROM '%s' not found in ale-py's ROM registry. Set ALE_ROM_PATH "
+            "or run 'AutoROM --accept-license'." % rom_id
+        )
+    return rom_path
+
+
+def _load_rom(ale, rom_path, seed):
+    """(Re)load ``rom_path`` into ``ale`` with ``seed`` as the RNG seed.
+
+    ALE only applies ``random_seed`` at ``loadROM`` time, so the seed must be
+    set *before* the load. Callers reload the ROM whenever the seed changes so
+    that ``AtariEnv::new(game, seed)`` actually controls the emulator RNG.
+    """
+    ale.setInt("random_seed", int(seed) & 0x7FFFFFFF)
+    ale.loadROM(rom_path)
+
+
 def _load_ale(rom_id, seed):
-    """Import ale-py and return an initialised (ALEInterface, minimal_actions).
+    """Import ale-py and return ``(ALEInterface, minimal_actions, rom_path)``.
 
     Raises with an actionable message on any failure so the Rust side can turn
     it into a typed error.
@@ -128,55 +169,47 @@ def _load_ale(rom_id, seed):
         )
 
     ale = ALEInterface()
-    ale.setInt("random_seed", int(seed) & 0x7FFFFFFF)
-
-    rom_path = _resolve_rom(rom_id)
-    if rom_path is None:
-        # Defer to ale-py's bundled ROM resolution (AutoROM / packaged ROMs).
-        try:
-            from ale_py import roms as ale_roms
-        except Exception as exc:
-            raise RuntimeError(
-                "ROM '%s' could not be resolved and ale-py's ROM registry is "
-                "unavailable (%s). Set ALE_ROM_PATH or run "
-                "'AutoROM --accept-license'." % (rom_id, exc)
-            )
-        # ale-py exposes ROMs as attributes named in TitleCase (e.g. Pong).
-        attr = rom_id[:1].upper() + rom_id[1:]
-        rom_path = getattr(ale_roms, attr, None)
-        if rom_path is None and hasattr(ale_roms, "get_rom_path"):
-            rom_path = ale_roms.get_rom_path(rom_id)
-        if rom_path is None:
-            raise FileNotFoundError(
-                "ROM '%s' not found in ale-py's ROM registry. Set ALE_ROM_PATH "
-                "or run 'AutoROM --accept-license'." % rom_id
-            )
-
-    ale.loadROM(rom_path)
+    rom_path = _resolve_rom_path(rom_id)
+    _load_rom(ale, rom_path, seed)
     minimal_actions = list(ale.getMinimalActionSet())
-    return ale, minimal_actions
+    return ale, minimal_actions, rom_path
 
 
-def _screen_bytes(ale, np):
+def _screen_bytes(ale):
     """Return the current RGB screen as row-major little-endian f32 bytes."""
     screen = ale.getScreenRGB()  # numpy uint8 array, shape (H, W, 3)
     return screen.astype("<f4").tobytes()
 
 
 def _clone_state_bytes(ale):
-    """Serialise the full ALE system state to opaque bytes."""
+    """Serialise the full ALE system state to opaque bytes.
+
+    Current ale-py (>= 0.10) serialises via ``ALEState.serialize()``. Older
+    builds exposed a top-level ``encodeState``; keep it as a legacy fallback.
+    """
     state = ale.cloneSystemState()
-    # ale-py exposes several serialisation surfaces across versions; try the
-    # documented ones in order.
-    if hasattr(ale, "encodeState"):
-        return bytes(ale.encodeState(state))
     if hasattr(state, "serialize"):
         return bytes(state.serialize())
+    if hasattr(ale, "encodeState"):
+        return bytes(ale.encodeState(state))
     raise RuntimeError("this ale-py build exposes no state serialisation API")
 
 
 def _restore_state_bytes(ale, blob):
-    """Restore the ALE system state from opaque bytes produced by clone."""
+    """Restore the ALE system state from opaque bytes produced by clone.
+
+    Current ale-py reconstructs an ``ALEState`` from the serialised blob and
+    hands it to ``restoreSystemState``. Older builds exposed a top-level
+    ``decodeState``; keep it as a legacy fallback.
+    """
+    blob = bytes(blob)
+    try:
+        from ale_py import ALEState
+    except Exception:  # pragma: no cover - only on very old ale-py
+        ALEState = None
+    if ALEState is not None:
+        ale.restoreSystemState(ALEState(blob))
+        return
     if hasattr(ale, "decodeState"):
         ale.restoreSystemState(ale.decodeState(blob))
         return
@@ -190,11 +223,15 @@ def main():
     rom_id = sys.argv[1]
 
     try:
-        import numpy as np
-        ale, minimal_actions = _load_ale(rom_id, 0)
+        ale, minimal_actions, rom_path = _load_ale(rom_id, 0)
     except Exception as exc:
         send_error(str(exc))
         return 1
+
+    # Track the seed the ROM is currently loaded under so RESET only pays the
+    # reload cost when the seed actually changes (ALE applies random_seed at
+    # loadROM time only).
+    loaded_seed = 0
 
     while True:
         payload = read_frame()
@@ -209,9 +246,13 @@ def main():
         try:
             if tag == TAG_RESET:
                 (seed,) = struct.unpack("<Q", body)
-                ale.setInt("random_seed", int(seed) & 0x7FFFFFFF)
+                # ALE only honours random_seed at loadROM time, so reload the
+                # ROM whenever the requested seed differs from the loaded one.
+                if seed != loaded_seed:
+                    _load_rom(ale, rom_path, seed)
+                    loaded_seed = seed
                 ale.reset_game()
-                send_obs(ale.game_over(), False, 0.0, _screen_bytes(ale, np))
+                send_obs(ale.game_over(), False, 0.0, _screen_bytes(ale))
             elif tag == TAG_STEP:
                 (action_index,) = struct.unpack("<i", body)
                 if 0 <= action_index < len(minimal_actions):
@@ -220,12 +261,12 @@ def main():
                     action = minimal_actions[0]
                 reward = ale.act(action)
                 terminated = ale.game_over()
-                send_obs(terminated, False, reward, _screen_bytes(ale, np))
+                send_obs(terminated, False, reward, _screen_bytes(ale))
             elif tag == TAG_CLONE_STATE:
                 send_state(_clone_state_bytes(ale))
             elif tag == TAG_RESTORE_STATE:
                 _restore_state_bytes(ale, body)
-                send_obs(ale.game_over(), False, 0.0, _screen_bytes(ale, np))
+                send_obs(ale.game_over(), False, 0.0, _screen_bytes(ale))
             elif tag == TAG_CLOSE:
                 return 0
             else:

--- a/src/env/games/atari/env.rs
+++ b/src/env/games/atari/env.rs
@@ -1,0 +1,363 @@
+//! [`AtariEnv`] — the subprocess client implementing [`Environment`].
+//!
+//! `AtariEnv` owns a child `ale-py` process (or, in tests, any transport that
+//! speaks the [frame protocol](super::protocol)) and forwards
+//! reset/step/clone/restore over the pipe. See the [module docs](super) for the
+//! GPL-2.0 runtime NOTICE and the ROM-resolution contract.
+
+use std::{
+    cell::RefCell,
+    env,
+    ffi::OsStr,
+    io::{BufReader, Read, Write},
+    path::{Path, PathBuf},
+    process::{Child, Command as ProcCommand, Stdio},
+};
+
+use super::{
+    error::AtariEnvError,
+    protocol::{self, Command, OBS_CHANNELS, OBS_HEIGHT, OBS_LEN, OBS_WIDTH, Response},
+};
+use crate::env::{Environment, SpaceInfo, SpaceType, StepInfo, StepResult};
+
+/// Environment variable naming the Python interpreter to launch. Defaults to
+/// `python3` when unset.
+pub const ENV_PYTHON: &str = "ATARI_PYTHON";
+/// Environment variable naming the `ale_worker.py` script. Defaults to
+/// `envs/atari/ale_worker.py` (relative to the current working directory) when
+/// unset.
+pub const ENV_WORKER_SCRIPT: &str = "ATARI_WORKER_SCRIPT";
+/// Default worker-script path, relative to the crate root / cwd.
+pub const DEFAULT_WORKER_SCRIPT: &str = "envs/atari/ale_worker.py";
+
+/// Number of discrete actions in Pong's minimal action set (`NOOP`, `FIRE`,
+/// `RIGHT`, `LEFT`, `RIGHTFIRE`, `LEFTFIRE`).
+pub const PONG_ACTION_COUNT: usize = 6;
+
+/// The reader/writer/child triple, held behind a [`RefCell`] so the
+/// `&self`-only [`Environment::clone_state`] can still drive the pipe.
+struct Transport {
+    reader: BufReader<Box<dyn Read + Send>>,
+    writer: Box<dyn Write + Send>,
+    child: Option<Child>,
+}
+
+/// A subprocess-backed Atari (ALE) environment.
+///
+/// `AtariEnv` implements [`Environment`] by forwarding each operation to an
+/// `ale-py` worker over a length-prefixed binary protocol. The raw
+/// `210 × 160 × 3` RGB frame is returned verbatim as `f32` values in
+/// `0.0..=255.0`; preprocessing (grayscale, downsample, frame-stack) is a
+/// downstream concern.
+///
+/// # Determinism
+///
+/// `reset()` forwards the seed captured at construction to the worker, so two
+/// `AtariEnv::new("pong", seed)` instances reset to bit-identical first
+/// observations. `clone_state()` / `restore_state()` round-trip the full ALE
+/// system state, so a trajectory replayed after `restore_state` is
+/// bit-identical to the original.
+///
+/// # Panics
+///
+/// The [`Environment`] trait methods panic (with an actionable message) if the
+/// worker reports an error or the pipe fails. Use the [`AtariEnv::try_reset`],
+/// [`AtariEnv::try_step`], etc. variants to handle those errors explicitly.
+pub struct AtariEnv {
+    io: RefCell<Transport>,
+    game_id: String,
+    seed: u64,
+    last_obs: Vec<f32>,
+    last_reward: f32,
+    last_terminated: bool,
+    last_truncated: bool,
+}
+
+impl AtariEnv {
+    /// Spawn the default worker (`ATARI_PYTHON` or `python3`, running
+    /// `ATARI_WORKER_SCRIPT` or [`DEFAULT_WORKER_SCRIPT`]) for `game_id`.
+    ///
+    /// `ALE_ROM_PATH`, if set in this process's environment, is inherited by
+    /// the child and used by the worker to resolve the ROM.
+    ///
+    /// This only launches the process; call [`Environment::reset`] (or
+    /// [`AtariEnv::try_reset`]) to drive the first frame. Worker-side failures
+    /// (missing `ale-py`, unresolved ROM) surface on that first exchange.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AtariEnvError::MissingPython`] if the interpreter cannot be
+    /// launched, or [`AtariEnvError::Io`] for other spawn failures.
+    pub fn new(game_id: &str, seed: u64) -> Result<Self, AtariEnvError> {
+        let python = env::var(ENV_PYTHON).unwrap_or_else(|_| "python3".to_string());
+        let script = env::var(ENV_WORKER_SCRIPT)
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(DEFAULT_WORKER_SCRIPT));
+        Self::spawn_with(python, script, game_id, seed)
+    }
+
+    /// Spawn an explicit `python`/`script` worker for `game_id`. Prefer
+    /// [`AtariEnv::new`] in application code; this constructor exists for tests
+    /// and callers that resolve the interpreter and script themselves.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AtariEnvError::MissingPython`] if the interpreter cannot be
+    /// launched (e.g. the path does not exist), or [`AtariEnvError::Io`] for
+    /// other spawn failures.
+    pub fn spawn_with(
+        python: impl AsRef<OsStr>,
+        script: impl AsRef<Path>,
+        game_id: &str,
+        seed: u64,
+    ) -> Result<Self, AtariEnvError> {
+        let python_ref = python.as_ref();
+        let mut child = ProcCommand::new(python_ref)
+            .arg(script.as_ref())
+            .arg(game_id)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|source| AtariEnvError::MissingPython {
+                path: python_ref.to_string_lossy().into_owned(),
+                source,
+            })?;
+
+        let writer: Box<dyn Write + Send> =
+            Box::new(child.stdin.take().expect("child stdin was requested as piped"));
+        let reader: Box<dyn Read + Send> =
+            Box::new(child.stdout.take().expect("child stdout was requested as piped"));
+
+        Ok(Self::from_parts(reader, writer, Some(child), game_id, seed))
+    }
+
+    /// Build an `AtariEnv` over an arbitrary transport that speaks the
+    /// [frame protocol](super::protocol). Used by tests to drive the env with a
+    /// mock worker (no Python required); also usable to bind an already-running
+    /// worker over any `Read`/`Write` pair (e.g. a socket).
+    pub fn from_transport(
+        reader: Box<dyn Read + Send>,
+        writer: Box<dyn Write + Send>,
+        game_id: &str,
+        seed: u64,
+    ) -> Self {
+        Self::from_parts(reader, writer, None, game_id, seed)
+    }
+
+    fn from_parts(
+        reader: Box<dyn Read + Send>,
+        writer: Box<dyn Write + Send>,
+        child: Option<Child>,
+        game_id: &str,
+        seed: u64,
+    ) -> Self {
+        AtariEnv {
+            io: RefCell::new(Transport { reader: BufReader::new(reader), writer, child }),
+            game_id: game_id.to_string(),
+            seed,
+            last_obs: Vec::new(),
+            last_reward: 0.0,
+            last_terminated: false,
+            last_truncated: false,
+        }
+    }
+
+    /// The game id this env was constructed with (e.g. `"pong"`).
+    #[must_use]
+    pub fn game_id(&self) -> &str {
+        &self.game_id
+    }
+
+    /// The seed forwarded to the worker on [`Environment::reset`].
+    #[must_use]
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    /// Send `cmd` and read the single response frame it elicits.
+    ///
+    /// Takes `&self` (via interior mutability) so `clone_state` can use it.
+    fn exchange(&self, cmd: &Command) -> Result<Response, AtariEnvError> {
+        let mut io = self.io.borrow_mut();
+        protocol::write_command(&mut io.writer, cmd)?;
+        io.writer.flush()?;
+        Ok(protocol::read_response(&mut io.reader)?)
+    }
+
+    /// Apply an `Obs` response to the cached observation fields, mapping
+    /// `Error`/unexpected responses onto typed errors.
+    fn apply_obs(&mut self, resp: Response) -> Result<(), AtariEnvError> {
+        match resp {
+            Response::Obs { terminated, truncated, reward, pixels } => {
+                if pixels.len() != OBS_LEN {
+                    return Err(AtariEnvError::Protocol(format!(
+                        "expected {OBS_LEN} observation elements ({OBS_HEIGHT}×{OBS_WIDTH}×{OBS_CHANNELS}), got {}",
+                        pixels.len()
+                    )));
+                }
+                self.last_obs = pixels;
+                self.last_reward = reward;
+                self.last_terminated = terminated;
+                self.last_truncated = truncated;
+                Ok(())
+            }
+            Response::Error(msg) => Err(AtariEnvError::from_worker_message(msg)),
+            Response::State(_) => Err(AtariEnvError::Protocol(
+                "expected an OBS response but the worker sent STATE".to_string(),
+            )),
+        }
+    }
+
+    /// Fallible [`Environment::reset`]: forward the seed and cache the initial
+    /// frame.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AtariEnvError`] if the worker reports an error (missing
+    /// `ale-py`, unresolved ROM) or the pipe fails.
+    pub fn try_reset(&mut self) -> Result<(), AtariEnvError> {
+        let resp = self.exchange(&Command::Reset(self.seed))?;
+        self.apply_obs(resp)
+    }
+
+    /// Fallible [`Environment::step`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AtariEnvError`] if the worker reports an error or the pipe
+    /// fails.
+    pub fn try_step(&mut self, action: i64) -> Result<StepResult, AtariEnvError> {
+        let resp = self.exchange(&Command::Step(action as i32))?;
+        self.apply_obs(resp)?;
+        Ok(StepResult {
+            observation: self.last_obs.clone(),
+            reward: self.last_reward,
+            terminated: self.last_terminated,
+            truncated: self.last_truncated,
+            info: StepInfo::default(),
+        })
+    }
+
+    /// Fallible [`Environment::clone_state`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AtariEnvError`] if the worker reports an error or the pipe
+    /// fails.
+    pub fn try_clone_state(&self) -> Result<Vec<u8>, AtariEnvError> {
+        match self.exchange(&Command::CloneState)? {
+            Response::State(bytes) => Ok(bytes),
+            Response::Error(msg) => Err(AtariEnvError::from_worker_message(msg)),
+            Response::Obs { .. } => Err(AtariEnvError::Protocol(
+                "expected a STATE response but the worker sent OBS".to_string(),
+            )),
+        }
+    }
+
+    /// Fallible [`Environment::restore_state`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AtariEnvError`] if the worker reports an error or the pipe
+    /// fails.
+    pub fn try_restore_state(&mut self, state: &[u8]) -> Result<(), AtariEnvError> {
+        let resp = self.exchange(&Command::RestoreState(state.to_vec()))?;
+        self.apply_obs(resp)
+    }
+
+    /// Fallible [`Environment::close`]: ask the worker to exit and reap the
+    /// child.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AtariEnvError`] if writing the CLOSE frame fails.
+    pub fn try_close(&mut self) -> Result<(), AtariEnvError> {
+        {
+            let mut io = self.io.borrow_mut();
+            protocol::write_command(&mut io.writer, &Command::Close)?;
+            io.writer.flush()?;
+            if let Some(child) = io.child.as_mut() {
+                let _ = child.wait();
+            }
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for AtariEnv {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let has_child = self.io.borrow().child.is_some();
+        f.debug_struct("AtariEnv")
+            .field("game_id", &self.game_id)
+            .field("seed", &self.seed)
+            .field("obs_len", &self.last_obs.len())
+            .field("owns_child", &has_child)
+            .finish()
+    }
+}
+
+impl Drop for AtariEnv {
+    fn drop(&mut self) {
+        // Best-effort: tell the worker to exit, then make sure the child does
+        // not linger as a zombie. Ignore all errors — Drop must not panic.
+        let mut io = self.io.borrow_mut();
+        let _ = protocol::write_command(&mut io.writer, &Command::Close);
+        let _ = io.writer.flush();
+        if let Some(mut child) = io.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+impl Environment for AtariEnv {
+    /// Discrete action index into the minimal action set.
+    type Action = i64;
+
+    /// Opaque ALE system-state blob (`ale.cloneSystemState()`), forwarded
+    /// verbatim to and from the worker.
+    type State = Vec<u8>;
+
+    fn reset(&mut self) {
+        self.try_reset().unwrap_or_else(|e| panic!("AtariEnv::reset failed: {e}"));
+    }
+
+    fn get_observation(&self) -> Vec<f32> {
+        self.last_obs.clone()
+    }
+
+    fn step(&mut self, action: i64) -> StepResult {
+        self.try_step(action).unwrap_or_else(|e| panic!("AtariEnv::step failed: {e}"))
+    }
+
+    fn observation_space(&self) -> SpaceInfo {
+        SpaceInfo { shape: vec![OBS_HEIGHT, OBS_WIDTH, OBS_CHANNELS], space_type: SpaceType::Box }
+    }
+
+    fn action_space(&self) -> SpaceInfo {
+        SpaceInfo {
+            shape: vec![PONG_ACTION_COUNT],
+            space_type: SpaceType::Discrete(PONG_ACTION_COUNT),
+        }
+    }
+
+    fn render(&self) -> Vec<u8> {
+        // Raw frame pixels are already in 0..=255; clamp defensively.
+        self.last_obs.iter().map(|&p| p.clamp(0.0, 255.0) as u8).collect()
+    }
+
+    fn close(&mut self) {
+        let _ = self.try_close();
+    }
+
+    fn clone_state(&self) -> Vec<u8> {
+        self.try_clone_state()
+            .unwrap_or_else(|e| panic!("AtariEnv::clone_state failed: {e}"))
+    }
+
+    fn restore_state(&mut self, state: &Vec<u8>) {
+        self.try_restore_state(state)
+            .unwrap_or_else(|e| panic!("AtariEnv::restore_state failed: {e}"));
+    }
+}

--- a/src/env/games/atari/error.rs
+++ b/src/env/games/atari/error.rs
@@ -1,0 +1,82 @@
+//! Error types for the `env-atari` subprocess adapter.
+//!
+//! Every variant's [`Display`](std::fmt::Display) text is written to be
+//! *actionable*: it names the remedy (install a package, set an env var, run
+//! AutoROM) rather than surfacing a bare "file not found". The
+//! [`Environment`](crate::env::Environment) trait methods (`reset`, `step`, …)
+//! return no `Result`, so on failure they
+//! panic with these messages; the fallible `try_*` methods on
+//! [`AtariEnv`](super::AtariEnv) return them directly for callers (and tests)
+//! that want to inspect the error.
+
+use std::io;
+
+/// Errors raised while spawning or communicating with the `ale-py` worker.
+#[derive(Debug, thiserror::Error)]
+pub enum AtariEnvError {
+    /// The Python interpreter could not be spawned (typically it is not on
+    /// `PATH`).
+    #[error(
+        "failed to launch the Python worker `{path}`: {source}. \
+         Install Python 3 and ensure it is on PATH, or set the ATARI_PYTHON \
+         environment variable to a valid interpreter."
+    )]
+    MissingPython {
+        /// The interpreter path or name that failed to launch.
+        path: String,
+        /// The underlying spawn error.
+        source: io::Error,
+    },
+
+    /// The worker's Python environment does not have `ale-py` importable.
+    #[error(
+        "the ale-py package is not available in the worker's Python \
+         environment ({0}). Install it with: pip install ale-py"
+    )]
+    MissingAlePy(String),
+
+    /// The requested ROM could not be resolved by the worker.
+    #[error(
+        "could not resolve the Atari ROM ({0}). Set ALE_ROM_PATH to a \
+         directory (or file) containing the ROM, or run \
+         `AutoROM --accept-license` to download ROMs into ale-py's ROM directory."
+    )]
+    MissingRom(String),
+
+    /// The worker sent a message that violated the frame protocol.
+    #[error("Atari worker protocol error: {0}")]
+    Protocol(String),
+
+    /// The worker reported an error that did not match a more specific variant.
+    #[error("Atari worker reported an error: {0}")]
+    Worker(String),
+
+    /// An I/O error occurred while reading from or writing to the worker.
+    #[error("I/O error communicating with the Atari worker: {0}")]
+    Io(#[from] io::Error),
+}
+
+impl AtariEnvError {
+    /// Classify a free-form error string reported by the worker (an `ERROR`
+    /// frame) into the most specific variant. The worker composes a
+    /// human-readable message; this maps it onto the typed surface so callers
+    /// can `match` on the cause while the [`Display`](std::fmt::Display) text
+    /// still names the remedy.
+    #[must_use]
+    pub fn from_worker_message(msg: String) -> Self {
+        let lower = msg.to_lowercase();
+        // Check ROM first: a "ROM" mention is the more specific signal, and a
+        // ROM error message may legitimately also name ale-py (e.g. "not found
+        // in ale-py's ROM registry").
+        if lower.contains("rom") {
+            AtariEnvError::MissingRom(msg)
+        } else if lower.contains("ale-py")
+            || lower.contains("ale_py")
+            || lower.contains("no module named")
+        {
+            AtariEnvError::MissingAlePy(msg)
+        } else {
+            AtariEnvError::Worker(msg)
+        }
+    }
+}

--- a/src/env/games/atari/mod.rs
+++ b/src/env/games/atari/mod.rs
@@ -1,0 +1,60 @@
+//! Atari (ALE) environment adapter — feature `env-atari`.
+//!
+//! [`AtariEnv`] implements the [`Environment`](crate::env::Environment) trait
+//! by driving Farama's [`ale-py`](https://github.com/Farama-Foundation/Arcade-Learning-Environment)
+//! as a **subprocess**: the Rust parent spawns `envs/atari/ale_worker.py` and
+//! exchanges seeds, actions, observations and state snapshots over a small
+//! length-prefixed binary protocol on the child's stdin/stdout. This is
+//! *Option D* from [`docs/ALE_BINDING_STRATEGY.md`](https://github.com/rjwalters/thrust/blob/main/docs/ALE_BINDING_STRATEGY.md);
+//! it adds **no** compile-time native dependency, so `env-atari = []` is a pure
+//! feature flag and a fresh checkout still builds with no system libraries.
+//!
+//! # ⚠️ Runtime requirements and licensing NOTICE
+//!
+//! Building with `--features env-atari` compiles only the Rust client. To
+//! *run* it you must, separately, install the emulator in the worker's Python
+//! environment:
+//!
+//! ```text
+//! pip install ale-py                          # the ALE emulator + Python API
+//! AutoROM --accept-license                     # (if your ale-py does not bundle ROMs)
+//! ```
+//!
+//! **ALE (`ale-py`) is licensed GPL-2.0-or-later.** thrust invokes it as a
+//! *separate program* over a pipe — arm's-length runtime aggregation — so no
+//! GPL code is linked into, vendored in, or distributed with the thrust crate,
+//! and thrust itself stays `MIT OR Apache-2.0`. Enabling this feature is a
+//! deliberate choice to depend on that external GPL program at runtime.
+//! Atari ROMs are copyrighted and are **never** committed to this repository or
+//! shipped in the crate tarball.
+//!
+//! # ROM resolution
+//!
+//! Set `ALE_ROM_PATH` to a directory (or file) of ROMs to override lookup; the
+//! variable is inherited by the worker process. When it is unset the worker
+//! falls back to `ale-py`'s own ROM resolution. An unresolved ROM produces an
+//! actionable [`AtariEnvError::MissingRom`] naming both remedies.
+//!
+//! # Scope (v1)
+//!
+//! Raw `210 × 160 × 3` RGB observations (as `f32`, `0.0..=255.0`); Pong's
+//! 6-action minimal set. Machado preprocessing and a CNN policy compose on top
+//! in follow-up issues.
+//!
+//! ```no_run
+//! use thrust_rl::env::{Environment, games::atari::AtariEnv};
+//!
+//! // Requires `ale-py` installed and a resolvable Pong ROM.
+//! let mut env = AtariEnv::new("pong", 42).expect("spawn ale-py worker");
+//! env.reset();
+//! let obs = env.get_observation();
+//! assert_eq!(obs.len(), 210 * 160 * 3);
+//! ```
+
+pub mod error;
+pub mod protocol;
+
+mod env;
+
+pub use env::{AtariEnv, DEFAULT_WORKER_SCRIPT, ENV_PYTHON, ENV_WORKER_SCRIPT, PONG_ACTION_COUNT};
+pub use error::AtariEnvError;

--- a/src/env/games/atari/protocol.rs
+++ b/src/env/games/atari/protocol.rs
@@ -1,0 +1,376 @@
+//! Frame protocol codec for the `env-atari` subprocess binding.
+//!
+//! `AtariEnv` (the Rust parent) talks to `envs/atari/ale_worker.py` (the
+//! `ale-py` child) over the child's stdin/stdout using a tiny, dependency-free
+//! binary protocol. This module is the single source of truth for that wire
+//! format so both the Rust codec and the Python worker stay in lock-step.
+//!
+//! # Framing
+//!
+//! Every message is a **4-byte little-endian unsigned length prefix** followed
+//! by exactly that many payload bytes. The first payload byte is a *tag* that
+//! identifies the message; the remaining bytes are tag-specific. Pure
+//! `struct`-packing — no msgpack, no serde — keeps the Python side stdlib-only
+//! and makes the Rust codec trivially unit-testable without spawning a process.
+//!
+//! # Messages
+//!
+//! Parent → child ([`Command`]):
+//!
+//! | Tag  | Name            | Payload                                   |
+//! |------|-----------------|-------------------------------------------|
+//! | 0x01 | `Reset`         | 8-byte LE `u64` seed                      |
+//! | 0x02 | `Step`          | 4-byte LE `i32` action index              |
+//! | 0x03 | `CloneState`    | (empty)                                   |
+//! | 0x04 | `RestoreState`  | opaque state bytes from a prior `State`   |
+//! | 0x05 | `Close`         | (empty — child flushes and exits)         |
+//!
+//! Child → parent ([`Response`]):
+//!
+//! | Tag  | Name    | Payload                                                        |
+//! |------|---------|---------------------------------------------------------------|
+//! | 0x81 | `Obs`   | 1-byte terminated, 1-byte truncated, 4-byte LE `f32` reward, then `H × W × C` LE `f32` pixels |
+//! | 0x82 | `State` | opaque ALE `cloneSystemState` blob                            |
+//! | 0x83 | `Error` | UTF-8 error string                                            |
+
+use std::io::{self, Read, Write};
+
+/// Tag byte for [`Command::Reset`].
+pub const TAG_RESET: u8 = 0x01;
+/// Tag byte for [`Command::Step`].
+pub const TAG_STEP: u8 = 0x02;
+/// Tag byte for [`Command::CloneState`].
+pub const TAG_CLONE_STATE: u8 = 0x03;
+/// Tag byte for [`Command::RestoreState`].
+pub const TAG_RESTORE_STATE: u8 = 0x04;
+/// Tag byte for [`Command::Close`].
+pub const TAG_CLOSE: u8 = 0x05;
+
+/// Tag byte for [`Response::Obs`].
+pub const TAG_OBS: u8 = 0x81;
+/// Tag byte for [`Response::State`].
+pub const TAG_STATE: u8 = 0x82;
+/// Tag byte for [`Response::Error`].
+pub const TAG_ERROR: u8 = 0x83;
+
+/// Observation frame height (raw ALE screen), in pixels.
+pub const OBS_HEIGHT: usize = 210;
+/// Observation frame width (raw ALE screen), in pixels.
+pub const OBS_WIDTH: usize = 160;
+/// Observation frame channel count (RGB).
+pub const OBS_CHANNELS: usize = 3;
+/// Total number of `f32` elements in one raw observation
+/// (`OBS_HEIGHT * OBS_WIDTH * OBS_CHANNELS`).
+pub const OBS_LEN: usize = OBS_HEIGHT * OBS_WIDTH * OBS_CHANNELS;
+
+/// A message sent from the Rust parent to the Python child.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Command {
+    /// Reset the emulator with the given RNG seed.
+    Reset(u64),
+    /// Step the emulator with an action index into the minimal action set.
+    Step(i32),
+    /// Request an opaque snapshot of the full emulator state.
+    CloneState,
+    /// Restore the emulator to a previously-snapshotted opaque state.
+    RestoreState(Vec<u8>),
+    /// Ask the child to flush and exit cleanly.
+    Close,
+}
+
+/// A message sent from the Python child back to the Rust parent.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Response {
+    /// An observation frame plus the transition flags and reward.
+    Obs {
+        /// Whether the episode terminated on this transition.
+        terminated: bool,
+        /// Whether the episode was truncated on this transition.
+        truncated: bool,
+        /// Reward accumulated over the transition.
+        reward: f32,
+        /// Raw pixel data, row-major `H × W × C`, values in `0.0..=255.0`.
+        pixels: Vec<f32>,
+    },
+    /// An opaque emulator-state blob (from `ale.cloneSystemState()`).
+    State(Vec<u8>),
+    /// A human-readable error reported by the worker.
+    Error(String),
+}
+
+fn invalid_data(msg: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, msg.into())
+}
+
+fn frame(payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + payload.len());
+    out.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    out.extend_from_slice(payload);
+    out
+}
+
+/// Encode a [`Command`] into a complete length-prefixed frame.
+#[must_use]
+pub fn encode_command(cmd: &Command) -> Vec<u8> {
+    frame(&command_payload(cmd))
+}
+
+fn command_payload(cmd: &Command) -> Vec<u8> {
+    match cmd {
+        Command::Reset(seed) => {
+            let mut p = Vec::with_capacity(9);
+            p.push(TAG_RESET);
+            p.extend_from_slice(&seed.to_le_bytes());
+            p
+        }
+        Command::Step(action) => {
+            let mut p = Vec::with_capacity(5);
+            p.push(TAG_STEP);
+            p.extend_from_slice(&action.to_le_bytes());
+            p
+        }
+        Command::CloneState => vec![TAG_CLONE_STATE],
+        Command::RestoreState(bytes) => {
+            let mut p = Vec::with_capacity(1 + bytes.len());
+            p.push(TAG_RESTORE_STATE);
+            p.extend_from_slice(bytes);
+            p
+        }
+        Command::Close => vec![TAG_CLOSE],
+    }
+}
+
+/// Decode a [`Command`] from a frame payload (the bytes *after* the length
+/// prefix).
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::InvalidData`] if the payload is empty, carries an
+/// unknown tag, or has the wrong length for its tag.
+pub fn decode_command(payload: &[u8]) -> io::Result<Command> {
+    let (&tag, rest) =
+        payload.split_first().ok_or_else(|| invalid_data("empty command payload"))?;
+    match tag {
+        TAG_RESET => {
+            let bytes: [u8; 8] =
+                rest.try_into().map_err(|_| invalid_data("RESET payload must be 8 bytes"))?;
+            Ok(Command::Reset(u64::from_le_bytes(bytes)))
+        }
+        TAG_STEP => {
+            let bytes: [u8; 4] =
+                rest.try_into().map_err(|_| invalid_data("STEP payload must be 4 bytes"))?;
+            Ok(Command::Step(i32::from_le_bytes(bytes)))
+        }
+        TAG_CLONE_STATE => Ok(Command::CloneState),
+        TAG_RESTORE_STATE => Ok(Command::RestoreState(rest.to_vec())),
+        TAG_CLOSE => Ok(Command::Close),
+        other => Err(invalid_data(format!("unknown command tag {other:#04x}"))),
+    }
+}
+
+/// Encode a [`Response`] into a complete length-prefixed frame.
+#[must_use]
+pub fn encode_response(resp: &Response) -> Vec<u8> {
+    frame(&response_payload(resp))
+}
+
+fn response_payload(resp: &Response) -> Vec<u8> {
+    match resp {
+        Response::Obs { terminated, truncated, reward, pixels } => {
+            let mut p = Vec::with_capacity(7 + pixels.len() * 4);
+            p.push(TAG_OBS);
+            p.push(u8::from(*terminated));
+            p.push(u8::from(*truncated));
+            p.extend_from_slice(&reward.to_le_bytes());
+            for px in pixels {
+                p.extend_from_slice(&px.to_le_bytes());
+            }
+            p
+        }
+        Response::State(bytes) => {
+            let mut p = Vec::with_capacity(1 + bytes.len());
+            p.push(TAG_STATE);
+            p.extend_from_slice(bytes);
+            p
+        }
+        Response::Error(msg) => {
+            let mut p = Vec::with_capacity(1 + msg.len());
+            p.push(TAG_ERROR);
+            p.extend_from_slice(msg.as_bytes());
+            p
+        }
+    }
+}
+
+/// Decode a [`Response`] from a frame payload (the bytes *after* the length
+/// prefix).
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::InvalidData`] if the payload is empty, carries an
+/// unknown tag, or is malformed for its tag (e.g. an `Obs` whose pixel byte
+/// count is not a multiple of 4).
+pub fn decode_response(payload: &[u8]) -> io::Result<Response> {
+    let (&tag, rest) =
+        payload.split_first().ok_or_else(|| invalid_data("empty response payload"))?;
+    match tag {
+        TAG_OBS => {
+            if rest.len() < 6 {
+                return Err(invalid_data("OBS payload shorter than its 6-byte header"));
+            }
+            let terminated = rest[0] != 0;
+            let truncated = rest[1] != 0;
+            let reward = f32::from_le_bytes(rest[2..6].try_into().unwrap());
+            let pixel_bytes = &rest[6..];
+            if !pixel_bytes.len().is_multiple_of(4) {
+                return Err(invalid_data("OBS pixel byte count is not a multiple of 4"));
+            }
+            let pixels = pixel_bytes
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+                .collect();
+            Ok(Response::Obs { terminated, truncated, reward, pixels })
+        }
+        TAG_STATE => Ok(Response::State(rest.to_vec())),
+        TAG_ERROR => Ok(Response::Error(String::from_utf8_lossy(rest).into_owned())),
+        other => Err(invalid_data(format!("unknown response tag {other:#04x}"))),
+    }
+}
+
+fn read_frame<R: Read>(reader: &mut R) -> io::Result<Vec<u8>> {
+    let mut len_buf = [0u8; 4];
+    reader.read_exact(&mut len_buf)?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+    let mut payload = vec![0u8; len];
+    reader.read_exact(&mut payload)?;
+    Ok(payload)
+}
+
+/// Write a [`Command`] frame to `writer`. Does not flush.
+///
+/// # Errors
+///
+/// Propagates any I/O error from the underlying writer.
+pub fn write_command<W: Write>(writer: &mut W, cmd: &Command) -> io::Result<()> {
+    writer.write_all(&encode_command(cmd))
+}
+
+/// Read one [`Command`] frame from `reader` (used by the worker-side mock in
+/// tests and by the Python worker's Rust-side test doubles).
+///
+/// # Errors
+///
+/// Propagates I/O errors (including [`io::ErrorKind::UnexpectedEof`] when the
+/// peer closes the pipe) and decode errors.
+pub fn read_command<R: Read>(reader: &mut R) -> io::Result<Command> {
+    let payload = read_frame(reader)?;
+    decode_command(&payload)
+}
+
+/// Write a [`Response`] frame to `writer`. Does not flush.
+///
+/// # Errors
+///
+/// Propagates any I/O error from the underlying writer.
+pub fn write_response<W: Write>(writer: &mut W, resp: &Response) -> io::Result<()> {
+    writer.write_all(&encode_response(resp))
+}
+
+/// Read one [`Response`] frame from `reader`.
+///
+/// # Errors
+///
+/// Propagates I/O errors (including [`io::ErrorKind::UnexpectedEof`] when the
+/// child closes the pipe) and decode errors.
+pub fn read_response<R: Read>(reader: &mut R) -> io::Result<Response> {
+    let payload = read_frame(reader)?;
+    decode_response(&payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Strip the 4-byte length prefix, asserting it matches the payload length.
+    fn payload_of(frame: &[u8]) -> &[u8] {
+        let len = u32::from_le_bytes(frame[0..4].try_into().unwrap()) as usize;
+        assert_eq!(len, frame.len() - 4, "length prefix must match payload length");
+        &frame[4..]
+    }
+
+    #[test]
+    fn codec_reset_round_trip() {
+        let frame = encode_command(&Command::Reset(42));
+        let decoded = decode_command(payload_of(&frame)).unwrap();
+        assert_eq!(decoded, Command::Reset(42));
+    }
+
+    #[test]
+    fn codec_step_round_trip() {
+        let frame = encode_command(&Command::Step(3));
+        let decoded = decode_command(payload_of(&frame)).unwrap();
+        assert_eq!(decoded, Command::Step(3));
+
+        // Negative action indices survive the i32 round-trip too.
+        let frame = encode_command(&Command::Step(-7));
+        assert_eq!(decode_command(payload_of(&frame)).unwrap(), Command::Step(-7));
+    }
+
+    #[test]
+    fn codec_obs_response_round_trip() {
+        let pixels: Vec<f32> = (0..OBS_LEN).map(|i| (i % 256) as f32).collect();
+        let resp = Response::Obs { terminated: false, truncated: true, reward: 1.0, pixels };
+        let frame = encode_response(&resp);
+        let decoded = decode_response(payload_of(&frame)).unwrap();
+        match decoded {
+            Response::Obs { terminated, truncated, reward, pixels } => {
+                assert!(!terminated);
+                assert!(truncated);
+                assert_eq!(reward, 1.0);
+                assert_eq!(pixels.len(), OBS_LEN);
+                assert_eq!(pixels[1], 1.0);
+                assert_eq!(pixels[255], 255.0);
+            }
+            other => panic!("expected Obs, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn codec_state_round_trip() {
+        let blob = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x7F];
+        let frame = encode_response(&Response::State(blob.clone()));
+        let decoded = decode_response(payload_of(&frame)).unwrap();
+        assert_eq!(decoded, Response::State(blob.clone()));
+
+        // A RestoreState command carries the same opaque bytes back the other way.
+        let frame = encode_command(&Command::RestoreState(blob.clone()));
+        assert_eq!(decode_command(payload_of(&frame)).unwrap(), Command::RestoreState(blob));
+    }
+
+    #[test]
+    fn codec_error_response() {
+        let resp = Response::Error("missing ROM".to_string());
+        let frame = encode_response(&resp);
+        let decoded = decode_response(payload_of(&frame)).unwrap();
+        assert_eq!(decoded, Response::Error("missing ROM".to_string()));
+    }
+
+    #[test]
+    fn read_write_stream_round_trip() {
+        // Exercise the streaming read/write helpers over an in-memory buffer.
+        let mut buf: Vec<u8> = Vec::new();
+        write_command(&mut buf, &Command::Reset(7)).unwrap();
+        write_command(&mut buf, &Command::CloneState).unwrap();
+        let mut cursor = std::io::Cursor::new(buf);
+        assert_eq!(read_command(&mut cursor).unwrap(), Command::Reset(7));
+        assert_eq!(read_command(&mut cursor).unwrap(), Command::CloneState);
+    }
+
+    #[test]
+    fn decode_rejects_unknown_and_short_frames() {
+        assert!(decode_command(&[]).is_err());
+        assert!(decode_command(&[0xEE]).is_err());
+        assert!(decode_command(&[TAG_RESET, 1, 2]).is_err()); // wrong seed length
+        assert!(decode_response(&[TAG_OBS, 0, 0, 0]).is_err()); // truncated header
+    }
+}

--- a/src/env/games/atari/protocol.rs
+++ b/src/env/games/atari/protocol.rs
@@ -225,10 +225,10 @@ pub fn decode_response(payload: &[u8]) -> io::Result<Response> {
             if !pixel_bytes.len().is_multiple_of(4) {
                 return Err(invalid_data("OBS pixel byte count is not a multiple of 4"));
             }
-            let pixels = pixel_bytes
-                .chunks_exact(4)
-                .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
-                .collect();
+            // `pixel_bytes.len()` is guaranteed a multiple of 4 above, so the
+            // `as_chunks` remainder is always empty.
+            let (chunks, _rest) = pixel_bytes.as_chunks::<4>();
+            let pixels = chunks.iter().map(|c| f32::from_le_bytes(*c)).collect();
             Ok(Response::Obs { terminated, truncated, reward, pixels })
         }
         TAG_STATE => Ok(Response::State(rest.to_vec())),

--- a/src/env/games/mod.rs
+++ b/src/env/games/mod.rs
@@ -63,7 +63,12 @@ pub mod t_maze;
 #[cfg(feature = "env-bucket-brigade")]
 pub mod bucket_brigade;
 
+#[cfg(feature = "env-atari")]
+pub mod atari;
+
 // Re-export main types for convenience
+#[cfg(feature = "env-atari")]
+pub use atari::AtariEnv;
 #[cfg(feature = "env-bucket-brigade")]
 pub use bucket_brigade::BucketBrigadeMaEnv;
 pub use cartpole::CartPole;

--- a/tests/test_atari_env.rs
+++ b/tests/test_atari_env.rs
@@ -1,0 +1,284 @@
+//! Tests for the `env-atari` subprocess adapter (issue #325).
+//!
+//! Two tiers:
+//!
+//! * **Mock-subprocess tests** drive [`AtariEnv`] over an in-process TCP socket
+//!   pair whose server speaks the frame protocol. They need no Python and no
+//!   `ale-py`, so they run in the normal `--features "training,env-atari"` CI
+//!   matrix and cover the happy path plus every error path.
+//! * **Integration tests** spawn the real `ale-py` worker and are
+//!   runtime-skipped when `ale-py` is not importable, keeping default CI green.
+//!
+//! The whole file is gated on `env-atari` because `AtariEnv` does not exist
+//! without it.
+#![cfg(feature = "env-atari")]
+
+use std::{
+    io::{BufReader, Read, Write},
+    net::{TcpListener, TcpStream},
+    path::{Path, PathBuf},
+    thread,
+};
+
+use thrust_rl::env::{
+    Environment,
+    games::atari::{
+        AtariEnv, AtariEnvError,
+        protocol::{self, Command, OBS_CHANNELS, OBS_HEIGHT, OBS_LEN, OBS_WIDTH, Response},
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Mock worker plumbing (no Python required)
+// ---------------------------------------------------------------------------
+
+/// Build an OBS response whose pixels encode `marker` in the first element so a
+/// test can assert which command produced it.
+fn obs(marker: f32, reward: f32, terminated: bool) -> Response {
+    let mut pixels = vec![0.0f32; OBS_LEN];
+    pixels[0] = marker;
+    Response::Obs { terminated, truncated: false, reward, pixels }
+}
+
+/// Spin up a mock worker on a loopback socket and return an [`AtariEnv`] wired
+/// to it. `serve` is handed the accepted server-side stream and speaks the
+/// protocol until the client hangs up.
+fn mock_env<F>(seed: u64, serve: F) -> AtariEnv
+where
+    F: FnOnce(TcpStream) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+    let addr = listener.local_addr().expect("local addr");
+    thread::spawn(move || {
+        if let Ok((stream, _)) = listener.accept() {
+            serve(stream);
+        }
+    });
+    let stream = TcpStream::connect(addr).expect("connect to mock worker");
+    let reader: Box<dyn Read + Send> = Box::new(stream.try_clone().expect("clone stream"));
+    let writer: Box<dyn Write + Send> = Box::new(stream);
+    AtariEnv::from_transport(reader, writer, "pong", seed)
+}
+
+/// A full mock worker: RESET/STEP/RESTORE_STATE reply with OBS, CLONE_STATE
+/// replies with a fixed opaque blob, CLOSE (or hang-up) ends the loop.
+fn full_worker(stream: TcpStream) {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let mut writer = stream;
+    loop {
+        match protocol::read_command(&mut reader) {
+            Ok(Command::Reset(seed)) => {
+                let resp = obs(seed as f32, 0.0, false);
+                protocol::write_response(&mut writer, &resp).unwrap();
+            }
+            Ok(Command::Step(action)) => {
+                let resp = obs(action as f32, action as f32, action == 9);
+                protocol::write_response(&mut writer, &resp).unwrap();
+            }
+            Ok(Command::CloneState) => {
+                let resp = Response::State(vec![0xAB, 0xCD, 0xEF, 0x01]);
+                protocol::write_response(&mut writer, &resp).unwrap();
+            }
+            Ok(Command::RestoreState(bytes)) => {
+                // Echo the first restored byte back in the marker so the caller
+                // can confirm the round-trip reached the worker.
+                let marker = bytes.first().copied().unwrap_or(0) as f32;
+                let resp = obs(marker, 0.0, false);
+                protocol::write_response(&mut writer, &resp).unwrap();
+            }
+            Ok(Command::Close) | Err(_) => break,
+        }
+    }
+}
+
+/// A worker that answers the first command with a single ERROR frame.
+fn error_worker(message: &'static str) -> impl FnOnce(TcpStream) + Send + 'static {
+    move |stream: TcpStream| {
+        let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+        let mut writer = stream;
+        if protocol::read_command(&mut reader).is_ok() {
+            let _ = protocol::write_response(&mut writer, &Response::Error(message.to_string()));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock-subprocess unit tests (no Python / no ale-py)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mock_subprocess_reset_step() {
+    let mut env = mock_env(42, full_worker);
+
+    env.try_reset().expect("reset over mock worker");
+    let obs = env.get_observation();
+    assert_eq!(obs.len(), OBS_LEN, "raw obs must be 210*160*3 elements");
+    assert_eq!(obs[0], 42.0, "reset marker should carry the seed");
+
+    let space = env.observation_space();
+    assert_eq!(space.shape, vec![OBS_HEIGHT, OBS_WIDTH, OBS_CHANNELS]);
+
+    let result = env.try_step(3).expect("step over mock worker");
+    assert_eq!(result.observation.len(), OBS_LEN);
+    assert_eq!(result.reward, 3.0);
+    assert!(!result.terminated);
+    assert!(!result.truncated);
+    assert_eq!(result.observation[0], 3.0, "step marker should carry the action");
+}
+
+#[test]
+fn mock_subprocess_clone_restore_round_trip() {
+    let mut env = mock_env(7, full_worker);
+    env.try_reset().expect("reset");
+
+    let state = env.try_clone_state().expect("clone_state");
+    assert_eq!(state, vec![0xAB, 0xCD, 0xEF, 0x01]);
+
+    env.try_restore_state(&state).expect("restore_state");
+    // The worker echoes the first restored byte into the obs marker.
+    assert_eq!(env.get_observation()[0], 0xAB as f32);
+}
+
+#[test]
+fn error_missing_python() {
+    // Point at an interpreter that cannot exist; spawning must fail with an
+    // actionable MissingPython error naming the remedy.
+    let err = AtariEnv::spawn_with(
+        "/nonexistent/definitely-not-python-42",
+        Path::new("envs/atari/ale_worker.py"),
+        "pong",
+        0,
+    )
+    .expect_err("spawning a non-existent interpreter must fail");
+
+    assert!(matches!(err, AtariEnvError::MissingPython { .. }));
+    let msg = err.to_string();
+    assert!(msg.contains("ATARI_PYTHON"), "message should name the remedy: {msg}");
+}
+
+#[test]
+fn error_missing_ale_py() {
+    let mut env =
+        mock_env(0, error_worker("ale-py could not be imported (No module named ale_py)"));
+    let err = env.try_reset().expect_err("worker reported missing ale-py");
+    assert!(matches!(err, AtariEnvError::MissingAlePy(_)), "got {err:?}");
+    assert!(
+        err.to_string().contains("pip install ale-py"),
+        "message should name the remedy: {err}"
+    );
+}
+
+#[test]
+fn error_missing_rom() {
+    let mut env = mock_env(0, error_worker("ROM 'pong' not found in ale-py's ROM registry"));
+    let err = env.try_reset().expect_err("worker reported missing ROM");
+    assert!(matches!(err, AtariEnvError::MissingRom(_)), "got {err:?}");
+    assert!(
+        err.to_string().contains("ALE_ROM_PATH"),
+        "message should name the ALE_ROM_PATH remedy: {err}"
+    );
+}
+
+#[test]
+fn mock_action_space_is_pong_minimal_set() {
+    let env = mock_env(0, full_worker);
+    let space = env.action_space();
+    assert_eq!(space.shape, vec![6]);
+    matches!(space.space_type, thrust_rl::env::SpaceType::Discrete(6))
+        .then_some(())
+        .expect("Pong action space is Discrete(6)");
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests — real ale-py, runtime-skipped when it is absent
+// ---------------------------------------------------------------------------
+
+fn python() -> String {
+    std::env::var("ATARI_PYTHON").unwrap_or_else(|_| "python3".to_string())
+}
+
+fn worker_script() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("envs/atari/ale_worker.py")
+}
+
+fn ale_py_available() -> bool {
+    std::process::Command::new(python())
+        .args(["-c", "import ale_py"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Build a real ALE env and reset it; return `None` (with a SKIP note) when
+/// `ale-py` or the ROM is unavailable so CI without Python stays green.
+fn real_env(seed: u64) -> Option<AtariEnv> {
+    if !ale_py_available() {
+        eprintln!("SKIP: ale-py not installed");
+        return None;
+    }
+    let mut env = match AtariEnv::spawn_with(python(), worker_script(), "pong", seed) {
+        Ok(env) => env,
+        Err(e) => {
+            eprintln!("SKIP: could not spawn ale-py worker ({e})");
+            return None;
+        }
+    };
+    match env.try_reset() {
+        Ok(()) => Some(env),
+        Err(e) => {
+            eprintln!("SKIP: could not reset ALE Pong ({e})");
+            None
+        }
+    }
+}
+
+#[test]
+fn ale_obs_shape() {
+    let Some(env) = real_env(42) else { return };
+    let obs = env.get_observation();
+    assert_eq!(obs.len(), OBS_LEN);
+    assert_eq!(env.observation_space().shape, vec![OBS_HEIGHT, OBS_WIDTH, OBS_CHANNELS]);
+    assert!(obs.iter().all(|&p| (0.0..=255.0).contains(&p)));
+}
+
+#[test]
+fn ale_seeded_determinism() {
+    let Some(a) = real_env(42) else { return };
+    let Some(b) = real_env(42) else { return };
+    assert_eq!(a.get_observation(), b.get_observation(), "same seed => same first frame");
+}
+
+#[test]
+fn ale_episode_terminates() {
+    let Some(mut env) = real_env(1) else { return };
+    let mut terminated = false;
+    for _ in 0..100_000 {
+        let result = env.step(0);
+        if result.terminated {
+            terminated = true;
+            break;
+        }
+    }
+    assert!(terminated, "a Pong episode should end within 100k NOOP frames");
+}
+
+#[test]
+fn ale_clone_restore() {
+    let Some(mut env) = real_env(7) else { return };
+    for _ in 0..5 {
+        env.step(0);
+    }
+    let snapshot = env.clone_state();
+
+    let actions = [2_i64, 3, 2];
+    let baseline: Vec<_> = actions.iter().map(|&a| env.step(a)).collect();
+
+    env.restore_state(&snapshot);
+    let replay: Vec<_> = actions.iter().map(|&a| env.step(a)).collect();
+
+    for (i, (x, y)) in baseline.iter().zip(replay.iter()).enumerate() {
+        assert_eq!(x.observation, y.observation, "obs mismatch after restore at step {i}");
+        assert_eq!(x.reward, y.reward, "reward mismatch after restore at step {i}");
+        assert_eq!(x.terminated, y.terminated, "terminated mismatch at step {i}");
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 2 of epic #306: an `AtariEnv` adapter behind an opt-in
`env-atari` Cargo feature. Following the Phase 1 spike verdict
(`docs/ALE_BINDING_STRATEGY.md`, Option D), the emulator is bound as a
**subprocess**: `AtariEnv` spawns Farama's `ale-py` worker and exchanges
seeds/actions/observations/state over a length-prefixed binary protocol on
stdin/stdout. `env-atari = []` is a pure compile-time flag — no `[dependencies]`
entry, no native/path dep, no publish `sed` workaround — so the default build,
docs, and `cargo publish` are completely unaffected and no GPL code enters the
crate.

## Changes

- **`src/env/games/atari/protocol.rs`** — frame codec: 4-byte LE length prefix +
  struct-packed payload. Commands RESET/STEP/CLONE_STATE/RESTORE_STATE/CLOSE;
  responses OBS/STATE/ERROR. Inline `#[cfg(test)]` round-trip tests (no Python).
- **`src/env/games/atari/env.rs`** — `AtariEnv` implementing the full
  `Environment` trait: `type State = Vec<u8>` (opaque ALE `cloneSystemState`
  blob), seeded reset forwarded on RESET, `210×160×3` raw RGB obs as `f32`,
  `Discrete(6)` Pong action space. Fallible `try_*` methods plus panicking trait
  methods; `new`/`spawn_with`/`from_transport` constructors.
- **`src/env/games/atari/error.rs`** — `AtariEnvError`
  (MissingPython/MissingAlePy/MissingRom/Protocol/Worker/Io) with remedy-naming
  `Display` messages.
- **`envs/atari/ale_worker.py`** — standalone stdlib+`ale-py` worker (no package
  structure), `ALE_ROM_PATH` resolution with actionable errors. Already covered
  by the existing `envs/**` tarball exclude.
- **`tests/test_atari_env.rs`** — mock-subprocess + error-path tests (run without
  Python, over a loopback socket speaking the protocol) and real `ale-py`
  integration tests that runtime-skip when `ale-py` is absent.
- **`Cargo.toml`** / **`src/env/games/mod.rs`** — `env-atari = []` feature and
  `#[cfg(feature = "env-atari")]` gating mirroring `env-bucket-brigade`.
- **`.github/workflows/ci.yml`** — `training,env-atari` clippy step; tarball
  audit grep extended to reject `.bin`/`.rom`/`.a26`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Default build/CI unaffected | ✅ | `cargo test --lib --features training` → 511 passed, 0 failed; `cargo check --no-default-features` clean; default clippy clean |
| `--features env-atari` builds the adapter | ✅ | `cargo build --features env-atari` succeeds |
| Trait contract (obs shape, seeded determinism, clone/restore) | ✅ | Mock tests assert obs `100800`/shape `[210,160,3]`, seed→marker, clone/restore round-trip; integration tests cover the real emulator (skip w/o ale-py) |
| Actionable errors (missing python/ale-py/ROM) | ✅ | `error_missing_python/ale_py/rom` tests assert typed variant + remedy text (`ATARI_PYTHON`, `pip install ale-py`, `ALE_ROM_PATH`) |
| `ALE_ROM_PATH` forwarded to child | ✅ | Inherited by the spawned worker; `_resolve_rom` honors it, falls back to ale-py otherwise |
| No ROM bytes in tarball; exclude audited | ✅ | `cargo package --list ... | grep -iE '\.(bin|rom|a26)$'` → empty; worker under `envs/**` exclude |
| Clippy -D warnings + fmt + doc clean (with feature) | ✅ | `clippy --all-targets --features "training,env-atari"`, `fmt --check`, `RUSTDOCFLAGS=-D warnings cargo doc --features "training,env-atari"` all pass |

## Test Plan

- Protocol codec unit tests (7) + mock/error tests (6) pass with **no Python
  installed**.
- 4 real-`ale-py` integration tests present and runtime-skipped locally (ale-py
  not installed) — the real emulator path was **not** exercised; only the mock
  transport and codec were.
- Default `cargo test --lib --features training`: 511 passed, 0 failed.

Closes #325