### PR TITLE
ci: advisory atari_integration job for real ale-py tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,41 @@ jobs:
           RAYON_NUM_THREADS: "1"
         run: cargo test --features training
 
+  # Optional advisory job: run the real ale-py integration tests.
+  # These 7 tests are runtime-skipped in the normal matrix (no Python/ale-py
+  # there); this job installs ale-py in a venv, sets ATARI_PYTHON, and verifies
+  # they all pass. Not in required-checks — promote after proving stable.
+  atari_integration:
+    name: Atari integration (real ale-py)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Create venv and install ale-py
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install --quiet "ale-py~=0.12.0"
+      - name: Run Atari integration tests
+        env:
+          ATARI_PYTHON: .venv/bin/python
+          RAYON_NUM_THREADS: "1"
+        run: |
+          set -euo pipefail
+          cargo test --features "training,env-atari" \
+            --test test_atari_env \
+            --test test_atari_preprocess \
+            -- --nocapture 2>&1 | tee /tmp/atari-test-output.txt
+          if grep -q "^SKIP:" /tmp/atari-test-output.txt; then
+            echo "::error::At least one integration test was skipped — ale-py setup failed."
+            grep "^SKIP:" /tmp/atari-test-output.txt
+            exit 1
+          fi
+
   # Documentation
   docs:
     name: Documentation


### PR DESCRIPTION
## Summary

Adds an advisory CI job `atari_integration` (Atari integration (real ale-py)) to `.github/workflows/ci.yml` that runs the 7 real ale-py integration tests which are runtime-skipped in the normal matrix.

The job:
- Checks out with `submodules: recursive`, `dtolnay/rust-toolchain@nightly`, `actions/setup-python@v5` (Python 3.11).
- Creates a venv and `pip install --quiet "ale-py~=0.12.0"` (pinned known-good minor; bundled Pong ROM via `ale_py.roms` — no AutoROM, no `ALE_ROM_PATH`).
- Runs `cargo test --features "training,env-atari" --test test_atari_env --test test_atari_preprocess -- --nocapture` with `ATARI_PYTHON=.venv/bin/python` and `RAYON_NUM_THREADS: "1"`.
- Guards against vacuous passes: fails the job if any `^SKIP:` marker appears in the tee'd output (cargo exits 0 on early-return, so silent skips are otherwise undetectable).

Scope is `.github/workflows/ci.yml` only — no Rust, Cargo.toml, test, or ROM changes.

## Advisory status

This job is **advisory** — it is not in any required-checks set. Branch protection on `main` is not configured, so there is nothing to entangle. Promote to required later once it proves stable.

## Local dry-run results

- **YAML valid** (`python -c "yaml.safe_load(...)"`) and **actionlint clean**.
- **With ale-py 0.12.0 present**: all 7 integration tests ran and passed (`test_atari_env`: 10 tests total = 6 mock + 4 integration; `test_atari_preprocess`: 3 integration). Zero `SKIP:` markers → guard passes.
- **Without ale-py** (`ATARI_PYTHON` pointing nowhere valid): cargo still exits 0 but emits 7 `SKIP: ale-py not installed` lines → guard correctly detects them and would exit 1. This confirms the guard catches the vacuous-pass case.

## CI note

GitHub Actions will run this job on the PR itself. I will check its result once CI runs.

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)