### PR TITLE
feat(examples): add Nature-DQN Pong training binary + runbook

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -344,6 +344,16 @@ name = "eval_pong"
 path = "examples/games/pong/eval_pong.rs"
 required-features = ["training"]
 
+# Nature-DQN on ALE Pong via the AtariPreprocess subprocess adapter
+# (Epic #306, Phase 4 -- issue #329). `env-atari` is the compile guard;
+# add `cuda` (NVIDIA) or `wgpu` (any GPU) at run time to select the GPU
+# backend via the `#[cfg]` type alias (see docs/BURN_BACKENDS.md). The
+# NdArray smoke run works CPU-only. Requires `ale-py` at run time.
+[[example]]
+name = "train_pong_dqn"
+path = "examples/games/atari/train_pong_dqn.rs"
+required-features = ["training", "env-atari"]
+
 # Bucket Brigade trainers (issue #115 / PR 4 of #117). Both gated
 # behind `env-bucket-brigade` (which is itself feature-gated off in
 # the published crate -- see the `[features]` block). The examples

--- a/docs/PONG_DQN_RUNBOOK.md
+++ b/docs/PONG_DQN_RUNBOOK.md
@@ -1,0 +1,156 @@
+# Pong DQN Training Runbook (Epic #306, Phase 4 — issue #329)
+
+Operator runbook for the reference-game training run: **Nature-DQN on ALE
+Pong**, executed on `alc-2` (RTX 4090 24 GB, CUDA 12.0). The training binary is
+`examples/games/atari/train_pong_dqn.rs` (`--example train_pong_dqn`).
+
+This run is **operator-gated** (like #134): the long GPU run needs operator
+hardware access and should not be auto-claimed by a builder. The committed
+binary + this runbook are the reviewable builder artifacts; the learning-curve
+report is committed as a post-run follow-up per the #298 / #306 protocol.
+
+## Success criterion
+
+Pong's random floor is ≈ −21. **Any positive mean episode score beats random**
+and is the decisive success signal. Published baselines: DQN ≈ 18.9 (Mnih 2015,
+50M frames) / PPO ≈ 20.7. Pong typically crosses zero well within 10M frames per
+the spike analysis in `docs/ALE_BINDING_STRATEGY.md`; this run targets ≤10M
+frames to produce a *positive* score, not a ceiling score.
+
+## Replay-buffer memory (honest f32 math)
+
+The in-tree `ReplayBuffer` stores both `obs` and `next_obs` as `Vec<f32>`
+(4 bytes/value). One Pong observation is `4 * 84 * 84 = 28_224` values, so one
+transition's frame storage is `2 * 28_224 * 4 = 225_792` bytes ≈ 221 KiB:
+
+```text
+buffer at 1M   : 2 * 28224 * 4 * 1_000_000 = ~210 GiB   (Mnih 2015 — does NOT fit)
+buffer at 100k : 2 * 28224 * 4 *   100_000 = ~21.0 GiB  (host RAM — DEFAULT)
+buffer at 50k  : 2 * 28224 * 4 *    50_000 = ~10.5 GiB  (host RAM — fallback)
+```
+
+The buffer lives in **host RAM**, not VRAM. Confirm host RAM before launching.
+If 100k (~21 GiB) is too large, set `BUFFER_CAPACITY=50000` (~10.5 GiB). A future
+u8 frame store (before the 1/255 scale) would cut this 4× (~5.3 GiB at 100k) but
+requires a new buffer type — out of scope for this issue.
+
+## Hyperparameters (Mnih 2015 adapted for a ≤10M-frame budget)
+
+| Parameter | Mnih 2015 (50M) | This run (5–10M) |
+|---|---|---|
+| `learning_rate` | 2.5e-4 (RMSProp) | 2.5e-4 (Adam) |
+| `batch_size` | 32 | 32 |
+| `buffer_capacity` | 1M | 100_000 (f32 budget) |
+| `min_buffer_size` | 50_000 | 10_000 |
+| `target_update_interval` | 10_000 | 10_000 (hard copy) |
+| `gamma` | 0.99 | 0.99 |
+| `epsilon_start` / `epsilon_end` | 1.0 / 0.1 | 1.0 / 0.1 |
+| `epsilon_decay_steps` | 1M | 1_000_000 |
+| `max_grad_norm` | 10.0 | 10.0 |
+| `soft_update_tau` | None (hard sync) | None (hard sync) |
+
+Frame budget default: `TOTAL_TIMESTEPS=5_000_000` (override via env var).
+
+## Env-var knobs
+
+| Var | Default | Meaning |
+|---|---|---|
+| `TOTAL_TIMESTEPS` | `5_000_000` | Total env steps. |
+| `BUFFER_CAPACITY` | `100_000` | Replay capacity (see RAM math). |
+| `MIN_BUFFER_SIZE` | `10_000` | Warmup transitions before updates. |
+| `LOG_INTERVAL` | `10_000` | Env-step period for stdout logs + CSV rows. |
+| `CURVE_CSV` | *(unset)* | Path for the `env_steps,mean_episode_reward` CSV. |
+| `CHECKPOINT_INTERVAL` | *(unset)* | Env-step period for weight snapshots. |
+| `CHECKPOINT_DIR` | `checkpoints` | Directory for `.bin` snapshots. |
+| `ATARI_PYTHON` | `python3` | Interpreter with `ale-py` installed. |
+| `ATARI_WORKER_SCRIPT` | `envs/atari/ale_worker.py` | Worker path (relative → run from repo root). |
+| `ALE_ROM_PATH` | *(unset)* | Override ROM lookup (dir or `.bin` file). |
+
+## Phase 0 — pre-flight (once, before the run)
+
+```bash
+# Confirm ale-py importable by the chosen interpreter
+/usr/bin/python3 -c "import ale_py; print(ale_py.__version__)"
+
+# Confirm the Pong ROM resolves (ale-py 0.12 ships ROMs via get_rom_path)
+/usr/bin/python3 -c "from ale_py import roms; print(roms.get_rom_path('pong'))"
+
+# Confirm CUDA visible
+nvidia-smi
+```
+
+If `ale-py` is not present: `pip install ale-py` (it bundles ROMs; otherwise
+`AutoROM --accept-license`). If the ROM does not resolve, set `ALE_ROM_PATH` to
+a directory containing `pong.bin`.
+
+## Phase 1 — start the training run (in a tmux session)
+
+```bash
+# On alc-2, from the repo root
+tmux new-session -s pong_dqn
+
+# cargo may not be on PATH in a fresh tmux on alc-* nodes:
+source ~/.cargo/env    # or: source ~/.bashrc
+
+# ale-py lives at /usr/bin/python3 on alc-2, not the default python3
+export ATARI_PYTHON=/usr/bin/python3
+
+# Learning-curve CSV output
+export CURVE_CSV="$HOME/pong_dqn_curve.csv"
+
+# Checkpoint every 500k steps
+export CHECKPOINT_INTERVAL=500000
+export CHECKPOINT_DIR="$HOME/pong_dqn_checkpoints"
+
+# Run the training binary (cuda feature selects the RTX 4090).
+# Run from the repo root so the default relative worker path resolves.
+cargo run --release \
+  --features "training,env-atari,cuda" \
+  --example train_pong_dqn \
+  2>&1 | tee "$HOME/pong_dqn_run.log"
+```
+
+### Throughput expectation
+
+CPU (NdArray) throughput on this stack is ~1 env-step/sec after warmup — a full
+1.6M-param CNN forward+backward per step (validated in the builder's smoke run),
+so the CPU path is smoke-test-only. On the RTX 4090, expect **~300–600
+frame/s** (i.e. ~75–150 ALE steps/s given frame-skip 4). The subprocess IPC
+overhead is amortized by the frame-skip. Validate actual throughput from the
+`fps=` field in the first few log lines; a 5M-frame run is roughly **2–5 hours**
+at that rate. If throughput is far below this band, the subprocess IPC is the
+suspect — profile before letting the full run continue.
+
+### Where results land
+
+- Stdout / tmux pane — progress every `LOG_INTERVAL` steps (with `fps=`).
+- `$HOME/pong_dqn_run.log` — full log.
+- `$HOME/pong_dqn_curve.csv` — learning-curve CSV.
+- `$HOME/pong_dqn_checkpoints/pong_dqn_<step>.bin` — weight snapshots.
+
+## Phase 2 — commit results (post-run, builder/operator follow-up)
+
+Per the #298 / epic #306 report protocol, after the run commit:
+
+- `docs/research/2026-07-pong-dqn-learning-curve.md` — honest report: hardware,
+  wall-clock, env steps, final mean score, learning-curve discussion, and a gap
+  analysis vs Mnih 2015. If Pong goes positive, report the step at which it
+  crossed zero and the final score. If not, report an honest gap analysis
+  (current score, convergence shape, likely blockers).
+- `docs/research/data/2026-07-pong_dqn_curve.csv` — the raw learning-curve CSV.
+
+## Local smoke test (reproduces the artifact acceptance gate)
+
+Requires a local `ale-py`. Tiny budget, CPU backend, small buffer/warmup so it
+finishes in minutes and exercises the full lifecycle (worker connect → buffer
+fill → DQN updates → CSV → checkpoint → clean exit):
+
+```bash
+TOTAL_TIMESTEPS=400 MIN_BUFFER_SIZE=100 BUFFER_CAPACITY=400 \
+LOG_INTERVAL=50 CHECKPOINT_INTERVAL=200 CHECKPOINT_DIR=/tmp/pong_ckpt \
+CURVE_CSV=/tmp/pong_smoke.csv ATARI_PYTHON=/path/to/venv/bin/python3 \
+cargo run --release --features "training,env-atari" --example train_pong_dqn
+```
+
+Verify `/tmp/pong_smoke.csv` has a header row plus at least one data row, and
+that `/tmp/pong_ckpt/` contains `pong_dqn_*.bin` snapshots.

--- a/docs/PONG_DQN_RUNBOOK.md
+++ b/docs/PONG_DQN_RUNBOOK.md
@@ -13,9 +13,16 @@ report is committed as a post-run follow-up per the #298 / #306 protocol.
 
 Pong's random floor is ≈ −21. **Any positive mean episode score beats random**
 and is the decisive success signal. Published baselines: DQN ≈ 18.9 (Mnih 2015,
-50M frames) / PPO ≈ 20.7. Pong typically crosses zero well within 10M frames per
-the spike analysis in `docs/ALE_BINDING_STRATEGY.md`; this run targets ≤10M
-frames to produce a *positive* score, not a ceiling score.
+50M **raw frames**) / PPO ≈ 20.7. Pong typically crosses zero well within ~10M
+**raw frames** per the spike analysis in `docs/ALE_BINDING_STRATEGY.md`.
+
+**Units — frames vs. wrapper steps.** `AtariPreprocess` applies **frame-skip 4**,
+so one wrapper `step()` = 4 raw ALE frames. The loop counts **wrapper steps**
+(`TOTAL_TIMESTEPS` is a wrapper-step budget), while the literature above counts
+**raw frames**. The default `TOTAL_TIMESTEPS=5_000_000` is therefore
+**5M wrapper steps = 20M raw frames**, which is ~2× the ~10M raw frames Pong
+needs to cross zero — conservatively over-budgeted for a *positive* score, not a
+ceiling score.
 
 ## Replay-buffer memory (honest f32 math)
 
@@ -34,9 +41,9 @@ If 100k (~21 GiB) is too large, set `BUFFER_CAPACITY=50000` (~10.5 GiB). A futur
 u8 frame store (before the 1/255 scale) would cut this 4× (~5.3 GiB at 100k) but
 requires a new buffer type — out of scope for this issue.
 
-## Hyperparameters (Mnih 2015 adapted for a ≤10M-frame budget)
+## Hyperparameters (Mnih 2015 adapted; budget = 5M wrapper steps ≈ 20M raw frames)
 
-| Parameter | Mnih 2015 (50M) | This run (5–10M) |
+| Parameter | Mnih 2015 (50M raw frames) | This run (5M wrapper steps ≈ 20M raw frames) |
 |---|---|---|
 | `learning_rate` | 2.5e-4 (RMSProp) | 2.5e-4 (Adam) |
 | `batch_size` | 32 | 32 |
@@ -48,14 +55,16 @@ requires a new buffer type — out of scope for this issue.
 | `epsilon_decay_steps` | 1M | 1_000_000 |
 | `max_grad_norm` | 10.0 | 10.0 |
 | `soft_update_tau` | None (hard sync) | None (hard sync) |
+| reward clipping | ±1 | n/a for Pong (rewards already ±1) |
 
-Frame budget default: `TOTAL_TIMESTEPS=5_000_000` (override via env var).
+Budget default: `TOTAL_TIMESTEPS=5_000_000` **wrapper steps** (= 20M raw frames;
+override via env var).
 
 ## Env-var knobs
 
 | Var | Default | Meaning |
 |---|---|---|
-| `TOTAL_TIMESTEPS` | `5_000_000` | Total env steps. |
+| `TOTAL_TIMESTEPS` | `5_000_000` | Total **wrapper steps** (frame-skip 4 → ≈ 4× raw frames). |
 | `BUFFER_CAPACITY` | `100_000` | Replay capacity (see RAM math). |
 | `MIN_BUFFER_SIZE` | `10_000` | Warmup transitions before updates. |
 | `LOG_INTERVAL` | `10_000` | Env-step period for stdout logs + CSV rows. |
@@ -112,14 +121,27 @@ cargo run --release \
 
 ### Throughput expectation
 
-CPU (NdArray) throughput on this stack is ~1 env-step/sec after warmup — a full
-1.6M-param CNN forward+backward per step (validated in the builder's smoke run),
-so the CPU path is smoke-test-only. On the RTX 4090, expect **~300–600
-frame/s** (i.e. ~75–150 ALE steps/s given frame-skip 4). The subprocess IPC
-overhead is amortized by the frame-skip. Validate actual throughput from the
-`fps=` field in the first few log lines; a 5M-frame run is roughly **2–5 hours**
-at that rate. If throughput is far below this band, the subprocess IPC is the
-suspect — profile before letting the full run continue.
+**Convention.** The code's `fps=` log field measures **wrapper steps/sec**
+(`total_env_steps / elapsed`), not raw frames/sec. Everything below is stated in
+that unit first, then converted; with frame-skip 4, raw frame/s = 4 × wrapper
+steps/s, and wall-clock = `5M wrapper_steps / (wrapper_steps_per_sec)`.
+
+CPU (NdArray) throughput on this stack is ~1 wrapper-step/sec after warmup — a
+full 1.6M-param CNN forward+backward per step (validated in the builder's smoke
+run), so the CPU path is smoke-test-only and its rate cannot predict the GPU
+rate. On the RTX 4090 the plausible band spans two cases:
+
+| Case | `fps=` (wrapper steps/s) | Raw frames/s (×4) | Wall-clock for 5M wrapper steps |
+|---|---|---|---|
+| Optimistic (GPU-bound) | 300–600 | 1_200–2_400 | ~2.5–5 h |
+| Conservative (IPC-bound) | 75–150 | 300–600 | ~9–18 h |
+
+The subprocess IPC overhead is partly amortized by the frame-skip, but whether
+the run lands GPU-bound (optimistic) or IPC-bound (conservative) is not something
+the CPU smoke run can tell you in advance. **Read the actual `fps=` value from
+the first few log lines and derive the wall-clock from the table above:** e.g.
+`fps=100` ⇒ ~14 h, `fps=400` ⇒ ~3.5 h. If `fps=` is far below the 75/s floor,
+the subprocess IPC is the suspect — profile before letting the full run continue.
 
 ### Where results land
 

--- a/examples/games/atari/train_pong_dqn.rs
+++ b/examples/games/atari/train_pong_dqn.rs
@@ -21,7 +21,7 @@
 //!   (any-vendor GPU; Metal/Vulkan/DX12).
 //! - `--features "training,env-atari"` (no GPU feature) →
 //!   `Autodiff<NdArray<f32>>` (CPU — the smoke-test path; too slow for a full
-//!   5M-frame run).
+//!   5M-wrapper-step run).
 //!
 //! `env-atari` is the compile guard (`required-features` in `Cargo.toml`); the
 //! GPU features are additive run-time backend selectors.
@@ -53,9 +53,26 @@
 //! u8 frame store (before the 1/255 scale) would cut this 4× (~5.3 GiB at 100k)
 //! but requires a new buffer type — out of scope here.
 //!
-//! # Hyperparameters (Mnih 2015 adapted for a ≤10M-frame budget)
+//! # Frames vs. wrapper steps (read this before the budget table)
 //!
-//! | Parameter | Mnih 2015 (50M) | This run (5–10M) |
+//! `AtariPreprocess` applies **frame-skip 4**: each wrapper `step()` submits
+//! the chosen action to the inner ALE **4×** and returns one stacked
+//! observation. The training loop counts **wrapper steps**
+//! (`trainer.total_env_steps()`), and `TOTAL_TIMESTEPS` is a **wrapper-step**
+//! budget. So the default `TOTAL_TIMESTEPS=5_000_000` means:
+//!
+//! - **5M wrapper steps = 20M raw ALE frames** (`5M × 4`).
+//!
+//! The Mnih 2015 literature convention ("50M frames", "Pong crosses zero within
+//! ~10M frames") counts **raw frames**. To compare honestly, convert to a
+//! single convention: **5M wrapper steps = 20M raw frames ≈ 2× the ~10M raw
+//! frames the spike analysis says Pong needs to cross zero**. The budget is
+//! therefore conservatively *over*-provisioned for the "go positive" goal, not
+//! under it.
+//!
+//! # Hyperparameters (Mnih 2015 adapted; budget = 5M wrapper steps ≈ 20M raw frames)
+//!
+//! | Parameter | Mnih 2015 (50M raw frames) | This run (5M wrapper steps ≈ 20M raw frames) |
 //! |---|---|---|
 //! | `learning_rate` | 2.5e-4 (RMSProp) | 2.5e-4 (Adam) |
 //! | `batch_size` | 32 | 32 |
@@ -67,10 +84,12 @@
 //! | `epsilon_decay_steps` | 1M | 1_000_000 |
 //! | `max_grad_norm` | 10.0 | 10.0 |
 //! | `soft_update_tau` | None (hard sync) | None (hard sync) |
+//! | reward clipping | ±1 | n/a for Pong (rewards already ±1) |
 //!
-//! DQN reaches ~18.9 at 50M frames (Mnih 2015); Pong typically crosses zero
-//! well within 10M frames per the spike analysis in
-//! `docs/ALE_BINDING_STRATEGY.md`. This run targets ≤10M frames to produce a
+//! DQN reaches ~18.9 at 50M raw frames (Mnih 2015); Pong typically crosses zero
+//! well within ~10M raw frames per the spike analysis in
+//! `docs/ALE_BINDING_STRATEGY.md`. This run's 5M wrapper steps = 20M raw frames
+//! is ~2× that "cross zero" bar — conservatively over-budgeted, aimed at a
 //! *positive* score (beating the ~−21 random floor), not a ceiling score.
 //!
 //! # Usage
@@ -95,7 +114,8 @@
 //!
 //! # Env-var knobs
 //!
-//! - `TOTAL_TIMESTEPS` (default `5_000_000`) — total env steps.
+//! - `TOTAL_TIMESTEPS` (default `5_000_000`) — total **wrapper steps**
+//!   (frame-skip 4, so ≈ 4× that many raw ALE frames).
 //! - `BUFFER_CAPACITY` (default `100_000`) — replay capacity (see RAM math).
 //! - `MIN_BUFFER_SIZE` (default `10_000`) — warmup transitions before updates.
 //! - `CURVE_CSV` (unset) — path for the `env_steps,mean_episode_reward` CSV.
@@ -168,16 +188,22 @@ const DEFAULT_LOG_INTERVAL: usize = 10_000;
 fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter("info").init();
 
-    let total_timesteps = env_usize("TOTAL_TIMESTEPS", DEFAULT_TIMESTEPS);
-    let buffer_capacity = env_usize("BUFFER_CAPACITY", DEFAULT_BUFFER_CAPACITY);
-    let min_buffer_size = env_usize("MIN_BUFFER_SIZE", DEFAULT_MIN_BUFFER_SIZE);
-    let checkpoint_interval = std::env::var("CHECKPOINT_INTERVAL")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .filter(|&n| n > 0);
+    let total_timesteps = env_usize("TOTAL_TIMESTEPS", DEFAULT_TIMESTEPS)?;
+    let buffer_capacity = env_usize("BUFFER_CAPACITY", DEFAULT_BUFFER_CAPACITY)?;
+    let min_buffer_size = env_usize("MIN_BUFFER_SIZE", DEFAULT_MIN_BUFFER_SIZE)?;
+    // Unset → disabled; present-but-unparseable → hard error (operator surprise
+    // on a long run); `0` → treated as disabled.
+    let checkpoint_interval =
+        match std::env::var("CHECKPOINT_INTERVAL") {
+            Ok(s) => Some(s.parse::<usize>().map_err(|e| {
+                anyhow::anyhow!("CHECKPOINT_INTERVAL={s:?} is not a valid usize: {e}")
+            })?)
+            .filter(|&n| n > 0),
+            Err(_) => None,
+        };
     let checkpoint_dir =
         std::env::var("CHECKPOINT_DIR").unwrap_or_else(|_| DEFAULT_CHECKPOINT_DIR.to_string());
-    let log_interval = env_usize("LOG_INTERVAL", DEFAULT_LOG_INTERVAL).max(1);
+    let log_interval = env_usize("LOG_INTERVAL", DEFAULT_LOG_INTERVAL)?.max(1);
 
     tracing::info!("Starting Pong DQN Training (Burn backend: {})", BACKEND_LABEL);
 
@@ -372,10 +398,17 @@ fn buffer_gib(capacity: usize, obs_len: usize) -> f64 {
     (2 * obs_len * 4 * capacity) as f64 / (1024.0 * 1024.0 * 1024.0)
 }
 
-/// Parse a `usize` env var, falling back to `default` when unset or
-/// unparseable.
-fn env_usize(key: &str, default: usize) -> usize {
-    std::env::var(key).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+/// Parse a `usize` env var, falling back to `default` only when the var is
+/// **unset**. A present-but-unparseable value (e.g. `TOTAL_TIMESTEPS=abc` or a
+/// stray suffix like `5000000x`) is an operator error on a multi-hour run, so
+/// it fails loudly rather than silently reverting to the default.
+fn env_usize(key: &str, default: usize) -> Result<usize> {
+    match std::env::var(key) {
+        Ok(s) => s
+            .parse::<usize>()
+            .map_err(|e| anyhow::anyhow!("{key}={s:?} is not a valid usize: {e}")),
+        Err(_) => Ok(default),
+    }
 }
 
 /// Save the online Q-network weights to `<dir>/pong_dqn_<step>.bin`.

--- a/examples/games/atari/train_pong_dqn.rs
+++ b/examples/games/atari/train_pong_dqn.rs
@@ -1,0 +1,414 @@
+//! Nature-DQN on ALE **Pong** via the `AtariPreprocess` subprocess adapter
+//! (Epic #306, Phase 4 — issue #329).
+//!
+//! End-to-end Double-DQN trainer for Pong-v5 using the
+//! [`NatureDqnQNetwork`](thrust_rl::policy::atari_cnn::NatureDqnQNetwork) +
+//! [`DQNTrainerBurn`](thrust_rl::train::dqn::DQNTrainerBurn) stack. The
+//! environment is Farama's `ale-py` driven as a **subprocess** through
+//! [`AtariPreprocess`](thrust_rl::env::games::atari::AtariPreprocess) (Option D
+//! from `docs/ALE_BINDING_STRATEGY.md`), with Machado preprocessing defaults
+//! (frame-skip 4, frame-stack 4, sticky-action p=0.25, 84×84 grayscale,
+//! life-loss termination).
+//!
+//! # Backend selection (compile-time)
+//!
+//! The concrete backend is chosen by Cargo features via a `#[cfg]` type alias,
+//! matching `docs/BURN_BACKENDS.md` and `train_cartpole_modern.rs`:
+//!
+//! - `--features "training,env-atari,cuda"` → `Autodiff<Cuda<f32, i32>>` (Linux
+//!   + NVIDIA — the alc-2 RTX 4090 run).
+//! - `--features "training,env-atari,wgpu"` → `Autodiff<Wgpu<f32, i32>>`
+//!   (any-vendor GPU; Metal/Vulkan/DX12).
+//! - `--features "training,env-atari"` (no GPU feature) →
+//!   `Autodiff<NdArray<f32>>` (CPU — the smoke-test path; too slow for a full
+//!   5M-frame run).
+//!
+//! `env-atari` is the compile guard (`required-features` in `Cargo.toml`); the
+//! GPU features are additive run-time backend selectors.
+//!
+//! # Runtime requirements
+//!
+//! `ale-py` must be importable by the worker's Python interpreter, and a Pong
+//! ROM must be resolvable. Point `ATARI_PYTHON` at the interpreter that has
+//! `ale-py` installed (falls back to `python3`). Run from the repo root so the
+//! default relative worker path (`envs/atari/ale_worker.py`) resolves, or set
+//! `ATARI_WORKER_SCRIPT` to an absolute path. See the runbook in
+//! `docs/PONG_DQN_RUNBOOK.md`.
+//!
+//! # Replay-buffer memory (honest f32 math)
+//!
+//! The in-tree [`ReplayBuffer`](thrust_rl::buffer::replay::ReplayBuffer) stores
+//! both `obs` and `next_obs` as `Vec<f32>` (4 bytes/value). One Pong
+//! observation is `4 * 84 * 84 = 28_224` values, so one transition's frame
+//! storage is `2 * 28_224 * 4 = 225_792` bytes ≈ 221 KiB. Hence:
+//!
+//! ```text
+//! buffer at 1M   : 2 * 28224 * 4 * 1_000_000 = ~210 GiB   (Mnih 2015 — does NOT fit)
+//! buffer at 100k : 2 * 28224 * 4 *   100_000 = ~21.0 GiB  (host RAM — DEFAULT here)
+//! buffer at 50k  : 2 * 28224 * 4 *    50_000 = ~10.5 GiB  (host RAM — fallback)
+//! ```
+//!
+//! The buffer lives in **host RAM**, not VRAM. Confirm host RAM before the run;
+//! override the capacity with `BUFFER_CAPACITY` if 100k is too large. A future
+//! u8 frame store (before the 1/255 scale) would cut this 4× (~5.3 GiB at 100k)
+//! but requires a new buffer type — out of scope here.
+//!
+//! # Hyperparameters (Mnih 2015 adapted for a ≤10M-frame budget)
+//!
+//! | Parameter | Mnih 2015 (50M) | This run (5–10M) |
+//! |---|---|---|
+//! | `learning_rate` | 2.5e-4 (RMSProp) | 2.5e-4 (Adam) |
+//! | `batch_size` | 32 | 32 |
+//! | `buffer_capacity` | 1M | 100_000 (f32 budget) |
+//! | `min_buffer_size` | 50_000 | 10_000 |
+//! | `target_update_interval` | 10_000 | 10_000 (hard copy) |
+//! | `gamma` | 0.99 | 0.99 |
+//! | `epsilon_start`/`end` | 1.0 / 0.1 | 1.0 / 0.1 |
+//! | `epsilon_decay_steps` | 1M | 1_000_000 |
+//! | `max_grad_norm` | 10.0 | 10.0 |
+//! | `soft_update_tau` | None (hard sync) | None (hard sync) |
+//!
+//! DQN reaches ~18.9 at 50M frames (Mnih 2015); Pong typically crosses zero
+//! well within 10M frames per the spike analysis in
+//! `docs/ALE_BINDING_STRATEGY.md`. This run targets ≤10M frames to produce a
+//! *positive* score (beating the ~−21 random floor), not a ceiling score.
+//!
+//! # Usage
+//!
+//! Full run (alc-2, CUDA — see `docs/PONG_DQN_RUNBOOK.md`):
+//!
+//! ```bash
+//! ATARI_PYTHON=/usr/bin/python3 \
+//! CURVE_CSV="$HOME/pong_dqn_curve.csv" \
+//! CHECKPOINT_INTERVAL=500000 CHECKPOINT_DIR="$HOME/pong_dqn_checkpoints" \
+//! cargo run --release --features "training,env-atari,cuda" \
+//!     --example train_pong_dqn
+//! ```
+//!
+//! CPU smoke run (tiny budget; requires a local `ale-py`):
+//!
+//! ```bash
+//! TOTAL_TIMESTEPS=2000 MIN_BUFFER_SIZE=200 BUFFER_CAPACITY=2000 \
+//! ATARI_PYTHON=/path/to/venv/bin/python3 CURVE_CSV=/tmp/pong_smoke.csv \
+//! cargo run --release --features "training,env-atari" --example train_pong_dqn
+//! ```
+//!
+//! # Env-var knobs
+//!
+//! - `TOTAL_TIMESTEPS` (default `5_000_000`) — total env steps.
+//! - `BUFFER_CAPACITY` (default `100_000`) — replay capacity (see RAM math).
+//! - `MIN_BUFFER_SIZE` (default `10_000`) — warmup transitions before updates.
+//! - `CURVE_CSV` (unset) — path for the `env_steps,mean_episode_reward` CSV.
+//! - `CHECKPOINT_INTERVAL` (unset) — env-step period for weight snapshots.
+//! - `CHECKPOINT_DIR` (default `checkpoints`) — directory for snapshots.
+//! - `ATARI_PYTHON` — interpreter with `ale-py` (falls back to `python3`).
+
+use std::io::Write;
+
+use anyhow::Result;
+use burn::{
+    optim::AdamConfig,
+    record::{BinFileRecorder, FullPrecisionSettings},
+    tensor::{Tensor, TensorData},
+};
+use rand::{SeedableRng, rngs::StdRng};
+use thrust_rl::{
+    env::{Environment, games::atari::AtariPreprocess},
+    policy::atari_cnn::{NatureDqnConfig, NatureDqnQNetwork},
+    train::{
+        dqn::{DQNConfig, DQNTrainerBurn},
+        optimizer::BurnOptimizer,
+    },
+    utils::cuda::default_burn_device,
+};
+
+// --- Compile-time backend selection (see docs/BURN_BACKENDS.md) -----------
+// `cuda` takes precedence over `wgpu`; with neither, fall back to CPU NdArray.
+#[cfg(feature = "cuda")]
+type Inner = burn::backend::Cuda<f32, i32>;
+#[cfg(all(feature = "wgpu", not(feature = "cuda")))]
+type Inner = burn::backend::Wgpu<f32, i32>;
+#[cfg(not(any(feature = "cuda", feature = "wgpu")))]
+type Inner = burn::backend::NdArray<f32>;
+
+type B = burn::backend::Autodiff<Inner>;
+
+#[cfg(feature = "cuda")]
+const BACKEND_LABEL: &str = "Cuda<f32, i32> + Autodiff (NVIDIA)";
+#[cfg(all(feature = "wgpu", not(feature = "cuda")))]
+const BACKEND_LABEL: &str = "Wgpu<f32, i32> + Autodiff (GPU: Vulkan/Metal/DX12/WebGPU)";
+#[cfg(not(any(feature = "cuda", feature = "wgpu")))]
+const BACKEND_LABEL: &str = "NdArray<f32> + Autodiff (CPU)";
+
+/// Frame-stack depth × height × width — the preprocessor's fixed layout.
+const CHANNELS: usize = 4;
+const HEIGHT: usize = 84;
+const WIDTH: usize = 84;
+
+/// Total env steps (default; overridable via `TOTAL_TIMESTEPS`).
+const DEFAULT_TIMESTEPS: usize = 5_000_000;
+/// Replay capacity (default; overridable via `BUFFER_CAPACITY`).
+const DEFAULT_BUFFER_CAPACITY: usize = 100_000;
+/// Warmup transitions before updates begin (default; via `MIN_BUFFER_SIZE`).
+const DEFAULT_MIN_BUFFER_SIZE: usize = 10_000;
+/// Default checkpoint directory when `CHECKPOINT_INTERVAL` is set.
+const DEFAULT_CHECKPOINT_DIR: &str = "checkpoints";
+
+/// Seed threaded through the Q-network FC init and the action/replay `StdRng`
+/// so the learning curve is reproducible up to the backend's own
+/// float-reduction nondeterminism.
+const SEED: u64 = 0;
+
+/// Progress-logging period, in env steps (overridable via `LOG_INTERVAL`;
+/// used for both stdout logging and learning-curve CSV rows). The default
+/// suits a multi-million-step run; the smoke test lowers it so the CSV and
+/// progress lines appear within a tiny budget.
+const DEFAULT_LOG_INTERVAL: usize = 10_000;
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt().with_env_filter("info").init();
+
+    let total_timesteps = env_usize("TOTAL_TIMESTEPS", DEFAULT_TIMESTEPS);
+    let buffer_capacity = env_usize("BUFFER_CAPACITY", DEFAULT_BUFFER_CAPACITY);
+    let min_buffer_size = env_usize("MIN_BUFFER_SIZE", DEFAULT_MIN_BUFFER_SIZE);
+    let checkpoint_interval = std::env::var("CHECKPOINT_INTERVAL")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n > 0);
+    let checkpoint_dir =
+        std::env::var("CHECKPOINT_DIR").unwrap_or_else(|_| DEFAULT_CHECKPOINT_DIR.to_string());
+    let log_interval = env_usize("LOG_INTERVAL", DEFAULT_LOG_INTERVAL).max(1);
+
+    tracing::info!("Starting Pong DQN Training (Burn backend: {})", BACKEND_LABEL);
+
+    // --- Environment (Machado defaults) ----------------------------------
+    let mut env = AtariPreprocess::new("pong", SEED)?;
+    let obs_shape = env.observation_space().shape;
+    let obs_len = obs_shape.iter().product::<usize>();
+    let n_actions = match env.action_space().space_type {
+        thrust_rl::env::SpaceType::Discrete(n) => n as i64,
+        thrust_rl::env::SpaceType::Box => {
+            anyhow::bail!("Pong must expose a discrete action space")
+        }
+    };
+
+    tracing::info!("Environment: ALE Pong (AtariPreprocess, Machado defaults)");
+    tracing::info!("  obs_shape       = {:?}  (obs_len = {})", obs_shape, obs_len);
+    tracing::info!("  n_actions       = {}", n_actions);
+    tracing::info!("  total_timesteps = {}", total_timesteps);
+    tracing::info!(
+        "  buffer_capacity = {}  (~{:.1} GiB host RAM)",
+        buffer_capacity,
+        buffer_gib(buffer_capacity, obs_len)
+    );
+    tracing::info!("  min_buffer_size = {}", min_buffer_size);
+
+    let device = default_burn_device::<B>();
+
+    // --- Online Q-network (target is cloned internally by the trainer) ----
+    let q_config = NatureDqnConfig::default().with_seed(SEED);
+    let online = NatureDqnQNetwork::<B>::with_config(n_actions as usize, q_config, &device);
+
+    // Mnih-2015-adapted hyperparameters (see module docs). Hard target sync
+    // (no soft tau) matches the Nature-DQN spec.
+    let config = DQNConfig::new()
+        .learning_rate(2.5e-4)
+        .batch_size(32)
+        .buffer_capacity(buffer_capacity)
+        .min_buffer_size(min_buffer_size)
+        .target_update_interval(10_000)
+        .gamma(0.99)
+        .epsilon_start(1.0)
+        .epsilon_end(0.1)
+        .epsilon_decay_steps(1_000_000)
+        .max_grad_norm(10.0);
+
+    let inner_opt = AdamConfig::new().init();
+    let burn_opt: BurnOptimizer<B, NatureDqnQNetwork<B>, _> =
+        BurnOptimizer::new(inner_opt, config.learning_rate);
+
+    // The trainer takes the device by value; the action-selection closure below
+    // needs it too. Clone here so both hold a device. `clone_on_copy` is
+    // silenced because on the CPU (`NdArray`) backend the device is `Copy` and
+    // the clone is a no-op, whereas the `cuda`/`wgpu` devices are not `Copy` and
+    // genuinely require it — one source across all three backends.
+    #[allow(clippy::clone_on_copy)]
+    let trainer_device = device.clone();
+    let mut trainer =
+        DQNTrainerBurn::new(config, online, burn_opt, obs_len, n_actions, trainer_device)?;
+
+    // --- Forward closures: reshape the flat replay obs to NCHW ------------
+    // Both the online and target forward passes share this reshape.
+    let forward_fn = |q: &NatureDqnQNetwork<B>, o_flat: Tensor<B, 2>| -> Tensor<B, 2> {
+        let b = o_flat.dims()[0];
+        q.forward(o_flat.reshape([b, CHANNELS, HEIGHT, WIDTH]))
+    };
+
+    env.reset();
+    let mut obs = env.get_observation();
+    let mut rng = StdRng::seed_from_u64(0xC0FFEE);
+
+    let mut curve_csv = open_curve_csv()?;
+
+    let mut episode_return: f32 = 0.0;
+    let mut episode_returns: Vec<f32> = Vec::new();
+    let mut last_log_step = 0_usize;
+    let mut last_checkpoint_step = 0_usize;
+    let training_start = std::time::Instant::now();
+
+    while trainer.total_env_steps() < total_timesteps {
+        // ε-greedy action selection: greedy branch reshapes a single obs.
+        let action = {
+            trainer.select_action(&obs, &mut rng, |q: &NatureDqnQNetwork<B>, o_host: &[f32]| {
+                let o_t: Tensor<B, 2> =
+                    Tensor::from_data(TensorData::new(o_host.to_vec(), [1, o_host.len()]), &device);
+                let q_values = q.forward(o_t.reshape([1, CHANNELS, HEIGHT, WIDTH]));
+                let q_host: Vec<f32> = q_values.into_data().to_vec().unwrap_or_default();
+                argmax(&q_host)
+            })
+        };
+
+        let result = env.step(action);
+        let next_obs = result.observation.clone();
+        let done = result.terminated || result.truncated;
+        trainer.buffer_mut().push(&obs, action, result.reward, &next_obs, done);
+
+        episode_return += result.reward;
+        obs = next_obs;
+
+        trainer.increment_env_step();
+        // Hard target sync on the interval (no soft blend — clone online).
+        let _ = trainer.maybe_sync_target(|online, _target, _tau| online.clone());
+
+        if done {
+            episode_returns.push(episode_return);
+            trainer.increment_episodes(1);
+            episode_return = 0.0;
+            env.reset();
+            obs = env.get_observation();
+        }
+
+        // One gradient update per env step (skipped until warmup completes).
+        let _ = trainer.train_step(&mut rng, forward_fn, forward_fn)?;
+
+        let step = trainer.total_env_steps();
+
+        // Periodic logging + learning-curve CSV row.
+        if step.saturating_sub(last_log_step) >= log_interval {
+            last_log_step = step;
+            let recent_avg = mean_last(&episode_returns, 100);
+            if let Some(w) = curve_csv.as_mut() {
+                writeln!(w, "{},{:.4}", step, recent_avg)?;
+                w.flush()?;
+            }
+            let fps = step as f64 / training_start.elapsed().as_secs_f64();
+            tracing::info!(
+                "step={:>8}  episodes={:>5}  avg(last≤100)={:7.2}  ε={:.3}  buf={:>7}  fps={:.0}",
+                step,
+                trainer.total_episodes(),
+                recent_avg,
+                trainer.last_epsilon(),
+                trainer.buffer_len(),
+                fps,
+            );
+        }
+
+        // Periodic checkpointing (opt-in via CHECKPOINT_INTERVAL).
+        if let Some(interval) = checkpoint_interval
+            && step.saturating_sub(last_checkpoint_step) >= interval
+        {
+            last_checkpoint_step = step;
+            save_checkpoint(trainer.online(), &checkpoint_dir, step)?;
+        }
+    }
+
+    if let Some(mut w) = curve_csv.take() {
+        w.flush()?;
+    }
+
+    let final_avg = mean_last(&episode_returns, 100);
+    let elapsed = training_start.elapsed();
+    tracing::info!("------------------------------------------------------------");
+    tracing::info!("Training complete.");
+    tracing::info!("  episodes         : {}", trainer.total_episodes());
+    tracing::info!("  env_steps        : {}", trainer.total_env_steps());
+    tracing::info!("  train_steps      : {}", trainer.total_train_steps());
+    tracing::info!("  avg(last≤100)    : {:.2}", final_avg);
+    tracing::info!("  wall clock       : {:.1}s", elapsed.as_secs_f64());
+    tracing::info!(
+        "  env-steps/sec    : {:.0}",
+        trainer.total_env_steps() as f64 / elapsed.as_secs_f64()
+    );
+
+    Ok(())
+}
+
+/// Argmax over a slice of Q-values (ties break to the lowest index).
+fn argmax(qs: &[f32]) -> i64 {
+    let mut best = 0_i64;
+    let mut best_v = f32::NEG_INFINITY;
+    for (i, &v) in qs.iter().enumerate() {
+        if v > best_v {
+            best_v = v;
+            best = i as i64;
+        }
+    }
+    best
+}
+
+/// Mean of the last `window` entries (or all, if fewer). Returns `0.0` when
+/// empty.
+fn mean_last(xs: &[f32], window: usize) -> f32 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    let slice = &xs[xs.len().saturating_sub(window)..];
+    slice.iter().copied().sum::<f32>() / slice.len() as f32
+}
+
+/// Host-RAM footprint (GiB) of a replay buffer holding `capacity` transitions,
+/// storing both `obs` and `next_obs` as `f32`. `obs_len` values per frame.
+fn buffer_gib(capacity: usize, obs_len: usize) -> f64 {
+    (2 * obs_len * 4 * capacity) as f64 / (1024.0 * 1024.0 * 1024.0)
+}
+
+/// Parse a `usize` env var, falling back to `default` when unset or
+/// unparseable.
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key).ok().and_then(|s| s.parse().ok()).unwrap_or(default)
+}
+
+/// Save the online Q-network weights to `<dir>/pong_dqn_<step>.bin`.
+///
+/// Uses Burn's [`BinFileRecorder`] (same recorder the self-play Pong example
+/// uses). Creates the directory if missing.
+fn save_checkpoint(q: &NatureDqnQNetwork<B>, dir: &str, step: usize) -> Result<()> {
+    std::fs::create_dir_all(dir)?;
+    // `save_file` appends the recorder's own extension (`.bin`), so pass the
+    // stem without it.
+    let stem = format!("{dir}/pong_dqn_{step}");
+    let recorder = BinFileRecorder::<FullPrecisionSettings>::new();
+    burn::module::Module::save_file(q.clone(), &stem, &recorder)
+        .map_err(|e| anyhow::anyhow!("checkpoint write failed: {e}"))?;
+    tracing::info!("  checkpoint written: {stem}.bin (env_steps={step})");
+    Ok(())
+}
+
+/// Open the opt-in learning-curve CSV writer.
+///
+/// Returns `Ok(Some(writer))` with the header row already written when the
+/// `CURVE_CSV` env var names a non-empty path, or `Ok(None)` when it is unset.
+/// Schema (`env_steps,mean_episode_reward`) matches the CartPole DQN/A2C/PPO
+/// curves so Pong's curve is tooling-compatible.
+fn open_curve_csv() -> Result<Option<std::io::BufWriter<std::fs::File>>> {
+    match std::env::var("CURVE_CSV") {
+        Ok(path) if !path.is_empty() => {
+            let file = std::fs::File::create(&path)?;
+            let mut w = std::io::BufWriter::new(file);
+            writeln!(w, "env_steps,mean_episode_reward")?;
+            tracing::info!("Writing learning-curve CSV to {}", path);
+            Ok(Some(w))
+        }
+        _ => Ok(None),
+    }
+}


### PR DESCRIPTION
## Summary

Implements the **builder artifact** for Epic #306 Phase 4 (issue #329): a
committed Nature-DQN training binary for ALE Pong plus an operator runbook. The
long GPU run itself is operator-gated (alc-2) and executed post-merge — this PR
is the reviewable, CI-checkable artifact half of the artifact-vs-run split.

**No `src/` changes** — the full Atari/CNN/DQN stack is already on `main`. This
PR is one example binary, one `Cargo.toml` entry, and one runbook doc, matching
the curator's scope guard.

## Changes

- **`examples/games/atari/train_pong_dqn.rs`** (NEW): end-to-end Double-DQN
  trainer wiring `AtariPreprocess::new("pong", SEED)` (Machado defaults) →
  `NatureDqnQNetwork` → `DQNTrainerBurn`.
  - Compile-time backend selection via `#[cfg]` type alias: `cuda` →
    `Autodiff<Cuda<f32,i32>>`, `wgpu` → `Autodiff<Wgpu<f32,i32>>`, else
    `Autodiff<NdArray<f32>>` (CPU smoke path). Device built with
    `default_burn_device::<B>()`.
  - Forward closures reshape flat replay obs to `[B, 4, 84, 84]` for both the
    online and target passes; hard-copy target sync (Mnih-2015 spec, no soft tau).
  - Mnih-2015-adapted hyperparams (lr 2.5e-4 Adam, batch 32, buffer 100k,
    min-buffer 10k, target-sync 10k, ε 1.0→0.1 over 1M, γ 0.99, grad-clip 10).
  - Honest f32 replay-buffer memory math in the module doc (~21 GiB host RAM at
    100k; 210 GiB at the Mnih 1M — does not fit; 50k fallback).
  - Env knobs: `TOTAL_TIMESTEPS` (default 5M), `BUFFER_CAPACITY`,
    `MIN_BUFFER_SIZE`, `LOG_INTERVAL`, `CURVE_CSV`, `CHECKPOINT_INTERVAL`,
    `CHECKPOINT_DIR`, `ATARI_PYTHON`. Checkpoints via Burn's `BinFileRecorder`.
- **`Cargo.toml`**: one `[[example]]` entry, `required-features = ["training", "env-atari"]`.
- **`docs/PONG_DQN_RUNBOOK.md`** (NEW): exact alc-2 command sequence (pre-flight,
  tmux launch with CUDA, results locations), memory math, throughput
  expectation, and the local smoke-test recipe.

## Acceptance Criteria Verification (artifact criteria)

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Example committed and compiles (`cargo check --features "training,env-atari"`) | ✅ | `cargo check --features "training,env-atari" --examples` passes |
| `[[example]]` entry with `required-features ["training","env-atari"]` | ✅ | Added after the pong examples in `Cargo.toml` |
| Smoke run passes CPU-side (worker connect, buffer fill, DQN updates, CSV, checkpoint, clean exit) | ✅ | Ran with a local ale-py 0.12 venv — see Test Plan |
| Runbook committed with alc-2 commands + memory math | ✅ | `docs/PONG_DQN_RUNBOOK.md` |
| `CURVE_CSV` + `CHECKPOINT_INTERVAL` documented in module doc | ✅ | Env-var knobs section of the module doc |

## Test Plan

Smoke run on this host (local `ale-py` 0.12 venv, `ATARI_PYTHON` pointed at it,
CPU NdArray backend, tiny budget):

```
TOTAL_TIMESTEPS=400 MIN_BUFFER_SIZE=100 BUFFER_CAPACITY=400 LOG_INTERVAL=50 \
CHECKPOINT_INTERVAL=200 CURVE_CSV=... ATARI_PYTHON=<venv>/bin/python3 \
./target/release/examples/train_pong_dqn
```

Confirmed: spawned the ale-py worker (Stella + Pong ROM loaded), filled the
buffer (50→400), ran 301 Double-DQN gradient updates after warmup **with no
shape panics**, wrote the CSV (header + 8 rows), saved `pong_dqn_200.bin` /
`pong_dqn_400.bin` (~6.7 MB each), and exited cleanly.

**Throughput signal for the alc-2 estimate**: CPU throughput is ~1 env-step/sec
after warmup (a full 1.6M-param CNN forward+backward per step on NdArray) — this
confirms the CPU path is smoke-only and the 5M-frame run needs the GPU, as
designed. On the RTX 4090 expect ~300–600 frame/s → ~2–5 h for 5M frames.

Verification:
- `cargo check --features "training,env-atari" --examples` ✅
- `cargo clippy --features "training,env-atari" --example train_pong_dqn -- -D warnings` ✅
- `cargo clippy --features "training,env-atari,cuda" --example train_pong_dqn -- -D warnings` ✅ (compile-only; no CUDA hardware here — the cuda **and** wgpu sets both `cargo check` cleanly on macOS)
- `cargo check --features "training,env-atari,wgpu" --example train_pong_dqn` ✅
- `cargo fmt --check` ✅
- `cargo doc --no-deps --features "training,env-atari"` (RUSTDOCFLAGS="-D warnings") ✅
- `cargo build` (default features) ✅ untouched

## Artifact-vs-run split

Per the #298 / epic #306 report protocol, the **run criteria** (positive Pong
score or honest gap analysis, learning-curve CSV, learning-curve report) are
fulfilled by the operator's alc-2 run and committed as a **follow-up** to
`docs/research/2026-07-pong-dqn-learning-curve.md` +
`docs/research/data/2026-07-pong_dqn_curve.csv`. This PR delivers the artifact
half only.

Closes #329