### PR TITLE
feat: adopt Atari-standard Adam LR (6.25e-5) + LEARNING_RATE knob for Pong DQN

### DIFF
--- a/docs/PONG_DQN_RUNBOOK.md
+++ b/docs/PONG_DQN_RUNBOOK.md
@@ -13,16 +13,18 @@ report is committed as a post-run follow-up per the #298 / #306 protocol.
 
 Pong's random floor is ≈ −21. **Any positive mean episode score beats random**
 and is the decisive success signal. Published baselines: DQN ≈ 18.9 (Mnih 2015,
-50M **raw frames**) / PPO ≈ 20.7. Pong typically crosses zero well within ~10M
-**raw frames** per the spike analysis in `docs/ALE_BINDING_STRATEGY.md`.
+50M **raw frames**) / PPO ≈ 20.7. Under the **sticky-action** protocol (p=0.25,
+Machado et al. 2018) crossing zero is typically seen within **10–20M raw
+frames** — later than the classic no-sticky DQN curves; the 5M wrapper step
+(20M raw frame) budget is sized to cover this range.
 
 **Units — frames vs. wrapper steps.** `AtariPreprocess` applies **frame-skip 4**,
 so one wrapper `step()` = 4 raw ALE frames. The loop counts **wrapper steps**
 (`TOTAL_TIMESTEPS` is a wrapper-step budget), while the literature above counts
 **raw frames**. The default `TOTAL_TIMESTEPS=5_000_000` is therefore
-**5M wrapper steps = 20M raw frames**, which is ~2× the ~10M raw frames Pong
-needs to cross zero — conservatively over-budgeted for a *positive* score, not a
-ceiling score.
+**5M wrapper steps = 20M raw frames**, which covers the 10–20M raw frame band in
+which sticky-action Pong typically crosses zero — budgeted for a *positive*
+score, not a ceiling score.
 
 ## Replay-buffer memory (honest f32 math)
 
@@ -45,7 +47,7 @@ requires a new buffer type — out of scope for this issue.
 
 | Parameter | Mnih 2015 (50M raw frames) | This run (5M wrapper steps ≈ 20M raw frames) |
 |---|---|---|
-| `learning_rate` | 2.5e-4 (RMSProp) | 2.5e-4 (Adam) |
+| `learning_rate` | 2.5e-4 (RMSProp) | 6.25e-5 (Adam; Rainbow/Dopamine) |
 | `batch_size` | 32 | 32 |
 | `buffer_capacity` | 1M | 100_000 (f32 budget) |
 | `min_buffer_size` | 50_000 | 10_000 |
@@ -68,12 +70,38 @@ override via env var).
 | `BUFFER_CAPACITY` | `100_000` | Replay capacity (see RAM math). |
 | `MIN_BUFFER_SIZE` | `10_000` | Warmup transitions before updates. |
 | `LOG_INTERVAL` | `10_000` | Env-step period for stdout logs + CSV rows. |
+| `LEARNING_RATE` | `6.25e-5` | Adam learning rate (Atari standard; Rainbow/Dopamine). Must be finite and positive. |
 | `CURVE_CSV` | *(unset)* | Path for the `env_steps,mean_episode_reward` CSV. |
 | `CHECKPOINT_INTERVAL` | *(unset)* | Env-step period for weight snapshots. |
 | `CHECKPOINT_DIR` | `checkpoints` | Directory for `.bin` snapshots. |
 | `ATARI_PYTHON` | `python3` | Interpreter with `ale-py` installed. |
 | `ATARI_WORKER_SCRIPT` | `envs/atari/ale_worker.py` | Worker path (relative → run from repo root). |
 | `ALE_ROM_PATH` | *(unset)* | Override ROM lookup (dir or `.bin` file). |
+
+## Experiment log
+
+### Run 1 — Adam 2.5e-4 (negative result, 2026-07-08)
+
+Stopped at the pre-declared no-learning decision point: **9.56M raw frames
+(2.39M wrapper steps, ~6.2 h on alc-2 RTX 4090)**. `avg(last≤100)` never
+exceeded −20.27 and sat at −20.8 ± 0.1 from ~1M wrapper steps onward (ε
+floor). Greedy policy marginally worse than random — flat curve with zero
+upward trend over 1.4M post-floor steps.
+
+**Diagnosis:** Adam 2.5e-4 is the Mnih 2015 RMSProp rate; the Atari-standard
+Adam rate is 6.25e-5 (Rainbow, Dopamine). The hyperparameter table's Adam
+column was copied from the RMSProp column without adaptation (see issue #342).
+
+**Resolution:** Default changed to 6.25e-5 in this PR. See run 2 below for
+the corrected-LR result. Artifacts preserved on alc-2 under
+`~/pong_dqn_run1_lr2.5e-4/` (curve CSV, full log, 4 checkpoints at 500k
+intervals).
+
+### Run 2 — Adam 6.25e-5 (corrected LR)
+
+_Placeholder — to be filled in post-run. This is the single-variable rerun
+isolating the LR change (6.25e-5 vs. run 1's 2.5e-4); no other hyperparameter
+changes. Append the crossing-zero step and final mean score here._
 
 ## Phase 0 — pre-flight (once, before the run)
 

--- a/examples/games/atari/train_pong_dqn.rs
+++ b/examples/games/atari/train_pong_dqn.rs
@@ -74,7 +74,7 @@
 //!
 //! | Parameter | Mnih 2015 (50M raw frames) | This run (5M wrapper steps ≈ 20M raw frames) |
 //! |---|---|---|
-//! | `learning_rate` | 2.5e-4 (RMSProp) | 2.5e-4 (Adam) |
+//! | `learning_rate` | 2.5e-4 (RMSProp) | 6.25e-5 (Adam; Rainbow/Dopamine) |
 //! | `batch_size` | 32 | 32 |
 //! | `buffer_capacity` | 1M | 100_000 (f32 budget) |
 //! | `min_buffer_size` | 50_000 | 10_000 |
@@ -114,6 +114,8 @@
 //!
 //! # Env-var knobs
 //!
+//! - `LEARNING_RATE` (default `6.25e-5`) — Adam learning rate (Atari standard;
+//!   Rainbow/Dopamine).
 //! - `TOTAL_TIMESTEPS` (default `5_000_000`) — total **wrapper steps**
 //!   (frame-skip 4, so ≈ 4× that many raw ALE frames).
 //! - `BUFFER_CAPACITY` (default `100_000`) — replay capacity (see RAM math).
@@ -165,6 +167,10 @@ const CHANNELS: usize = 4;
 const HEIGHT: usize = 84;
 const WIDTH: usize = 84;
 
+/// Atari-standard Adam LR (Rainbow / Dopamine defaults). 4× lower than the
+/// RMSProp 2.5e-4 from Mnih 2015; see issue #342.
+const DEFAULT_LEARNING_RATE: f64 = 6.25e-5;
+
 /// Total env steps (default; overridable via `TOTAL_TIMESTEPS`).
 const DEFAULT_TIMESTEPS: usize = 5_000_000;
 /// Replay capacity (default; overridable via `BUFFER_CAPACITY`).
@@ -188,6 +194,7 @@ const DEFAULT_LOG_INTERVAL: usize = 10_000;
 fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter("info").init();
 
+    let learning_rate = env_f64("LEARNING_RATE", DEFAULT_LEARNING_RATE)?;
     let total_timesteps = env_usize("TOTAL_TIMESTEPS", DEFAULT_TIMESTEPS)?;
     let buffer_capacity = env_usize("BUFFER_CAPACITY", DEFAULT_BUFFER_CAPACITY)?;
     let min_buffer_size = env_usize("MIN_BUFFER_SIZE", DEFAULT_MIN_BUFFER_SIZE)?;
@@ -228,6 +235,7 @@ fn main() -> Result<()> {
         buffer_gib(buffer_capacity, obs_len)
     );
     tracing::info!("  min_buffer_size = {}", min_buffer_size);
+    tracing::info!("  learning_rate   = {}  (Adam)", learning_rate);
 
     let device = default_burn_device::<B>();
 
@@ -238,7 +246,7 @@ fn main() -> Result<()> {
     // Mnih-2015-adapted hyperparameters (see module docs). Hard target sync
     // (no soft tau) matches the Nature-DQN spec.
     let config = DQNConfig::new()
-        .learning_rate(2.5e-4)
+        .learning_rate(learning_rate)
         .batch_size(32)
         .buffer_capacity(buffer_capacity)
         .min_buffer_size(min_buffer_size)
@@ -407,6 +415,31 @@ fn env_usize(key: &str, default: usize) -> Result<usize> {
         Ok(s) => s
             .parse::<usize>()
             .map_err(|e| anyhow::anyhow!("{key}={s:?} is not a valid usize: {e}")),
+        Err(_) => Ok(default),
+    }
+}
+
+/// Parse an `f64` env var, falling back to `default` only when the var is
+/// **unset**, mirroring [`env_usize`]'s fail-loud semantics: a present-but-
+/// unparseable value (e.g. `LEARNING_RATE=abc`) is an operator error on a
+/// multi-hour run and fails loudly rather than silently reverting to default.
+///
+/// The positive-finite guard here is **learning-rate-specific**: a
+/// non-finite (`inf`/`NaN`) or non-positive (`0`, negative) LR is a broken run,
+/// so it errors rather than silently producing a stalled or NaN-loss training
+/// loop. Future `env_f64` callers that legitimately accept zero (e.g. an
+/// epsilon floor) should relax or replace this guard for their own knob.
+fn env_f64(key: &str, default: f64) -> Result<f64> {
+    match std::env::var(key) {
+        Ok(s) => {
+            let v = s
+                .parse::<f64>()
+                .map_err(|e| anyhow::anyhow!("{key}={s:?} is not a valid f64: {e}"))?;
+            if !v.is_finite() || v <= 0.0 {
+                anyhow::bail!("{key}={s:?} must be a finite positive f64");
+            }
+            Ok(v)
+        }
         Err(_) => Ok(default),
     }
 }


### PR DESCRIPTION
## Summary

`train_pong_dqn` defaulted to `learning_rate = 2.5e-4` — the Mnih 2015 **RMSProp** rate copied verbatim into the Adam column without adaptation. Run 1 on alc-2 (RTX 4090) sat flat at the ε-floor (−20.8 ± 0.1, greedy marginally worse than random) through 9.56M raw frames with zero upward trend — a training defect, not patience. The Atari-DQN community standard for Adam is **6.25e-5** (Rainbow, Dopamine; 4× lower). This PR switches the default and adds a `LEARNING_RATE` env override so run 2 can rerun as a single-variable experiment.

Scope: `examples/games/atari/train_pong_dqn.rs` and `docs/PONG_DQN_RUNBOOK.md` only. No `src/` changes, no other hyperparameter changes.

## Changes

- `train_pong_dqn.rs`:
  - `DEFAULT_LEARNING_RATE: f64 = 6.25e-5` module constant.
  - New `env_f64` helper mirroring `env_usize`'s fail-loud semantics (unset → default; present-but-unparseable → clear error) plus a learning-rate-specific finite-positive guard; doc comment notes the guard is LR-specific.
  - Wire `LEARNING_RATE` through `DQNConfig` and log the resolved LR in the startup banner.
  - Module-doc hyperparameter table: `2.5e-4 (Adam)` → `6.25e-5 (Adam; Rainbow/Dopamine)`; env-var list gains `LEARNING_RATE`.
- `docs/PONG_DQN_RUNBOOK.md`:
  - Same hyperparameter-table update; env-var table gains a `LEARNING_RATE` row.
  - New "Experiment log" section with the run-1 negative result (9.56M raw frames flat at −20.8, Adam 2.5e-4 diagnosis, artifacts at `~/pong_dqn_run1_lr2.5e-4/` on alc-2) and a run-2 placeholder.
  - Liftoff language hedged to 10–20M raw frames under sticky actions.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `DEFAULT_LEARNING_RATE` = `6.25e-5` | ✅ | Const added; startup banner logs `0.0000625` when unset |
| `env_f64` fail-loud + finite-positive guard | ✅ | `LEARNING_RATE=abc` → "not a valid f64"; `=0` / `=-1e-4` → "must be a finite positive f64" |
| `LEARNING_RATE` wired to `.learning_rate()` + `BurnOptimizer` | ✅ | `LEARNING_RATE=1e-4` logs `0.0001`; flows via `config.learning_rate` |
| Module-doc + runbook hyperparameter tables updated | ✅ | Both rows read `6.25e-5 (Adam; Rainbow/Dopamine)` |
| Module-doc env-var list + runbook env-var table gain `LEARNING_RATE` | ✅ | Both updated |
| Runbook run-1 negative-result note | ✅ | Experiment log with 9.56M frames, −20.8 floor, diagnosis, alc-2 artifact path |
| Liftoff language hedged to 10–20M raw frames | ✅ | Success criterion + units paragraphs updated |
| No `src/` changes; no other hyperparameter changes | ✅ | `git diff --stat`: 2 files only |

## Test Plan

Against the built binary (with a scratch ale-py 0.12 venv where the env must load):
- `LEARNING_RATE=abc` → `Error: LEARNING_RATE="abc" is not a valid f64: invalid float literal`
- `LEARNING_RATE=0` → `Error: LEARNING_RATE="0" must be a finite positive f64`
- `LEARNING_RATE=-1e-4` → `must be a finite positive f64`
- Unset → banner logs `learning_rate = 0.0000625  (Adam)`
- `LEARNING_RATE=1e-4` → banner logs `learning_rate = 0.0001  (Adam)`
- Smoke run (`TOTAL_TIMESTEPS=200 MIN_BUFFER_SIZE=50 BUFFER_CAPACITY=200`, CPU, release): full lifecycle to "Training complete" — 151 DQN updates, 4 CSV rows, 2 checkpoints, clean exit.

CI gates (feature set `training,env-atari`):
- `cargo check --examples` ✅
- `cargo clippy --examples -- -D warnings` ✅ (clean)
- `cargo fmt --check` ✅
- `cargo doc --no-deps --examples` ✅ (3 warnings are pre-existing redundant-link-target lints on unmodified header lines 5/6/8)

Closes #342