### PR TITLE
docs: correct qnet cuda speedup ratios and Pong best-window figure

### DIFF
--- a/docs/BURN_BACKENDS.md
+++ b/docs/BURN_BACKENDS.md
@@ -52,7 +52,7 @@ through libtorch. Linux + an NVIDIA GPU + CUDA toolkit required.
 | --- | --- |
 | CI / headless tests / numerical reproducibility | NdArray (default) |
 | Small-net control tasks (CartPole, Pendulum, bandits) | NdArray (default) — CPU wins 4.4–9.5× at these sizes |
-| Large-net / CNN / image-env training (e.g. Nature-DQN on Atari) | **GPU** — cuda on Linux+NVIDIA (fastest, 65–1230× over CPU), else wgpu |
+| Large-net / CNN / image-env training (e.g. Nature-DQN on Atari) | **GPU** — cuda on Linux+NVIDIA (fastest, 65–876× over CPU), else wgpu |
 | Local laptop GPU (any vendor) | wgpu |
 | Linux box with an NVIDIA GPU | **cuda** (beats wgpu on the same card; measured on the large-net suite) |
 | Browser-side inference / training | wgpu (compiles to WebGPU) |
@@ -401,11 +401,20 @@ Because cuda and the M3 CPU are different hosts, the honest speedup is
 | `nature_dqn_qnet_forward` (b256) | 3.86 ms | 1.10 s | ~285× |
 | `nature_dqn_policy_train_step` (b32) | 4.47 ms | 954 ms | ~213× |
 | `nature_dqn_policy_train_step` (b256) | 10.2 ms | 7.58 s | ~743× |
-| `nature_dqn_qnet_train_step` (b32) | 4.00 ms | 954 ms | ~310× |
-| `nature_dqn_qnet_train_step` (b256) | 8.65 ms | 7.58 s | ~1230× |
+| `nature_dqn_qnet_train_step` (b32) | 4.00 ms | 954 ms | ~238× |
+| `nature_dqn_qnet_train_step` (b256) | 8.65 ms | 7.58 s | ~876× |
+
+Ratios are `alc-2 CPU / cuda`, both from primary data (cuda from
+`cudabench2.log`, CPU `ndarray` from `cudabench.log`). Note the two
+`qnet_train_step` CPU cells (954 ms / 7.58 s) are the *qnet* `ndarray` times,
+which on alc-2 land within noise of the *policy* `ndarray` times (953.8 ms /
+7.577 s vs 954.2 ms / 7.578 s) — unlike the M3 wgpu run, where qnet CPU sat
+slightly above policy CPU. Both networks are the same Nature-CNN torso, so on a
+warm single-thread `ndarray` host the train-step CPU cost is effectively
+identical.
 
 The cuda crossover is **larger** than the wgpu/Metal one on every row: cuda wins
-by 65–1230× over the alc-2 CPU, versus wgpu's ~7–64× over the M3 CPU. The
+by 65–876× over the alc-2 CPU, versus wgpu's ~7–64× over the M3 CPU. The
 train-step groups (forward + backward + Adam — the most arithmetic per launch)
 show the largest advantage, and the gap widens with batch size (b256 > b32),
 exactly as predicted. This confirms the GPU-wins conclusion for image-env
@@ -484,7 +493,7 @@ small-net default is unchanged; the large-net default is now GPU.
 **cuda status — measured, verdict extended.** The cuda large-net column is now
 measured on alc-2 (RTX 4090); see the
 [cuda large-net column](#cuda-large-net-column-measured-on-alc-2) subsection. The
-prediction held: cuda wins by **65–1230×** over the alc-2 CPU across the eight
+prediction held: cuda wins by **65–876×** over the alc-2 CPU across the eight
 groups — an *even larger* crossover than the wgpu/Metal ~7–64×, and it beats
 wgpu's absolute wall-clock on every row (e.g. `policy_train_step/b256`
 10.2 ms cuda vs 169.5 ms wgpu). The GPU-wins conclusion for image-env training is

--- a/docs/PONG_DQN_RUNBOOK.md
+++ b/docs/PONG_DQN_RUNBOOK.md
@@ -105,7 +105,8 @@ steps (first >−19 at 590k), −15 at the ε floor (~1M steps), plateau near �
 (~1.9–2.6M), then a climb toward −5.5. **Final `avg(last≤100) = −5.14 at exactly
 5M wrapper steps (20M raw frames)** — STILL IMPROVING at budget exhaustion; the
 last 400k window oscillates −6.3 → −3.9 → −5.1 with a rising envelope, best
-window **−3.89**, single best point −3.44 at 4.67M steps. **Did not cross zero**
+strict 400k-step trailing mean (40 logged points at 10k spacing) **−4.13**,
+single best logged 10k-step point −3.44 at 4.67M steps. **Did not cross zero**
 within budget (expected — see gap analysis). Stats: 2,289 episodes, 14.0 h wall
 clock, ~99 wrapper steps/s. Artifacts: `alc-2:~/pong_dqn_run2_lr6.25e-5/` (curve
 CSV, full log, 9 checkpoints).

--- a/docs/research/2026-07-pong-dqn-learning-curve.md
+++ b/docs/research/2026-07-pong-dqn-learning-curve.md
@@ -17,15 +17,16 @@ random floor it lifts off at ~200k wrapper steps, climbs through the ε-decay
 floor, and converges toward a rising envelope. With the corrected Atari-standard
 Adam learning rate (**6.25e-5**, Rainbow/Dopamine), run 2 arm A reaches
 `avg(last≤100) = −5.14` at the 5M wrapper-step (20M raw-frame) budget and is
-**still improving at budget exhaustion** (best 400k window: **−3.89**). It does
+**still improving at budget exhaustion** (best 400k-step trailing mean:
+**−4.13**; best single 10k-step logged point: **−3.44**). It does
 not cross zero within this budget.
 
 Three runs, one conclusion:
 
-| Run | Adam LR | Host | Final `avg(last≤100)` | Best 400k window | Verdict |
+| Run | Adam LR | Host | Final `avg(last≤100)` | Best 400k-step trailing mean | Verdict |
 |---|---|---|---|---|---|
 | Run 1 | 2.5e-4 | alc-2 | **−20.76** (stopped at 2.39M steps) | −20.42 | Negative result — wrong LR (Mnih RMSProp rate) |
-| Run 2 arm A | **6.25e-5** | alc-2 | **−5.14** at 5M steps | **−3.89** | Textbook curve, still rising at budget end |
+| Run 2 arm A | **6.25e-5** | alc-2 | **−5.14** at 5M steps | **−4.13** | Textbook curve, still rising at budget end |
 | Run 2 arm B | 1e-4 | alc-8 | **−7.21** at 5M steps | −6.73 | Learns, but repeated instability dips; ends worse than arm A |
 
 The gap to a zero-crossing is a **budget-and-buffer** story, not a code defect:
@@ -91,8 +92,10 @@ The corrected-LR rerun isolates a single variable (LR: 6.25e-5 vs run 1's
 - **Final `avg(last≤100) = −5.14` at exactly 5M wrapper steps (20M raw
   frames)** — and **still improving at budget exhaustion**. The last 400k-step
   window oscillates −6.3 → −3.9 → −5.1 with a **rising envelope**; the best
-  400k window mean is **−3.89** (starting ~4.48M steps) and the single best
-  logged point is **−3.44** at 4.67M steps.
+  strict 400k-step trailing mean (40 logged points at 10k-step spacing) is
+  **−4.13** (window starting ~4.48M steps) and the single best logged 10k-step
+  point is **−3.44** at 4.67M steps. (A narrower ~200–300k-step window peaks
+  around −3.8 to −4.0.)
 - **Stats:** 2,289 episodes, 14.0 h wall clock, ~99 wrapper steps/s.
 - **Artifacts:** `alc-2:~/pong_dqn_run2_lr6.25e-5/` (curve CSV, full log, 9
   checkpoints).
@@ -101,7 +104,8 @@ Curve: [`data/2026-07-pong-dqn-run2a-lr6.25e-5.csv`](data/2026-07-pong-dqn-run2a
 (500 rows).
 
 This is the honest headline result: the stack learns Pong, the curve is still
-rising at the budget wall, and the score at the wall (−5.14, best window −3.89)
+rising at the budget wall, and the score at the wall (−5.14, best 400k-step
+trailing mean −4.13)
 is bounded by the budget/buffer — not by any correctness defect.
 
 ## Run 2 arm B — Adam 1e-4 (parallel LR-stability arm)
@@ -136,8 +140,8 @@ multi-point instability dips** (three separate −8.5 to −10.9 excursions afte
 2M steps) and ends **worse (−7.21)** despite an extra hour of wall clock and more
 episodes. The takeaway: **6.25e-5 is the right default** — the Rainbow/Dopamine
 rate is not just conventional, it is empirically the more stable of the two on
-this stack, and arm A was still improving at budget exhaustion (best window
-−3.89) while arm B had already peaked and settled lower.
+this stack, and arm A was still improving at budget exhaustion (best 400k-step
+trailing mean −4.13) while arm B had already peaked and settled lower.
 
 ## Gap analysis — why zero was not crossed (and how to cross it)
 
@@ -148,7 +152,8 @@ raw-frame budget. This is expected and honest given the budget and buffer:
 **Budget.** Sticky-action (Machado et al. 2018, p=0.25) DQN baselines typically
 need **15–25M+ raw frames** to cross zero on Pong — later than the classic
 no-sticky curves. This run's 20M raw frames sits at the *low end* of that band.
-Arm A was **still improving at 20M frames** (rising envelope, best window −3.89),
+Arm A was **still improving at 20M frames** (rising envelope, best 400k-step
+trailing mean −4.13),
 consistent with a crossing that lands just beyond the current budget wall.
 
 **Replay buffer.** The in-tree `ReplayBuffer` stores frames as `f32`


### PR DESCRIPTION
## Summary
Two docs-only consistency fixes from Judge review of PR #344, both recomputed from primary data.

## Changes

### 1. `docs/BURN_BACKENDS.md` — qnet_train_step cuda ratios
The two `qnet_train_step` rows claimed ~310× / ~1230× but were not reproducible from the shown CPU column. Recomputing `alc-2 CPU / cuda` from the primary criterion logs:

| Group | cuda | alc-2 CPU (ndarray) | old × | corrected × |
|---|---|---|---|---|
| `qnet_train_step` b32 | 4.00 ms | 954 ms | ~310× | **~238×** (953.84 / 3.999) |
| `qnet_train_step` b256 | 8.65 ms | 7.58 s | ~1230× | **~876×** (7576.8 / 8.6532) |

The **CPU column values are correct**: the raw log shows qnet `ndarray` = 953.84 ms (b32) / 7.5768 s (b256), i.e. within noise of the policy `ndarray` baselines (954.19 ms / 7.5782 s). Both nets share the same Nature-CNN torso, so on a warm single-thread `ndarray` host the train-step CPU cost is effectively identical — unlike the earlier M3 wgpu run where qnet CPU sat slightly above policy CPU. Only the **ratios** were wrong (they had been divided against a phantom higher qnet CPU baseline). Also updated the two "65–1230×" summary ranges (lines 55, 496) to "65–876×" and added a provenance note.

**Data sources** (verified this session):
- cuda: `alc-2:/tmp/cudabench2.log` (the log the doc already cites) — matches every displayed cuda value.
- CPU `ndarray`: `alc-2:/tmp/cudabench.log` — cudabench2.log contains no ndarray rows.

All other seven rows already check out: policy_train b32 954/4.467=214× ✓, b256 7578/10.232=741× ✓, forwards 83/323/65/286× ✓.

### 2. `docs/research/2026-07-pong-dqn-learning-curve.md` + `docs/PONG_DQN_RUNBOOK.md` — best-window figure
"best 400k window −3.89" was not a strict 400k-step mean. Recomputing sliding trailing means over the committed CSV `docs/research/data/2026-07-pong-dqn-run2a-lr6.25e-5.csv` (500 rows, 10k-step spacing):

| Window | Rows | Best trailing mean | Window start |
|---|---|---|---|
| 200k | 20 | −3.77 | 4.53M |
| 300k | 30 | −3.96 | 4.49M |
| **400k** | **40** | **−4.13** | **4.48M** |

So −3.89 sat between the 200k and 300k windows. Fixed to **−4.13** with an explicit window definition ("400k-step trailing mean = 40 logged points at 10k spacing"), and kept the −3.44 best single 10k-step logged point. Cross-checked the sibling figures use the same 40-row definition and are already correct: run-2b −6.73 (recomputed −6.7283 ✓), run-1 −20.42 (recomputed −20.4156 ✓).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| qnet cuda ratios self-consistent with CPU column | ✅ | 954/4.00=238×, 7580/8.65=876× computed from raw logs |
| best-window figure has explicit window definition | ✅ | "400k-step trailing mean (40 logged points at 10k spacing) = −4.13" |
| every touched figure recomputed from primary data | ✅ | criterion logs + committed CSV (arithmetic above) |
| markdown links intact | ✅ | anchor + CSV links untouched in diff |
| docs-only diff | ✅ | `git diff --name-only` = 3 `.md` files only |

## Test Plan
- `grep` confirms no stale −3.89 / ~310× / 1230× remain in `docs/` (excluding CSV/JSON data files, where 310000/1230000 are step counts).
- Full diff reviewed: 3 markdown files, +30/−15 lines.

Closes #345