### PR TITLE
feat(ppo): add TCP transport for the actor-learner channel seam

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,9 +83,23 @@ rayon = { version = "1.8", optional = true }
 # Zero-copy operations
 bytemuck = { version = "1.14", features = ["derive"] }
 
-# Serialization for checkpoints
-serde = { version = "1", features = ["derive"] }
+# Serialization for checkpoints. `rc` lets `#[derive(Serialize, Deserialize)]`
+# work through `Arc<T>` fields (e.g. `PolicyBroadcast::Bytes.bytes`) without a
+# hand-rolled wire DTO -- needed for the networked actor-learner transport
+# (issue #281 / epic #265 Phase 4).
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1.0"
+
+# Wire encoding for the networked actor-learner transport (issue #281 / epic
+# #265 Phase 4): encodes `Experience` / `PolicyBroadcast` / `ControlMessage`
+# frames sent over TCP between a remote actor process and the learner.
+# Already present in the dependency tree at this exact version+feature set
+# (`burn-core` depends on `bincode 2.0.1` with the `serde` feature for its
+# record format), so declaring it directly here adds no new crate to the
+# build -- just a direct, nameable dependency on what Cargo already compiles.
+# Gated by the `training` feature (see `[features]` below), matching
+# `crossbeam-channel`.
+bincode = { version = "2.0.1", features = ["serde"], optional = true }
 
 # Metrics and logging (simplified for WASM)
 tracing = { version = "0.1", optional = true }
@@ -144,7 +158,7 @@ default = ["training"]
 # Defaults to Burn's pure-Rust NdArray backend so a fresh checkout builds
 # without any external system libraries. GPU backends are opt-in via
 # additional feature flags below.
-training = ["dep:burn", "tokio", "rayon", "tracing", "tracing-subscriber", "crossbeam-channel", "chrono"]
+training = ["dep:burn", "tokio", "rayon", "tracing", "tracing-subscriber", "crossbeam-channel", "chrono", "dep:bincode"]
 # Threaded matmul for the CPU NdArray backend (OFF by default). Enables
 # `burn-ndarray/multi-threads`, which turns on `matrixmultiply/threading` +
 # `ndarray/rayon` — both PURE RUST (matrixmultiply pulls in `thread-tree` +

--- a/src/multi_agent/messages.rs
+++ b/src/multi_agent/messages.rs
@@ -17,6 +17,8 @@
 
 use std::sync::Arc;
 
+use serde::{Deserialize, Serialize};
+
 /// Unique identifier for an agent across a multi-agent training run.
 pub type AgentId = usize;
 
@@ -26,7 +28,12 @@ pub type AgentId = usize;
 /// replaced with plain `Vec<f32>` host buffers. Construct Burn tensors at
 /// the learner-side rollout buffer with `Tensor::from_floats(...)` once
 /// the buffer is full.
-#[derive(Debug, Clone)]
+///
+/// `Serialize`/`Deserialize` back the networked actor-learner transport's
+/// wire encoding ([`crate::train::ppo::transport`], issue #281 / epic #265
+/// Phase 4) — the in-process `crossbeam_channel` path never touches these
+/// impls, it passes `Experience` values directly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Experience {
     /// Agent that generated this experience.
     pub agent_id: AgentId,
@@ -125,7 +132,12 @@ pub struct PolicyUpdate {
 /// `crossbeam_channel` broadcast channel after a learner update. The
 /// payload representation is chosen by the learner implementation; the
 /// actor side stays agnostic by matching on the variant.
-#[derive(Debug, Clone)]
+///
+/// `Serialize`/`Deserialize` (via serde's `rc` feature for the `Arc<Vec<u8>>`
+/// payload) back the networked actor-learner transport's wire encoding
+/// ([`crate::train::ppo::transport`], issue #281 / epic #265 Phase 4). The
+/// in-process `crossbeam_channel` path never touches these impls.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PolicyBroadcast {
     /// Serialized Burn module record bytes, produced by
     /// [`burn::record::BinBytesRecorder`] with
@@ -135,7 +147,10 @@ pub enum PolicyBroadcast {
     /// raw module clones, whose `Send`-ness depends on the backend's
     /// tensor primitives), and the [`Arc`] keeps the N-actor fan-out
     /// allocation-free — each actor channel receives a cheap pointer
-    /// clone of the same serialized blob.
+    /// clone of the same serialized blob. Over the wire, deserializing
+    /// allocates a fresh `Arc` per remote actor (no sharing across the
+    /// network), which is the correct behavior for a byte payload received
+    /// independently by each connection.
     Bytes {
         /// Monotonically increasing policy version. Incremented by the
         /// learner once per broadcast so actors (and tests) can observe
@@ -206,7 +221,12 @@ impl Default for TrainingStats {
 /// surface, but a runner that wants to support checkpointing and
 /// learning-rate scheduling can plumb this enum through its channel
 /// network.
-#[derive(Debug, Clone)]
+///
+/// `Serialize`/`Deserialize` back the networked actor-learner transport's
+/// wire encoding ([`crate::train::ppo::transport`], issue #281 / epic #265
+/// Phase 4). The in-process `crossbeam_channel` path never touches these
+/// impls.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ControlMessage {
     /// Stop training and shut down.
     Shutdown,

--- a/src/train/ppo.rs
+++ b/src/train/ppo.rs
@@ -20,6 +20,9 @@
 //!   (Burn's optimizer-consumes-module ownership model) and exposes a
 //!   `train_step` that runs the surrogate-loss / gradient-step / KL early stop
 //!   logic.
+//! - [`transport`] — the networked (TCP) actor-learner transport, an
+//!   interchangeable alternative to `actor_learner`'s default in-process
+//!   `crossbeam_channel` path (Phase 4 of the distributed-training epic #265).
 
 pub mod actor_learner;
 pub mod config;
@@ -27,6 +30,7 @@ pub mod loss;
 pub mod recurrent_trainer;
 pub mod stats;
 pub mod trainer;
+pub mod transport;
 
 pub use actor_learner::{
     ActorChannels, ActorHandle, ActorStats, AsyncActorLearnerConfig, LearnerReport, actor_thread,
@@ -40,3 +44,7 @@ pub use loss::{
 pub use recurrent_trainer::RecurrentPPOTrainer;
 pub use stats::{AggregatedStats, TrainingStats};
 pub use trainer::PPOTrainerBurn;
+pub use transport::{
+    BroadcastSender, ControlSender, ExperienceSender, TcpActorHandle, TcpExperienceSender,
+    TcpPeerSender, WireMessage, accept_actors_over_tcp, connect_actor_transport,
+};

--- a/src/train/ppo/actor_learner.rs
+++ b/src/train/ppo/actor_learner.rs
@@ -88,7 +88,11 @@ use burn::{
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TryRecvError, unbounded};
 use rand::{SeedableRng, rngs::StdRng};
 
-use super::{stats::TrainingStats, trainer::PPOTrainerBurn};
+use super::{
+    stats::TrainingStats,
+    trainer::PPOTrainerBurn,
+    transport::{BroadcastSender, ControlSender, ExperienceSender},
+};
 use crate::{
     buffer::rollout::{RolloutBatch, RolloutBuffer, compute_advantages},
     env::Environment,
@@ -333,9 +337,22 @@ impl ActorThrottle {
 ///
 /// Constructed by [`spawn_actor`]; exposed publicly so callers with
 /// bespoke threading can wire [`actor_thread`] themselves.
-pub struct ActorChannels {
-    /// Cloned sender half of the shared actors→learner MPSC channel.
-    pub experience_tx: Sender<Experience>,
+///
+/// Generic over the actor→learner experience sender (`EXP`), defaulting to
+/// the in-process [`crossbeam_channel::Sender`] every existing caller uses
+/// unchanged. This is the transport seam (issue #281 / epic #265 Phase 4):
+/// [`crate::train::ppo::transport::connect_actor_transport`] builds the same
+/// struct with a TCP-backed `EXP` so [`actor_thread`] runs identically
+/// whether the learner is in-process or across the network. `broadcast_rx` /
+/// `control_rx` stay the concrete crossbeam types in both cases — a
+/// networked transport bridges incoming broadcast/control frames onto an
+/// ordinary local crossbeam channel (see the transport module docs), so only
+/// the experience direction needs to be generic.
+pub struct ActorChannels<EXP: ExperienceSender = Sender<Experience>> {
+    /// Sender half of the actors→learner experience stream. The in-process
+    /// default is a cloned [`crossbeam_channel::Sender`]; a networked
+    /// transport supplies a type that writes wire-encoded frames instead.
+    pub experience_tx: EXP,
     /// Receive half of this actor's learner→actor broadcast channel.
     pub broadcast_rx: Receiver<PolicyBroadcast>,
     /// Receive half of this actor's control channel (shutdown etc.).
@@ -358,24 +375,54 @@ pub struct ActorStats {
     pub last_policy_version: u64,
 }
 
-/// Handle to a spawned actor thread.
+/// Handle to a spawned actor thread — or, for the networked transport, to
+/// the learner-side connection-handler thread for one remote actor.
 ///
 /// The learner uses [`ActorHandle::send_broadcast`] /
 /// [`ActorHandle::send_shutdown`]; the orchestrating caller consumes the
 /// handle with [`ActorHandle::join`] after [`learner_loop`] returns.
-pub struct ActorHandle {
+///
+/// Generic over the broadcast (`BR`) and control (`CTRL`) senders, defaulting
+/// to the in-process [`crossbeam_channel::Sender`] every existing caller uses
+/// unchanged. This is the learner-side half of the transport seam (issue
+/// #281 / epic #265 Phase 4):
+/// [`crate::train::ppo::transport::accept_actors_over_tcp`] builds this same
+/// struct with a TCP-backed `BR`/`CTRL` pair per remote actor connection, so
+/// [`learner_loop`] broadcasts/shuts down local and remote actors through the
+/// exact same call sites. `join` stays a plain
+/// `thread::JoinHandle<Result<ActorStats>>` in both cases: for a local actor
+/// it is [`spawn_actor`]'s env-stepping thread; for a remote one it is the
+/// background reader thread that decodes incoming experience frames off the
+/// socket (see the transport module).
+pub struct ActorHandle<
+    BR: BroadcastSender = Sender<PolicyBroadcast>,
+    CTRL: ControlSender = Sender<ControlMessage>,
+> {
     /// Which actor this handle controls.
     pub actor_id: AgentId,
     join: thread::JoinHandle<Result<ActorStats>>,
-    broadcast_tx: Sender<PolicyBroadcast>,
-    control_tx: Sender<ControlMessage>,
+    broadcast_tx: BR,
+    control_tx: CTRL,
 }
 
-impl ActorHandle {
+impl<BR: BroadcastSender, CTRL: ControlSender> ActorHandle<BR, CTRL> {
+    /// Build a handle from its parts. `pub(crate)` because the fields stay
+    /// private to external callers — only [`spawn_actor`] (in-process) and
+    /// [`crate::train::ppo::transport`] (networked) construct these.
+    pub(crate) fn from_parts(
+        actor_id: AgentId,
+        join: thread::JoinHandle<Result<ActorStats>>,
+        broadcast_tx: BR,
+        control_tx: CTRL,
+    ) -> Self {
+        Self { actor_id, join, broadcast_tx, control_tx }
+    }
+
     /// Send a policy broadcast to this actor. Returns `false` when the
-    /// actor has already exited (its receiver is disconnected).
+    /// actor has already exited (its receiver is disconnected, or — for a
+    /// networked actor — the connection is gone).
     pub fn send_broadcast(&self, broadcast: PolicyBroadcast) -> bool {
-        self.broadcast_tx.send(broadcast).is_ok()
+        self.broadcast_tx.send(broadcast)
     }
 
     /// Ask this actor to shut down (best-effort; a dead actor is fine).
@@ -385,11 +432,25 @@ impl ActorHandle {
 
     /// Wait for the actor thread to exit and return its stats.
     ///
+    /// Drops `broadcast_tx`/`control_tx` *before* blocking on the thread
+    /// join. This is a no-op for the in-process crossbeam path (dropping a
+    /// `Sender` just marks the channel disconnected). It is load-bearing
+    /// for the networked transport: [`crate::train::ppo::transport`]'s
+    /// learner-side reader thread only exits on a clean socket EOF, and a
+    /// socket whose file descriptor is duplicated across a reader clone and
+    /// a writer clone (`TcpStream::try_clone`) never reaches EOF while
+    /// *any* clone stays open — so joining first and dropping the sender
+    /// after (the naive order) would hold the writer clone open for the
+    /// entire blocking join, deadlocking forever.
+    ///
     /// # Errors
     /// Returns an error when the actor thread panicked or itself
     /// returned an error (e.g. a malformed policy broadcast).
     pub fn join(self) -> Result<ActorStats> {
-        self.join.join().map_err(|_| anyhow!("actor thread panicked"))?
+        let ActorHandle { actor_id: _, join, broadcast_tx, control_tx } = self;
+        drop(broadcast_tx);
+        drop(control_tx);
+        join.join().map_err(|_| anyhow!("actor thread panicked"))?
     }
 }
 
@@ -474,14 +535,21 @@ where
 /// Most callers should use [`spawn_actor`] instead of calling this
 /// directly.
 ///
+/// Generic over the experience sender `EXP` (see [`ActorChannels`]) so this
+/// same function body runs identically whether `channels` was built by
+/// [`spawn_actor`] (in-process `crossbeam_channel`) or
+/// [`crate::train::ppo::transport::connect_actor_transport`] (TCP) — the
+/// transport seam for issue #281 / epic #265 Phase 4. `EXP` defaults to the
+/// crossbeam type, so every pre-existing caller compiles unchanged.
+///
 /// # Errors
 /// Returns an error when a policy broadcast fails to decode.
 #[allow(clippy::too_many_arguments)] // mirror of spawn_actor; bundling hides the wiring
-pub fn actor_thread<B2, M, E, F>(
+pub fn actor_thread<B2, M, E, F, EXP>(
     actor_id: AgentId,
     mut env: E,
     mut policy: M,
-    channels: ActorChannels,
+    channels: ActorChannels<EXP>,
     device: B2::Device,
     seed: u64,
     throttle: ActorThrottle,
@@ -492,6 +560,7 @@ where
     M: Module<B2>,
     E: Environment<Action = i64>,
     F: FnMut(&M, &[f32], &mut StdRng) -> (i64, f32, f32),
+    EXP: ExperienceSender,
 {
     let mut rng = StdRng::seed_from_u64(seed);
     let mut stats = ActorStats { actor_id, ..Default::default() };
@@ -548,7 +617,7 @@ where
             value,
             log_prob,
         );
-        if channels.experience_tx.send(experience).is_err() {
+        if !channels.experience_tx.send(experience) {
             break; // learner is gone; nothing left to do
         }
         stats.steps_sent += 1;
@@ -592,12 +661,12 @@ where
     let join = thread::Builder::new()
         .name(format!("thrust-actor-{actor_id}"))
         .spawn(move || {
-            actor_thread::<B2, M, E, F>(
+            actor_thread::<B2, M, E, F, _>(
                 actor_id, env, policy, channels, device, seed, throttle, act_fn,
             )
         })
         .expect("failed to spawn actor thread");
-    ActorHandle { actor_id, join, broadcast_tx, control_tx }
+    ActorHandle::from_parts(actor_id, join, broadcast_tx, control_tx)
 }
 
 /// Summary returned by [`learner_loop`] alongside the trained
@@ -668,13 +737,13 @@ impl LearnerReport {
 /// experience carries an out-of-range `agent_id`, or when a
 /// `train_step` / policy serialization fails.
 #[allow(clippy::too_many_arguments)] // trainer + channels + two closures; same shape as train_step
-pub fn learner_loop<B, P, O, F, G>(
+pub fn learner_loop<B, P, O, F, G, BR, CTRL>(
     config: &AsyncActorLearnerConfig,
     mut trainer: PPOTrainerBurn<B, P, O>,
     obs_dim: usize,
     device: &B::Device,
     experience_rx: &Receiver<Experience>,
-    actors: &[ActorHandle],
+    actors: &[ActorHandle<BR, CTRL>],
     mut evaluate_fn: F,
     mut value_fn: G,
 ) -> Result<(PPOTrainerBurn<B, P, O>, LearnerReport)>
@@ -684,6 +753,8 @@ where
     O: Optimizer<P, B>,
     F: FnMut(&P, Tensor<B, 2>, Tensor<B, 1, Int>) -> (Tensor<B, 1>, Tensor<B, 1>, Tensor<B, 1>),
     G: FnMut(&P, Tensor<B, 2>) -> Vec<f32>,
+    BR: BroadcastSender,
+    CTRL: ControlSender,
 {
     config.validate()?;
     let num_actors = config.num_actors;

--- a/src/train/ppo/transport.rs
+++ b/src/train/ppo/transport.rs
@@ -5,7 +5,7 @@
 //! experience sender
 //! ([`ActorChannels::experience_tx`](super::actor_learner::ActorChannels))
 //! and the learner→actor broadcast/control senders
-//! ([`ActorHandle`](super::actor_learner::ActorHandle)'s `BR`/`CTRL` type
+//! ([`ActorHandle`]'s `BR`/`CTRL` type
 //! parameters). Both default to the in-process `crossbeam_channel` types
 //! every pre-#281 caller already used — **that path is unchanged, still the
 //! default, and every Phase 2/3 test keeps exercising it verbatim.**
@@ -21,7 +21,7 @@
 //!
 //! Every frame is one [`WireMessage`] value, `bincode`-encoded
 //! ([`bincode::config::standard`] via `bincode`'s `serde` integration — see
-//! [`write_message`] / [`read_message`]) and length-prefixed with a 4-byte
+//! `write_message` / `read_message`) and length-prefixed with a 4-byte
 //! big-endian `u32`. `Experience`/`PolicyBroadcast`/`ControlMessage` derive
 //! `Serialize`/`Deserialize` directly (`PolicyBroadcast`'s `Arc<Vec<u8>>`
 //! payload via serde's `rc` feature — see `src/multi_agent/messages.rs`), so
@@ -48,8 +48,8 @@
 //!   shared crossbeam sender feeding the single `experience_rx`
 //!   [`learner_loop`](super::actor_learner::learner_loop) already consumes.
 //!   That reader thread *is* the resulting
-//!   [`ActorHandle`](super::actor_learner::ActorHandle)'s join handle: it
-//!   returns best-effort [`ActorStats`](super::actor_learner::ActorStats)
+//!   [`ActorHandle`]'s join handle: it
+//!   returns best-effort [`ActorStats`]
 //!   (steps/episodes forwarded) once the remote actor disconnects, so an actor
 //!   dying mid-training surfaces the same way a local actor panic would — the
 //!   learner's fill loop simply stops receiving from that column and the others
@@ -101,7 +101,7 @@ pub trait ExperienceSender: Send {
 
 /// Learner-side sender half of one actor's broadcast channel.
 ///
-/// [`ActorHandle`](super::actor_learner::ActorHandle)'s `BR` bound.
+/// [`ActorHandle`]'s `BR` bound.
 /// Implemented for [`crossbeam_channel::Sender<PolicyBroadcast>`] (default)
 /// and [`TcpPeerSender`] (networked).
 pub trait BroadcastSender: Send {
@@ -112,7 +112,7 @@ pub trait BroadcastSender: Send {
 
 /// Learner-side sender half of one actor's control channel.
 ///
-/// [`ActorHandle`](super::actor_learner::ActorHandle)'s `CTRL` bound.
+/// [`ActorHandle`]'s `CTRL` bound.
 /// Implemented for [`crossbeam_channel::Sender<ControlMessage>`] (default)
 /// and [`TcpPeerSender`] (networked).
 pub trait ControlSender: Send {

--- a/src/train/ppo/transport.rs
+++ b/src/train/ppo/transport.rs
@@ -1,0 +1,629 @@
+//! Networked actor-learner transport (Phase 4 of the distributed-training
+//! epic #265 — see `docs/DISTRIBUTED_TRAINING_DESIGN.md`).
+//!
+//! [`actor_learner`](super::actor_learner) is generic over the actor→learner
+//! experience sender
+//! ([`ActorChannels::experience_tx`](super::actor_learner::ActorChannels))
+//! and the learner→actor broadcast/control senders
+//! ([`ActorHandle`](super::actor_learner::ActorHandle)'s `BR`/`CTRL` type
+//! parameters). Both default to the in-process `crossbeam_channel` types
+//! every pre-#281 caller already used — **that path is unchanged, still the
+//! default, and every Phase 2/3 test keeps exercising it verbatim.**
+//!
+//! This module supplies the second implementation of that seam: a TCP
+//! transport that lets a remote actor process stream `Experience` batches to
+//! a learner over the network, and receive `PolicyBroadcast`/`ControlMessage`
+//! frames back, using [`actor_thread`](super::actor_learner::actor_thread)
+//! and [`learner_loop`](super::actor_learner::learner_loop) completely
+//! unmodified — only the channel endpoints they are handed differ.
+//!
+//! # Wire format
+//!
+//! Every frame is one [`WireMessage`] value, `bincode`-encoded
+//! ([`bincode::config::standard`] via `bincode`'s `serde` integration — see
+//! [`write_message`] / [`read_message`]) and length-prefixed with a 4-byte
+//! big-endian `u32`. `Experience`/`PolicyBroadcast`/`ControlMessage` derive
+//! `Serialize`/`Deserialize` directly (`PolicyBroadcast`'s `Arc<Vec<u8>>`
+//! payload via serde's `rc` feature — see `src/multi_agent/messages.rs`), so
+//! no separate wire DTO is needed.
+//!
+//! # Topology
+//!
+//! One TCP connection per remote actor, carrying **both** directions:
+//! - actor → learner: [`WireMessage::Experience`] frames only.
+//! - learner → actor: [`WireMessage::Broadcast`] / [`WireMessage::Control`]
+//!   frames only.
+//!
+//! Each side runs one background thread that only ever reads its incoming
+//! direction and forwards decoded values onto an ordinary local
+//! `crossbeam_channel`:
+//! - **Actor side** ([`connect_actor_transport`]): a "demux" thread reads
+//!   `Broadcast`/`Control` frames off the socket and forwards them onto local
+//!   `broadcast_tx`/`control_tx` senders — so
+//!   [`actor_thread`](super::actor_learner::actor_thread)'s `broadcast_rx` /
+//!   `control_rx` stay the exact concrete crossbeam receivers it always used.
+//!   Only `experience_tx` is TCP-backed ([`TcpExperienceSender`]).
+//! - **Learner side** ([`accept_actors_over_tcp`]): one reader thread per
+//!   accepted connection decodes `Experience` frames and forwards them onto a
+//!   shared crossbeam sender feeding the single `experience_rx`
+//!   [`learner_loop`](super::actor_learner::learner_loop) already consumes.
+//!   That reader thread *is* the resulting
+//!   [`ActorHandle`](super::actor_learner::ActorHandle)'s join handle: it
+//!   returns best-effort [`ActorStats`](super::actor_learner::ActorStats)
+//!   (steps/episodes forwarded) once the remote actor disconnects, so an actor
+//!   dying mid-training surfaces the same way a local actor panic would — the
+//!   learner's fill loop simply stops receiving from that column and the others
+//!   continue.
+//!
+//! # Loopback verification
+//!
+//! `tests/test_actor_learner_tcp.rs` runs a learner (accepting on
+//! `127.0.0.1:0`, i.e. an OS-assigned ephemeral port) against two remote
+//! actor threads dialing back in over `TcpStream::connect`, training
+//! CartPole PPO to completion with clean shutdown — the loopback-verification
+//! acceptance criterion for issue #281. Real multi-host runs (distinct
+//! `alc-*` hosts) are documented as a runbook in
+//! `docs/DISTRIBUTED_TRAINING_DESIGN.md` rather than automated, since this
+//! environment cannot reach those hosts.
+
+use std::{
+    io::{self, Read, Write},
+    net::{Shutdown, TcpListener, TcpStream, ToSocketAddrs},
+    sync::{Arc, Mutex},
+    thread,
+};
+
+use anyhow::{Result, anyhow};
+use crossbeam_channel::{Receiver, Sender, unbounded};
+use serde::{Deserialize, Serialize};
+
+use super::actor_learner::{ActorChannels, ActorHandle, ActorStats};
+use crate::multi_agent::{ControlMessage, Experience, PolicyBroadcast};
+
+// ---------------------------------------------------------------------------
+// The transport seam: traits `actor_thread` / `learner_loop` are generic
+// over. Blanket-implemented for the in-process crossbeam types below, so the
+// existing default path satisfies them with zero behavior change; the TCP
+// types further down implement them for the networked path.
+// ---------------------------------------------------------------------------
+
+/// Actor-side sender half of the actors→learner experience stream.
+///
+/// [`ActorChannels::experience_tx`](super::actor_learner::ActorChannels)'s
+/// bound. Implemented for [`crossbeam_channel::Sender<Experience>`] (the
+/// default, unchanged in-process path) and [`TcpExperienceSender`] (networked).
+pub trait ExperienceSender: Send {
+    /// Send one experience. Returns `false` when the receiving side is gone
+    /// (disconnected channel, or — for a network transport — a dead
+    /// connection), mirroring `crossbeam_channel::Sender::send(..).is_ok()`.
+    fn send(&self, experience: Experience) -> bool;
+}
+
+/// Learner-side sender half of one actor's broadcast channel.
+///
+/// [`ActorHandle`](super::actor_learner::ActorHandle)'s `BR` bound.
+/// Implemented for [`crossbeam_channel::Sender<PolicyBroadcast>`] (default)
+/// and [`TcpPeerSender`] (networked).
+pub trait BroadcastSender: Send {
+    /// Send one policy broadcast to this actor. Returns `false` when the
+    /// actor is gone.
+    fn send(&self, broadcast: PolicyBroadcast) -> bool;
+}
+
+/// Learner-side sender half of one actor's control channel.
+///
+/// [`ActorHandle`](super::actor_learner::ActorHandle)'s `CTRL` bound.
+/// Implemented for [`crossbeam_channel::Sender<ControlMessage>`] (default)
+/// and [`TcpPeerSender`] (networked).
+pub trait ControlSender: Send {
+    /// Send one control message to this actor. Returns `false` when the
+    /// actor is gone.
+    fn send(&self, message: ControlMessage) -> bool;
+}
+
+impl ExperienceSender for Sender<Experience> {
+    fn send(&self, experience: Experience) -> bool {
+        Sender::send(self, experience).is_ok()
+    }
+}
+
+impl BroadcastSender for Sender<PolicyBroadcast> {
+    fn send(&self, broadcast: PolicyBroadcast) -> bool {
+        Sender::send(self, broadcast).is_ok()
+    }
+}
+
+impl ControlSender for Sender<ControlMessage> {
+    fn send(&self, message: ControlMessage) -> bool {
+        Sender::send(self, message).is_ok()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire encoding
+// ---------------------------------------------------------------------------
+
+/// One frame of the actor↔learner wire protocol.
+///
+/// Directional by convention (see the module docs): actor→learner sockets
+/// only ever carry [`WireMessage::Experience`]; learner→actor sockets only
+/// ever carry [`WireMessage::Broadcast`] / [`WireMessage::Control`]. Bundled
+/// into one enum (rather than three separate wire types) so both directions
+/// share one `write_message`/`read_message` pair.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum WireMessage {
+    /// One actor→learner experience tuple.
+    Experience(Experience),
+    /// One learner→actor policy broadcast.
+    Broadcast(PolicyBroadcast),
+    /// One learner→actor control message.
+    Control(ControlMessage),
+}
+
+/// Encode `msg` with `bincode`'s `serde` integration and write it to
+/// `stream` as a 4-byte big-endian length prefix followed by the payload.
+///
+/// # Errors
+/// Returns an error when encoding fails (never expected for these plain
+/// types) or the underlying socket write fails.
+fn write_message(stream: &mut impl Write, msg: &WireMessage) -> io::Result<()> {
+    let bytes = bincode::serde::encode_to_vec(msg, bincode::config::standard())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let len = u32::try_from(bytes.len())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "frame too large"))?;
+    stream.write_all(&len.to_be_bytes())?;
+    stream.write_all(&bytes)?;
+    stream.flush()
+}
+
+/// Read one length-prefixed [`WireMessage`] frame from `stream`.
+///
+/// Returns `Ok(None)` on a clean EOF at a frame boundary (the peer closed
+/// the connection between frames — the expected shutdown path), and
+/// `Err(..)` for any other I/O failure or decode error (including a
+/// truncated frame, which is a genuine error rather than a clean close).
+///
+/// # Errors
+/// Returns an error when the socket read fails (other than a clean EOF
+/// before any bytes of the next frame) or the payload fails to decode.
+fn read_message(stream: &mut impl Read) -> io::Result<Option<WireMessage>> {
+    let mut len_buf = [0u8; 4];
+    match stream.read_exact(&mut len_buf) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+    let len = u32::from_be_bytes(len_buf) as usize;
+    let mut buf = vec![0u8; len];
+    stream.read_exact(&mut buf)?;
+    let (msg, _consumed) = bincode::serde::decode_from_slice(&buf, bincode::config::standard())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    Ok(Some(msg))
+}
+
+// ---------------------------------------------------------------------------
+// TCP sender types
+// ---------------------------------------------------------------------------
+
+/// Shut down `stream` (both directions) when `handle` is the last
+/// `Arc` reference to it, ignoring any error (the socket may already be
+/// gone).
+///
+/// This is the fix for a real deadlock class in this transport:
+/// `TcpStream::try_clone` duplicates the underlying OS socket, and merely
+/// *dropping* (closing) one clone does **not** send a TCP `FIN` while
+/// another local clone of the same socket stays open — the read/write
+/// halves used by the demux/reader background threads are exactly such
+/// clones. An explicit `shutdown()` call, by contrast, acts on the shared
+/// socket itself (not the per-fd refcount): it immediately unblocks any
+/// local thread blocked reading *any* clone of this socket, **and** sends a
+/// real `FIN` so the remote peer's blocked read sees a clean EOF too. Used
+/// by both [`TcpExperienceSender`] and [`TcpPeerSender`]'s `Drop` impls so
+/// each side's demux/reader thread reliably observes EOF once the sender
+/// that shares its socket is done, instead of only when every dup'd fd
+/// happens to be closed (which can never happen if the reader thread that
+/// would close its own clone is exactly the thread blocked waiting for
+/// EOF to exit).
+fn shutdown_when_last_ref(handle: &Arc<Mutex<TcpStream>>) {
+    if Arc::strong_count(handle) == 1
+        && let Ok(stream) = handle.lock()
+    {
+        let _ = stream.shutdown(Shutdown::Both);
+    }
+}
+
+/// Actor-side [`ExperienceSender`]: writes each [`Experience`] as one
+/// [`WireMessage::Experience`] frame to the learner's socket.
+///
+/// `actor_thread` only ever calls `send` from its own single thread, so the
+/// `Mutex` here is never contended — it exists to satisfy `Sync`-free
+/// interior mutability for the `&self`-taking trait method, not for real
+/// concurrent access.
+#[derive(Clone)]
+pub struct TcpExperienceSender(Arc<Mutex<TcpStream>>);
+
+impl ExperienceSender for TcpExperienceSender {
+    fn send(&self, experience: Experience) -> bool {
+        let Ok(mut guard) = self.0.lock() else {
+            return false;
+        };
+        write_message(&mut *guard, &WireMessage::Experience(experience)).is_ok()
+    }
+}
+
+impl Drop for TcpExperienceSender {
+    fn drop(&mut self) {
+        shutdown_when_last_ref(&self.0);
+    }
+}
+
+/// Learner-side sender for both [`PolicyBroadcast`] and [`ControlMessage`]
+/// frames to one remote actor connection. One type serves both
+/// [`BroadcastSender`] and [`ControlSender`] because both directions share
+/// the same socket (learner → actor) and the same framing.
+#[derive(Clone)]
+pub struct TcpPeerSender(Arc<Mutex<TcpStream>>);
+
+impl BroadcastSender for TcpPeerSender {
+    fn send(&self, broadcast: PolicyBroadcast) -> bool {
+        let Ok(mut guard) = self.0.lock() else {
+            return false;
+        };
+        write_message(&mut *guard, &WireMessage::Broadcast(broadcast)).is_ok()
+    }
+}
+
+impl ControlSender for TcpPeerSender {
+    fn send(&self, message: ControlMessage) -> bool {
+        let Ok(mut guard) = self.0.lock() else {
+            return false;
+        };
+        write_message(&mut *guard, &WireMessage::Control(message)).is_ok()
+    }
+}
+
+impl Drop for TcpPeerSender {
+    fn drop(&mut self) {
+        shutdown_when_last_ref(&self.0);
+    }
+}
+
+/// An [`ActorHandle`] to a remote actor connected over TCP — the return
+/// type of [`accept_actors_over_tcp`], named to keep that signature (and
+/// callers') types readable.
+pub type TcpActorHandle = ActorHandle<TcpPeerSender, TcpPeerSender>;
+
+// ---------------------------------------------------------------------------
+// Actor side: dial the learner
+// ---------------------------------------------------------------------------
+
+/// Dial `addr` (the learner's listening address) and build the
+/// [`ActorChannels`] a remote actor process hands to
+/// [`actor_thread`](super::actor_learner::actor_thread) — the exact same
+/// function the in-process path uses, unmodified.
+///
+/// Spawns one background "demux" thread that reads incoming
+/// [`WireMessage::Broadcast`] / [`WireMessage::Control`] frames off the
+/// socket and forwards them onto ordinary local `crossbeam_channel` senders,
+/// so `actor_thread`'s `broadcast_rx` / `control_rx` stay the exact concrete
+/// crossbeam types it always used — only `experience_tx` is TCP-backed. The
+/// demux thread exits (and is safe to `join`) once the local
+/// `broadcast_rx`/`control_rx` receivers are dropped (i.e. once
+/// `actor_thread` returns and its `ActorChannels` goes out of scope) or the
+/// learner closes the connection, whichever comes first.
+///
+/// # Errors
+/// Returns an error when the connection cannot be established.
+pub fn connect_actor_transport(
+    addr: impl ToSocketAddrs,
+) -> Result<(ActorChannels<TcpExperienceSender>, thread::JoinHandle<()>)> {
+    let stream =
+        TcpStream::connect(addr).map_err(|e| anyhow!("failed to connect to learner: {e}"))?;
+    stream.set_nodelay(true).ok();
+    let mut read_stream = stream
+        .try_clone()
+        .map_err(|e| anyhow!("failed to clone tcp stream for demux: {e}"))?;
+
+    let (broadcast_tx, broadcast_rx) = unbounded();
+    let (control_tx, control_rx) = unbounded();
+
+    let demux = thread::Builder::new()
+        .name("thrust-actor-tcp-demux".to_string())
+        .spawn(move || {
+            loop {
+                match read_message(&mut read_stream) {
+                    Ok(Some(WireMessage::Broadcast(broadcast))) => {
+                        if broadcast_tx.send(broadcast).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(Some(WireMessage::Control(message))) => {
+                        if control_tx.send(message).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(Some(WireMessage::Experience(_))) => {
+                        // Wrong direction for a learner→actor socket; a
+                        // conformant learner never sends this. Ignore rather
+                        // than tear down the connection over a protocol
+                        // violation that costs nothing to skip.
+                        tracing::warn!(
+                            "actor tcp demux: ignoring unexpected Experience frame from learner"
+                        );
+                    }
+                    Ok(None) => break, // learner closed the connection cleanly
+                    Err(e) => {
+                        tracing::warn!("actor tcp demux: read error, stopping: {e}");
+                        break;
+                    }
+                }
+            }
+        })
+        .expect("failed to spawn tcp demux thread");
+
+    let experience_tx = TcpExperienceSender(Arc::new(Mutex::new(stream)));
+    Ok((ActorChannels { experience_tx, broadcast_rx, control_rx }, demux))
+}
+
+// ---------------------------------------------------------------------------
+// Learner side: accept remote actors
+// ---------------------------------------------------------------------------
+
+/// Accept `num_actors` remote actor connections on `listener` and build the
+/// shared experience receiver plus per-actor [`ActorHandle`]s
+/// [`learner_loop`](super::actor_learner::learner_loop) consumes —
+/// unmodified from the in-process path (only the `BR`/`CTRL` type
+/// parameters differ, inferred as [`TcpPeerSender`]).
+///
+/// Blocks accepting connections one at a time until `num_actors` remote
+/// actors have dialed in. Each accepted connection gets one background
+/// reader thread that decodes incoming [`WireMessage::Experience`] frames
+/// and forwards them onto a clone of the shared experience sender feeding
+/// the returned `experience_rx`; that thread *is* the resulting
+/// [`ActorHandle`]'s join handle and returns best-effort [`ActorStats`]
+/// (steps/episodes forwarded) once the connection closes — so
+/// [`ActorHandle::join`](super::actor_learner::ActorHandle::join) works the
+/// same way for a remote actor as for a local one, and an actor dying
+/// mid-training surfaces as that column's reader thread exiting rather than
+/// a learner panic.
+///
+/// # Errors
+/// Returns an error when accepting a connection fails.
+pub fn accept_actors_over_tcp(
+    listener: &TcpListener,
+    num_actors: usize,
+) -> Result<(Receiver<Experience>, Vec<TcpActorHandle>)> {
+    let (experience_tx, experience_rx) = unbounded();
+    let mut handles = Vec::with_capacity(num_actors);
+
+    for actor_id in 0..num_actors {
+        let (stream, _peer_addr) = listener
+            .accept()
+            .map_err(|e| anyhow!("failed to accept actor connection: {e}"))?;
+        stream.set_nodelay(true).ok();
+        let mut read_stream = stream
+            .try_clone()
+            .map_err(|e| anyhow!("failed to clone tcp stream for actor {actor_id}: {e}"))?;
+        let peer_sender = TcpPeerSender(Arc::new(Mutex::new(stream)));
+        let exp_tx = experience_tx.clone();
+
+        let join = thread::Builder::new()
+            .name(format!("thrust-learner-tcp-reader-{actor_id}"))
+            .spawn(move || -> Result<ActorStats> {
+                let mut stats = ActorStats { actor_id, ..Default::default() };
+                loop {
+                    match read_message(&mut read_stream) {
+                        Ok(Some(WireMessage::Experience(experience))) => {
+                            stats.steps_sent += 1;
+                            if experience.is_done() {
+                                stats.episodes_completed += 1;
+                            }
+                            if exp_tx.send(experience).is_err() {
+                                break; // learner dropped experience_rx; nothing left to do
+                            }
+                        }
+                        Ok(Some(_)) => {
+                            // Wrong direction for an actor→learner socket;
+                            // ignore rather than abort the run.
+                            tracing::warn!(
+                                actor_id,
+                                "learner tcp reader: ignoring unexpected non-Experience frame"
+                            );
+                        }
+                        Ok(None) => break, // actor closed the connection cleanly
+                        Err(e) => {
+                            tracing::warn!(
+                                actor_id,
+                                "learner tcp reader: read error, stopping: {e}"
+                            );
+                            break;
+                        }
+                    }
+                }
+                Ok(stats)
+            })
+            .expect("failed to spawn tcp learner reader thread");
+
+        handles.push(ActorHandle::from_parts(actor_id, join, peer_sender.clone(), peer_sender));
+    }
+
+    Ok((experience_rx, handles))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::TcpListener, time::Duration};
+
+    use super::*;
+
+    /// Round-trip every [`WireMessage`] variant through `write_message` /
+    /// `read_message` over a real loopback socket pair, proving the wire
+    /// encoding (not just in-memory serde) preserves every field.
+    #[test]
+    fn wire_message_roundtrips_over_loopback_socket() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = TcpStream::connect(addr).unwrap();
+        let (mut server, _) = listener.accept().unwrap();
+
+        let experience = Experience::new(
+            2,
+            vec![0.1, -0.2, 0.3, 0.4],
+            vec![1],
+            1.5,
+            vec![0.5, 0.6, 0.7, 0.8],
+            true,
+            false,
+            0.25,
+            -0.42,
+        );
+        let broadcast = PolicyBroadcast::Bytes { version: 9, bytes: Arc::new(vec![1, 2, 3, 4, 5]) };
+        let control = ControlMessage::Shutdown;
+
+        let mut writer = client;
+        write_message(&mut writer, &WireMessage::Experience(experience.clone())).unwrap();
+        write_message(&mut writer, &WireMessage::Broadcast(broadcast.clone())).unwrap();
+        write_message(&mut writer, &WireMessage::Control(control.clone())).unwrap();
+        drop(writer); // signal clean EOF after the three frames
+
+        match read_message(&mut server).unwrap().unwrap() {
+            WireMessage::Experience(got) => {
+                assert_eq!(got.agent_id, experience.agent_id);
+                assert_eq!(got.observation, experience.observation);
+                assert_eq!(got.action, experience.action);
+                assert_eq!(got.reward, experience.reward);
+                assert_eq!(got.next_observation, experience.next_observation);
+                assert_eq!(got.terminated, experience.terminated);
+                assert_eq!(got.truncated, experience.truncated);
+                assert_eq!(got.value, experience.value);
+                assert_eq!(got.log_prob, experience.log_prob);
+            }
+            other => panic!("expected Experience, got {other:?}"),
+        }
+
+        match read_message(&mut server).unwrap().unwrap() {
+            WireMessage::Broadcast(PolicyBroadcast::Bytes { version, bytes }) => {
+                assert_eq!(version, 9);
+                assert_eq!(*bytes, vec![1, 2, 3, 4, 5]);
+            }
+            other => panic!("expected Broadcast, got {other:?}"),
+        }
+
+        match read_message(&mut server).unwrap().unwrap() {
+            WireMessage::Control(ControlMessage::Shutdown) => {}
+            other => panic!("expected Control(Shutdown), got {other:?}"),
+        }
+
+        // Clean EOF at the next frame boundary decodes as `None`, not an error.
+        assert!(read_message(&mut server).unwrap().is_none());
+    }
+
+    /// A truncated frame (length prefix present, payload cut short) is a
+    /// genuine I/O error, not a clean `None` — distinguishing a mid-frame
+    /// disconnect (bug / crash) from a between-frames shutdown.
+    #[test]
+    fn read_message_errors_on_truncated_frame() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let mut client = TcpStream::connect(addr).unwrap();
+        let (mut server, _) = listener.accept().unwrap();
+
+        // Claim a 100-byte payload, then only send 3 bytes and close.
+        client.write_all(&100u32.to_be_bytes()).unwrap();
+        client.write_all(&[1, 2, 3]).unwrap();
+        drop(client);
+
+        let err = read_message(&mut server).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    /// Actor disconnect mid-training: the learner survives and the shared
+    /// experience channel keeps working for the surviving actor.
+    ///
+    /// Accepts 2 remote actor connections, sends a few experiences on each,
+    /// then abruptly drops actor 0's connection (simulating a crash) while
+    /// actor 1's connection stays open. Asserts: (1) actor 0's
+    /// [`ActorHandle::join`] returns cleanly (no hang, no panic) with the
+    /// steps it forwarded before disconnecting; (2) the shared
+    /// `experience_rx` is unaffected by actor 0's disconnect — a short
+    /// `recv_timeout` on it (with no traffic pending) reports a plain
+    /// timeout, not `Disconnected`, since actor 1's sender clone keeps the
+    /// channel alive. This is the transport-level guarantee `learner_loop`'s
+    /// fill loop relies on: one actor going away does not sever the shared
+    /// channel the other columns still feed.
+    #[test]
+    fn learner_survives_one_actor_disconnecting_mid_training() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let mut client0 = TcpStream::connect(addr).unwrap();
+        let mut client1 = TcpStream::connect(addr).unwrap();
+
+        let (experience_rx, mut handles) = accept_actors_over_tcp(&listener, 2).unwrap();
+
+        // Both actors send a couple of experiences.
+        let make_exp = |agent_id: usize| {
+            Experience::new(
+                agent_id,
+                vec![0.0; 4],
+                vec![0],
+                1.0,
+                vec![0.0; 4],
+                false,
+                false,
+                0.0,
+                0.0,
+            )
+        };
+        write_message(&mut client0, &WireMessage::Experience(make_exp(0))).unwrap();
+        write_message(&mut client0, &WireMessage::Experience(make_exp(0))).unwrap();
+        write_message(&mut client1, &WireMessage::Experience(make_exp(1))).unwrap();
+
+        // Drain those 3 so the reader threads have processed them before we
+        // pull the plug (avoids a race between the disconnect and the last
+        // read on actor 0's connection).
+        for _ in 0..3 {
+            experience_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("expected buffered experience");
+        }
+
+        // Simulate actor 0 crashing: close its connection abruptly.
+        drop(client0);
+
+        // Actor 0's handle joins cleanly (reader thread sees EOF, exits,
+        // returns its forwarded-step count) without hanging.
+        let actor0 = handles.remove(0);
+        let stats0 = actor0
+            .join()
+            .expect("learner-side reader thread for a disconnected actor must not panic");
+        assert_eq!(stats0.actor_id, 0);
+        assert_eq!(stats0.steps_sent, 2, "actor 0's reader should report the 2 steps it forwarded");
+
+        // The shared channel survives: actor 1's sender clone is still
+        // alive, so a short timeout reports Timeout (no more traffic
+        // pending), never Disconnected.
+        match experience_rx.recv_timeout(Duration::from_millis(200)) {
+            Err(crossbeam_channel::RecvTimeoutError::Timeout) => {}
+            other => panic!(
+                "expected the shared experience channel to survive actor 0's disconnect \
+                 (Timeout, no more traffic), got {other:?}"
+            ),
+        }
+
+        // Actor 1 can still send and be received — the learner truly kept
+        // training on the surviving actor.
+        write_message(&mut client1, &WireMessage::Experience(make_exp(1))).unwrap();
+        let got = experience_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("actor 1 still delivers");
+        assert_eq!(got.agent_id, 1);
+
+        // Clean up actor 1's handle too.
+        drop(client1);
+        let actor1 = handles.remove(0);
+        let stats1 = actor1.join().expect("actor 1 reader thread must not panic");
+        assert_eq!(stats1.actor_id, 1);
+        assert_eq!(stats1.steps_sent, 2);
+    }
+}

--- a/src/train/ppo/transport.rs
+++ b/src/train/ppo/transport.rs
@@ -47,13 +47,11 @@
 //!   accepted connection decodes `Experience` frames and forwards them onto a
 //!   shared crossbeam sender feeding the single `experience_rx`
 //!   [`learner_loop`](super::actor_learner::learner_loop) already consumes.
-//!   That reader thread *is* the resulting
-//!   [`ActorHandle`]'s join handle: it
-//!   returns best-effort [`ActorStats`]
-//!   (steps/episodes forwarded) once the remote actor disconnects, so an actor
-//!   dying mid-training surfaces the same way a local actor panic would — the
-//!   learner's fill loop simply stops receiving from that column and the others
-//!   continue.
+//!   That reader thread *is* the resulting [`ActorHandle`]'s join handle: it
+//!   returns best-effort [`ActorStats`] (steps/episodes forwarded) once the
+//!   remote actor disconnects, so an actor dying mid-training surfaces the same
+//!   way a local actor panic would — the learner's fill loop simply stops
+//!   receiving from that column and the others continue.
 //!
 //! # Loopback verification
 //!

--- a/tests/test_actor_learner_tcp.rs
+++ b/tests/test_actor_learner_tcp.rs
@@ -1,0 +1,274 @@
+//! Networked actor-learner PPO loopback verification (issue #281, Phase 4 of
+//! the distributed-training epic #265).
+//!
+//! Mirrors `tests/test_cartpole_async.rs` (the in-process crossbeam Phase 2
+//! test) but wires the actors and learner together over real TCP sockets on
+//! `127.0.0.1` instead of local channels, using
+//! [`thrust_rl::train::ppo::transport`]'s `connect_actor_transport` /
+//! `accept_actors_over_tcp`. Two remote "actor" threads dial in to a learner
+//! listening on an OS-assigned loopback port, train CartPole PPO, and the
+//! test asserts the loopback-verification acceptance bar from #281: reward
+//! improves and shutdown is clean (every thread joins, no hang, no panic).
+//!
+//! Real multi-host runs (distinct `alc-*` hosts) are documented as a runbook
+//! in `docs/DISTRIBUTED_TRAINING_DESIGN.md` rather than automated here.
+
+#![cfg(feature = "training")]
+
+use std::{net::TcpListener, thread};
+
+use burn::{
+    backend::{Autodiff, NdArray, ndarray::NdArrayDevice},
+    module::AutodiffModule,
+    optim::AdamConfig,
+    tensor::{Tensor, TensorData},
+};
+use rand::rngs::StdRng;
+use thrust_rl::{
+    env::{Environment, cartpole::CartPole},
+    policy::mlp::{BurnActivation, MlpBurnConfig, MlpBurnPolicy},
+    train::{
+        optimizer::BurnOptimizer,
+        ppo::{
+            ActorStats, AsyncActorLearnerConfig, LearnerReport, PPOConfig, PPOTrainerBurn,
+            actor_thread, learner_loop,
+            transport::{accept_actors_over_tcp, connect_actor_transport},
+        },
+    },
+};
+
+type InnerBackend = NdArray<f32>;
+type Backend = Autodiff<InnerBackend>;
+
+const HIDDEN_DIM: usize = 64;
+const SEED: u64 = 0;
+
+/// Run one remote actor: dial `addr`, then run the *unmodified*
+/// [`actor_thread`] against the resulting TCP-backed [`ActorChannels`].
+/// Returns the actor's own [`ActorStats`] once it shuts down, after joining
+/// the connection's demux thread.
+fn run_remote_actor(
+    actor_id: usize,
+    addr: std::net::SocketAddr,
+    policy: MlpBurnPolicy<InnerBackend>,
+    device: NdArrayDevice,
+    seed: u64,
+    throttle: thrust_rl::train::ppo::actor_learner::ActorThrottle,
+) -> ActorStats {
+    let (channels, demux) =
+        connect_actor_transport(addr).expect("remote actor failed to connect to learner");
+
+    let act_device = device;
+    let stats = actor_thread::<InnerBackend, _, _, _, _>(
+        actor_id,
+        CartPole::new(),
+        policy,
+        channels,
+        device,
+        seed,
+        throttle,
+        move |policy: &MlpBurnPolicy<InnerBackend>, obs: &[f32], rng: &mut StdRng| {
+            let obs_t = Tensor::<InnerBackend, 2>::from_data(
+                TensorData::new(obs.to_vec(), [1, obs.len()]),
+                &act_device,
+            );
+            let (actions, log_probs, values) = policy.get_action_host_seeded(obs_t, rng);
+            (actions[0], log_probs[0], values[0])
+        },
+    )
+    .expect("actor_thread failed over tcp transport");
+
+    demux.join().expect("actor tcp demux thread panicked");
+    stats
+}
+
+/// Bind a loopback listener, spawn `config.num_actors` remote actor threads
+/// dialing in, run the learner over the accepted TCP connections, and
+/// return the learner's report plus each actor's own stats (from the actor
+/// side, not the learner's reader-thread view).
+fn run_tcp_cartpole(
+    config: &AsyncActorLearnerConfig,
+    learning_rate: f64,
+    n_epochs: usize,
+    batch_size: usize,
+) -> (LearnerReport, Vec<ActorStats>) {
+    let device = Default::default();
+
+    let probe = CartPole::new();
+    let obs_dim = probe.observation_space().shape[0];
+    let action_dim = match probe.action_space().space_type {
+        thrust_rl::env::SpaceType::Discrete(n) => n,
+        _ => panic!("CartPole is discrete"),
+    };
+
+    let policy_config = MlpBurnConfig {
+        num_layers: 2,
+        hidden_dim: HIDDEN_DIM,
+        use_orthogonal_init: true,
+        activation: BurnActivation::ReLU,
+        seed: Some(config.seed),
+    };
+    let policy = MlpBurnPolicy::<Backend>::with_config(obs_dim, action_dim, policy_config, &device);
+
+    let inner_opt = AdamConfig::new().init();
+    let burn_opt: BurnOptimizer<Backend, MlpBurnPolicy<Backend>, _> =
+        BurnOptimizer::new(inner_opt, learning_rate);
+
+    let ppo_config = PPOConfig::new()
+        .learning_rate(learning_rate)
+        .n_epochs(n_epochs)
+        .batch_size(batch_size)
+        .gamma(config.gamma as f64)
+        .gae_lambda(config.gae_lambda as f64)
+        .clip_range(0.2)
+        .clip_range_vf(0.2)
+        .vf_coef(0.5)
+        .ent_coef(0.01)
+        .max_grad_norm(0.5)
+        .target_kl(1.0);
+
+    let trainer = PPOTrainerBurn::new(ppo_config, policy, burn_opt).unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind loopback listener");
+    let addr = listener.local_addr().expect("listener has no local addr");
+
+    // Spawn the remote actors first: TCP connections queue in the listen
+    // backlog until `accept_actors_over_tcp` below calls `accept()`, so
+    // ordering here is safe either way.
+    let throttle = config.actor_throttle();
+    let actor_threads: Vec<thread::JoinHandle<ActorStats>> = (0..config.num_actors)
+        .map(|actor_id| {
+            let policy = trainer.policy().valid();
+            let seed = config.seed + 1 + actor_id as u64;
+            thread::Builder::new()
+                .name(format!("remote-actor-{actor_id}"))
+                .spawn(move || run_remote_actor(actor_id, addr, policy, device, seed, throttle))
+                .expect("failed to spawn remote actor thread")
+        })
+        .collect();
+
+    let (experience_rx, actor_handles) = accept_actors_over_tcp(&listener, config.num_actors)
+        .expect("learner failed to accept remote actors");
+
+    let (_trainer, report) = learner_loop(
+        config,
+        trainer,
+        obs_dim,
+        &device,
+        &experience_rx,
+        &actor_handles,
+        |p: &MlpBurnPolicy<Backend>, o, a| p.evaluate_actions(o, a),
+        |p: &MlpBurnPolicy<Backend>, o| p.forward(o).1.into_data().to_vec().unwrap_or_default(),
+    )
+    .expect("learner_loop failed over tcp transport");
+
+    // Clean shutdown: every learner-side reader thread and every remote
+    // actor thread must join without hanging or panicking.
+    for handle in actor_handles {
+        handle.join().expect("learner-side tcp reader thread failed");
+    }
+    let actor_stats: Vec<ActorStats> = actor_threads
+        .into_iter()
+        .map(|h| h.join().expect("remote actor thread panicked"))
+        .collect();
+
+    (report, actor_stats)
+}
+
+/// Fast wiring smoke test: 2 remote actors dial in over real TCP sockets,
+/// stream a couple of updates' worth of real CartPole transitions, and the
+/// learner broadcasts policy updates back over the wire. No learning bar —
+/// proves the transport plumbing (wire encoding, demux, shutdown) end to
+/// end quickly.
+#[test]
+fn tcp_actor_learner_wiring_smoke() {
+    let config = AsyncActorLearnerConfig {
+        num_actors: 2,
+        num_steps: 32,
+        total_env_steps: 32 * 2 * 2, // 2 updates
+        broadcast_every: 1,
+        max_lead_steps: 0,
+        gamma: 0.99,
+        gae_lambda: 0.95,
+        use_vtrace: false,
+        vtrace_rho_bar: 1.0,
+        vtrace_c_bar: 1.0,
+        seed: SEED,
+    };
+
+    let (report, actor_stats) = run_tcp_cartpole(&config, 3e-4, 1, 32);
+
+    assert_eq!(report.updates_completed, 2);
+    assert_eq!(report.env_steps_consumed, 128);
+    assert_eq!(report.broadcasts_sent, 2);
+    assert_eq!(report.last_policy_version, 2);
+
+    let stats = report.final_stats.expect("updates ran");
+    assert!(stats.policy_loss.is_finite());
+    assert!(stats.value_loss.is_finite());
+    assert!(stats.entropy.is_finite());
+
+    assert_eq!(actor_stats.len(), 2);
+    for (i, stats) in actor_stats.iter().enumerate() {
+        assert_eq!(stats.actor_id, i);
+        assert!(stats.steps_sent >= 32 * 2, "actor {i} sent only {} steps", stats.steps_sent);
+        assert!(
+            stats.policy_updates_received >= 1,
+            "actor {i} never loaded a policy broadcast delivered over tcp"
+        );
+        assert!(stats.last_policy_version >= 1);
+    }
+}
+
+/// Loopback-verification acceptance bar (issue #281): remote actors connect
+/// over TCP, the learner trains CartPole PPO, and reward improves over the
+/// ~22-step random baseline within a modest env-step budget (kept smaller
+/// than the in-process #279 bar test to bound wall-clock: this test pays
+/// per-step socket + bincode framing overhead the in-process path does
+/// not). Shutdown must be clean: every actor thread and every learner-side
+/// reader thread joins without hanging or panicking.
+#[test]
+fn tcp_actor_learner_reward_improves_and_shuts_down_cleanly() {
+    let config = AsyncActorLearnerConfig {
+        num_actors: 2,
+        num_steps: 64,
+        total_env_steps: 64 * 2 * 20, // 20 updates
+        broadcast_every: 1,
+        max_lead_steps: 0,
+        gamma: 0.99,
+        gae_lambda: 0.95,
+        use_vtrace: false,
+        vtrace_rho_bar: 1.0,
+        vtrace_c_bar: 1.0,
+        seed: SEED,
+    };
+
+    let (report, actor_stats) = run_tcp_cartpole(&config, 1e-3, 10, 32);
+
+    assert_eq!(report.updates_completed, 20);
+    assert_eq!(report.last_policy_version, 20);
+    assert_eq!(actor_stats.len(), 2);
+    for stats in &actor_stats {
+        assert!(
+            stats.policy_updates_received >= 1,
+            "actor {} never loaded a policy broadcast delivered over tcp",
+            stats.actor_id
+        );
+    }
+
+    // Random-policy CartPole averages ~22 steps/episode; a working PPO
+    // update pipeline (including the network hop) should clear that
+    // comfortably within 20 updates.
+    let mean_reward = report.mean_recent_episode_reward(20);
+    assert!(
+        report.episodes_completed > 0,
+        "no episodes completed within the tcp test budget"
+    );
+    assert!(
+        mean_reward > 30.0,
+        "networked actor-learner did not show learning: mean episode reward {mean_reward:.1} \
+         after {} env steps ({} episodes) over tcp",
+        report.env_steps_consumed,
+        report.episodes_completed,
+    );
+}


### PR DESCRIPTION
## Summary

Implements the networked actor-learner transport recommended by #281 (Phase 4
of the distributed-training epic #265): a TCP transport that is
interchangeable with the existing in-process `crossbeam_channel` actor↔learner
path, without touching DDP (which stays deferred per the design-note
verdict — the GPU-workload trigger has not fired).

Per #281's Scope Guard ("transport abstraction + networked implementation +
benchmarks + docs will likely exceed 400 LOC"), this PR covers split (a):
**transport abstraction + loopback networked transport with tests**. Split
(b) — benchmark group + multi-host `alc-*` runbook + design-doc Phase 4
results section — is tracked separately in #351.

## Changes

- `src/train/ppo/actor_learner.rs`: generalizes `ActorChannels` /
  `ActorHandle` over new `ExperienceSender` / `BroadcastSender` /
  `ControlSender` traits (default type parameters keep every existing
  crossbeam caller compiling unchanged). Fixes `ActorHandle::join`'s
  drop-then-join ordering, which is load-bearing for the TCP transport (a
  `TcpStream::try_clone`'d socket only unblocks a background reader on EOF
  once every local clone, including the sender's, is closed or shut down).
- `src/train/ppo/transport.rs` (new): the TCP implementation of the seam —
  `connect_actor_transport` (actor-side dial + demux thread) and
  `accept_actors_over_tcp` (learner-side accept + per-connection reader
  thread), a length-prefixed `bincode`-encoded `WireMessage` wire format, and
  unit tests covering wire round-trips, truncated-frame error handling, and
  an actor mid-training disconnect (learner survives, shared channel stays
  alive for the other actor).
- `src/multi_agent/messages.rs`: derives `Serialize`/`Deserialize` on
  `Experience`, `PolicyBroadcast` (via serde's `rc` feature for its
  `Arc<Vec<u8>>` payload), and `ControlMessage` — the wire encoding these
  frame types need. The in-process crossbeam path never touches these impls.
- `Cargo.toml`: adds `bincode 2.0.1` (`serde` feature), gated behind the
  `training` feature. Already present in the dependency tree transitively via
  `burn-core`'s record format, so this adds no new crate to the build — just
  a direct, nameable dependency. Also enables serde's `rc` feature.
- `tests/test_actor_learner_tcp.rs` (new): end-to-end loopback verification —
  a learner listens on `127.0.0.1:0` (OS-assigned port), two remote actor
  threads dial in over `TcpStream::connect`, train CartPole PPO, and the test
  asserts reward improves and every actor/reader thread joins cleanly. Mirrors
  `tests/test_cartpole_async.rs` (the Phase 2 in-process test) but wired over
  real TCP sockets.

## Acceptance Criteria Verification

| Criterion (from #281) | Status | Verification |
|---|---|---|
| Transport abstraction over actor↔learner channels; in-process crossbeam path unchanged, remains default, all Phase 2/3 tests still pass | ✅ | `ActorChannels<EXP = Sender<Experience>>` / `ActorHandle<BR = Sender<PolicyBroadcast>, CTRL = Sender<ControlMessage>>` default type params; `tests/test_cartpole_async.rs` (Phase 2/3 crossbeam regression test) passes unmodified |
| Networked transport implementation: actor process(es) connect to the learner over TCP; verified end-to-end on loopback (remote actors, learner trains CartPole PPO, reward improves, clean shutdown) | ✅ | `tests/test_actor_learner_tcp.rs::tcp_actor_learner_reward_improves_and_shuts_down_cleanly` — 2 remote actors over `127.0.0.1`, mean reward > 30 (vs ~22-step random baseline) within 20 updates, every thread joins without hanging |
| `cargo test --features training` and `cargo clippy` pass | ✅ | Full suite: `test result: ok` on every binary (lib: 516 passed / 0 failed / 3 ignored; all integration + doc-tests: 0 failed). `cargo clippy --features training --all-targets`: 0 warnings |
| Throughput benchmark recorded; multi-host `alc-*` runbook documented | ➡️ tracked in #351 | Split per the Scope Guard — see #351 |
| DDP explicitly not implemented; deferral trigger restated in design-doc Phase 4 results | ➡️ tracked in #351 | Design-doc results section is part of #351's scope; this PR adds no `burn-collective` code |

## Test Plan

- `cargo check --features training` — clean.
- `cargo clippy --features training --all-targets` — 0 warnings.
- `cargo fmt --all -- --check` — clean on every file this PR touches (pre-existing formatting drift in unrelated `envs/bucket-brigade/*` files is untouched, out of scope).
- `cargo test --features training` (full suite, including doc-tests) — every `test result:` line reports `0 failed`; new tests exercised:
  - `train::ppo::transport::tests::{wire_message_roundtrips_over_loopback_socket, read_message_errors_on_truncated_frame, learner_survives_one_actor_disconnecting_mid_training}` — wire encoding round-trip, truncated-frame error handling, and the actor-disconnect-mid-training edge case from #281's Test Plan.
  - `tests/test_actor_learner_tcp.rs::{tcp_actor_learner_wiring_smoke, tcp_actor_learner_reward_improves_and_shuts_down_cleanly}` — the loopback-verification acceptance bar.
  - `tests/test_cartpole_async.rs` (pre-existing, unmodified) — confirms the in-process crossbeam path has zero regression.

Part of #281